### PR TITLE
fix(extract): treat absent Resource field as (nil, nil)

### DIFF
--- a/otlpwire.go
+++ b/otlpwire.go
@@ -509,8 +509,11 @@ func forEachResourceSpans(data []byte, fn func([]byte, error) bool) {
 	forEachRepeatedField(data, 1, fn)
 }
 
-// extractResourceMessage extracts the Resource message (field 1) from
-// ResourceMetrics/ResourceLogs/ResourceSpans messages.
+// extractResourceMessage extracts the Resource sub-message (field 1) from a
+// ResourceSpans/ResourceMetrics/ResourceLogs payload. Resource is optional in
+// the OTLP proto schema, so an absent field returns (nil, nil) — the same
+// convention used by extractFixedBytesField. Callers should unmarshal a nil
+// result as an empty Resource{}.
 func extractResourceMessage(data []byte) ([]byte, error) {
 	pos := 0
 
@@ -541,7 +544,7 @@ func extractResourceMessage(data []byte) ([]byte, error) {
 		pos += n
 	}
 
-	return nil, errors.New("resource field not found")
+	return nil, nil
 }
 
 // writeResourceMessage writes resource data as a valid OTLP export request message.

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -1139,8 +1139,9 @@ func TestResourceMetrics_Resource_WrongWireType(t *testing.T) {
 	assert.Contains(t, err.Error(), "wrong wire type")
 }
 
-func TestResourceMetrics_Resource_Missing(t *testing.T) {
-	// Craft ResourceMetrics without Resource field (only ScopeMetrics)
+func TestResourceMetrics_Resource_Absent(t *testing.T) {
+	// Resource is optional in OTLP; absent field 1 must return (nil, nil) so
+	// callers can treat it as an empty Resource without a poison-message loop.
 	buf := []byte{}
 
 	// Field 2 = ScopeMetrics (empty)
@@ -1148,9 +1149,9 @@ func TestResourceMetrics_Resource_Missing(t *testing.T) {
 	buf = protowire.AppendBytes(buf, []byte{})
 
 	rm := ResourceMetrics(buf)
-	_, err := rm.Resource()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	resourceBytes, err := rm.Resource()
+	require.NoError(t, err)
+	assert.Nil(t, resourceBytes)
 }
 
 func TestResourceLogs_Resource_WrongWireType(t *testing.T) {
@@ -1164,15 +1165,15 @@ func TestResourceLogs_Resource_WrongWireType(t *testing.T) {
 	assert.Contains(t, err.Error(), "wrong wire type")
 }
 
-func TestResourceLogs_Resource_Missing(t *testing.T) {
+func TestResourceLogs_Resource_Absent(t *testing.T) {
 	buf := []byte{}
 	buf = protowire.AppendTag(buf, 2, protowire.BytesType)
 	buf = protowire.AppendBytes(buf, []byte{})
 
 	rl := ResourceLogs(buf)
-	_, err := rl.Resource()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	resourceBytes, err := rl.Resource()
+	require.NoError(t, err)
+	assert.Nil(t, resourceBytes)
 }
 
 func TestResourceSpans_Resource_WrongWireType(t *testing.T) {
@@ -1186,15 +1187,15 @@ func TestResourceSpans_Resource_WrongWireType(t *testing.T) {
 	assert.Contains(t, err.Error(), "wrong wire type")
 }
 
-func TestResourceSpans_Resource_Missing(t *testing.T) {
+func TestResourceSpans_Resource_Absent(t *testing.T) {
 	buf := []byte{}
 	buf = protowire.AppendTag(buf, 2, protowire.BytesType)
 	buf = protowire.AppendBytes(buf, []byte{})
 
 	rs := ResourceSpans(buf)
-	_, err := rs.Resource()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	resourceBytes, err := rs.Resource()
+	require.NoError(t, err)
+	assert.Nil(t, resourceBytes)
 }
 
 // ========== Benchmarks ==========


### PR DESCRIPTION
## Summary

`extractResourceMessage` treated an absent Resource field as an error, which turned valid OTLP payloads into poison messages in downstream consumers.

Align with `extractFixedBytesField`: absent optional field returns `(nil, nil)`. `proto.Unmarshal(nil)` on the receiving side yields an empty `&Resource{}`, matching the full pdata path.

## Changes

- `extractResourceMessage`: return `(nil, nil)` when field 1 is absent
- Doc comment updated
- Renamed 3 tests `*_Missing` → `*_Absent` and updated assertions

## Compat

Behavioral change. Callers previously had to handle a string-matched ``resource field not found`` error to treat as absent; now they get nil bytes. Cleaner semantic, aligned with OTLP spec where Resource is optional.

## Release plan

Tag v0.0.3 after merge so go.olly.garden/trellis can bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional Resource fields in OTLP wire format messages. Absent Resource fields are now treated as valid (returning nil) instead of raising an error, providing more consistent behavior across resource metadata, logs, and spans operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->