### PR TITLE
feat: metrics-depth iteration (ScopeMetrics → Metric → DataPoint → KeyValue) with zero-alloc variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ See [example_test.go](example_test.go) for complete working examples.
 ```
 ExportMetricsServiceRequest (OTLP message bytes)
   └─ ResourceMetrics[] (one per resource)
+       └─ ScopeMetrics[] (one per instrumentation scope)
+            └─ Metric[] (individual metrics)
+                 ├─ Name()
+                 └─ DataPoint[] (one per data point, any metric type)
+                      ├─ Type()          (Gauge/Sum/Histogram/ExponentialHistogram/Summary)
+                      ├─ Timestamp()
+                      └─ KeyValue[] (attributes)
+                           ├─ Key()
+                           └─ ValueRaw()
 
 ExportLogsServiceRequest (OTLP message bytes)
   └─ ResourceLogs[] (one per resource)
@@ -166,6 +175,52 @@ func (s Span) SpanID() ([8]byte, error)
 func (s Span) ParentSpanID() ([8]byte, error)
 ```
 
+**Scope- and metric-level operations (metrics depth):**
+```go
+type ScopeMetrics []byte
+func (s ScopeMetrics) Metrics() (iter.Seq[Metric], func() error)
+
+type Metric []byte
+func (m Metric) Name() ([]byte, error)
+func (m Metric) DataPoints() (iter.Seq[DataPoint], func() error)     // ergonomic, 2 allocs per open
+func (m Metric) DataPointsSeq(yield func(DataPoint, error) bool)     // zero-alloc, range directly
+
+type DataPoint struct{ /* unexported */ }
+func (d DataPoint) Raw() []byte
+func (d DataPoint) Type() MetricType
+func (d DataPoint) Timestamp() (uint64, error)
+func (d DataPoint) Attributes() (iter.Seq[KeyValue], func() error)   // ergonomic, 2 allocs per open
+func (d DataPoint) AttributesSeq(yield func(KeyValue, error) bool)   // zero-alloc, range directly
+
+type KeyValue []byte
+func (kv KeyValue) Key() ([]byte, error)
+func (kv KeyValue) ValueRaw() ([]byte, error)
+
+type MetricType int
+const (
+	MetricTypeGauge                MetricType = 5
+	MetricTypeSum                  MetricType = 7
+	MetricTypeHistogram            MetricType = 9
+	MetricTypeExponentialHistogram MetricType = 10
+	MetricTypeSummary              MetricType = 11
+)
+```
+
+`DataPoint` carries its `MetricType` because the attribute field number differs
+per data point wire type (histograms and exponential histograms encode
+attributes on a different field than gauges, sums, and summaries) — `Attributes()`
+and `AttributesSeq()` use `Type()` internally to pick the right field.
+
+Every level in this chain has both a closure-based iterator
+(`Metrics()`, `DataPoints()`, `Attributes()` — return `(iter.Seq[T], func() error)`,
+2 allocations per call to open) and, at the two hottest, deepest levels
+(`Metric.DataPointsSeq`, `DataPoint.AttributesSeq`), a zero-allocation `iter.Seq2`-style
+variant you range over directly, e.g. `for dp, err := range m.DataPointsSeq { ... }`.
+Prefer the closure-based API for ordinary code — it reads naturally and the error
+check is explicit. Reach for the `Seq` variants on a per-element hot path, such as
+hashing every data point's attributes across thousands of metrics per scrape,
+where the allocations from opening a closure-based iterator per metric add up.
+
 ## Design Philosophy
 
 This library provides:
@@ -207,6 +262,32 @@ Benchmarks on Apple M4 (5 resources, 100 signals per resource):
 | Logs | 51 ns, 2 allocs | 178 μs, 8,692 allocs | 3,490x |
 
 **Note:** The 2 allocations (24 bytes) in iteration are from the iterator error handling pattern (closure capture mechanism).
+
+### Deep Iteration Performance (metrics depth)
+
+Walking `ResourceMetrics.ScopeMetrics()` → `ScopeMetrics.Metrics()` → `Metric.DataPoints()` →
+`DataPoint.Attributes()` all the way down to individual attribute key/value bytes, compared
+against a full pdata unmarshal doing the equivalent walk (median of 5 runs, Apple M4):
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| `BenchmarkMetrics_ScrapeDeepIteration_WireFormat` | 827,544 | 460,987 | 19,207 |
+| `BenchmarkMetrics_ScrapeDeepIterationSeq_WireFormat` | 634,474 | 184 | 7 |
+| `BenchmarkMetrics_ScrapeDeepIteration_Unmarshal` | 2,268,745 | 3,507,250 | 105,631 |
+| `BenchmarkMetrics_DeepIteration_WireFormat` | 42,548 | 20,912 | 1,033 |
+| `BenchmarkMetrics_DeepIteration_Unmarshal` | 87,263 | 159,361 | 5,161 |
+
+Speedup (wire format vs. unmarshal, by ns/op):
+
+| Fixture | Speedup |
+|---|---|
+| Scrape-shaped, closure-based (4,800 metrics × 1 dp × 4 attrs) | 2.74x |
+| Scrape-shaped, Seq variants (4,800 metrics × 1 dp × 4 attrs) | 3.58x |
+| Continuity (5 × 1 × 1 × 100 dp) | 2.05x |
+
+The Seq variants cut allocations from thousands per batch to 7 — this is the API to
+reach for when hashing or otherwise touching every data point's attributes across a
+large scrape.
 
 For detailed benchmarks and methodology, see [BENCHMARKS.md](docs/BENCHMARKS.md).
 

--- a/benchmark_comparison_test.go
+++ b/benchmark_comparison_test.go
@@ -1,6 +1,7 @@
 package otlpwire
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -523,5 +524,202 @@ func BenchmarkMetrics_ResourceExtraction_Unmarshal(b *testing.B) {
 		for ri := 0; ri < metrics.ResourceMetrics().Len(); ri++ {
 			_ = metrics.ResourceMetrics().At(ri).Resource()
 		}
+	}
+}
+
+// ========== Metrics: Deep Iteration (E-2608, marigold workload) ==========
+
+// createScrapeShapedMetrics mirrors the traffic shape from E-2601: one
+// resource, one scope, thousands of metrics with a single datapoint each.
+func createScrapeShapedMetrics() pmetric.Metrics {
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "scraped-service")
+	rm.Resource().Attributes().PutStr("host.name", "host-1")
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("prometheus-receiver")
+
+	for i := 0; i < 4800; i++ {
+		metric := sm.Metrics().AppendEmpty()
+		metric.SetName(fmt.Sprintf("process_metric_%d_total", i))
+		var dp pmetric.NumberDataPoint
+		if i%2 == 0 {
+			dp = metric.SetEmptyGauge().DataPoints().AppendEmpty()
+		} else {
+			sum := metric.SetEmptySum()
+			sum.SetIsMonotonic(true)
+			sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+			dp = sum.DataPoints().AppendEmpty()
+		}
+		dp.SetDoubleValue(float64(i))
+		dp.SetTimestamp(1000000000)
+		dp.Attributes().PutStr("job", "node-exporter")
+		dp.Attributes().PutStr("instance", fmt.Sprintf("10.0.0.%d:9100", i%250))
+		dp.Attributes().PutStr("le", "0.5")
+		dp.Attributes().PutStr("quantile", "0.99")
+	}
+	return metrics
+}
+
+// deepIterateWire simulates marigold's zero-copy hashing workload: visit
+// every datapoint, read the timestamp, and consume every attribute's key
+// and raw AnyValue bytes (stand-in for feeding them to xxh3).
+func deepIterateWire(b *testing.B, req ExportMetricsServiceRequest) (datapoints int, consumed int) {
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for sm := range scopeSeq {
+			metricSeq, metricErr := sm.Metrics()
+			for m := range metricSeq {
+				dpSeq, dpErr := m.DataPoints()
+				for dp := range dpSeq {
+					datapoints++
+					ts, err := dp.Timestamp()
+					if err != nil {
+						b.Fatal(err)
+					}
+					consumed += int(ts % 2)
+					attrSeq, attrErr := dp.Attributes()
+					for kv := range attrSeq {
+						key, err := kv.Key()
+						if err != nil {
+							b.Fatal(err)
+						}
+						val, err := kv.ValueRaw()
+						if err != nil {
+							b.Fatal(err)
+						}
+						consumed += len(key) + len(val)
+					}
+					if err := attrErr(); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := dpErr(); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := metricErr(); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := scopeErr(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := resErr(); err != nil {
+		b.Fatal(err)
+	}
+	return datapoints, consumed
+}
+
+// deepIteratePdata is the equivalent workload through pdata: full unmarshal,
+// visit every datapoint, and re-serialize each datapoint's attributes into a
+// buffer for hashing (what marigold does today).
+func deepIteratePdata(b *testing.B, unmarshaler *pmetric.ProtoUnmarshaler, bytes []byte) (datapoints int, consumed int) {
+	metrics, err := unmarshaler.UnmarshalMetrics(bytes)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	buf := make([]byte, 0, 256)
+	rms := metrics.ResourceMetrics()
+	for ri := 0; ri < rms.Len(); ri++ {
+		sms := rms.At(ri).ScopeMetrics()
+		for si := 0; si < sms.Len(); si++ {
+			ms := sms.At(si).Metrics()
+			for mi := 0; mi < ms.Len(); mi++ {
+				m := ms.At(mi)
+				var dps pmetric.NumberDataPointSlice
+				switch m.Type() {
+				case pmetric.MetricTypeGauge:
+					dps = m.Gauge().DataPoints()
+				case pmetric.MetricTypeSum:
+					dps = m.Sum().DataPoints()
+				default:
+					continue
+				}
+				for di := 0; di < dps.Len(); di++ {
+					dp := dps.At(di)
+					datapoints++
+					consumed += int(uint64(dp.Timestamp()) % 2)
+					buf = buf[:0]
+					for k, v := range dp.Attributes().All() {
+						buf = append(buf, k...)
+						buf = append(buf, v.AsString()...)
+					}
+					consumed += len(buf)
+				}
+			}
+		}
+	}
+	return datapoints, consumed
+}
+
+func BenchmarkMetrics_ScrapeDeepIteration_WireFormat(b *testing.B) {
+	data := createScrapeShapedMetrics()
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(data)
+	require.NoError(b, err)
+
+	req := ExportMetricsServiceRequest(bytes)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		datapoints, _ := deepIterateWire(b, req)
+		if datapoints != 4800 {
+			b.Fatalf("expected 4800 datapoints, got %d", datapoints)
+		}
+	}
+}
+
+func BenchmarkMetrics_ScrapeDeepIteration_Unmarshal(b *testing.B) {
+	data := createScrapeShapedMetrics()
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(data)
+	require.NoError(b, err)
+
+	unmarshaler := &pmetric.ProtoUnmarshaler{}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		datapoints, _ := deepIteratePdata(b, unmarshaler, bytes)
+		if datapoints != 4800 {
+			b.Fatalf("expected 4800 datapoints, got %d", datapoints)
+		}
+	}
+}
+
+// Continuity pair on the existing 5×100 fixture.
+
+func BenchmarkMetrics_DeepIteration_WireFormat(b *testing.B) {
+	data := createBenchMetrics()
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(data)
+	require.NoError(b, err)
+
+	req := ExportMetricsServiceRequest(bytes)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		deepIterateWire(b, req)
+	}
+}
+
+func BenchmarkMetrics_DeepIteration_Unmarshal(b *testing.B) {
+	data := createBenchMetrics()
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(data)
+	require.NoError(b, err)
+
+	unmarshaler := &pmetric.ProtoUnmarshaler{}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		deepIteratePdata(b, unmarshaler, bytes)
 	}
 }

--- a/benchmark_comparison_test.go
+++ b/benchmark_comparison_test.go
@@ -692,6 +692,73 @@ func BenchmarkMetrics_ScrapeDeepIteration_Unmarshal(b *testing.B) {
 	}
 }
 
+// deepIterateWireSeq is deepIterateWire using the zero-allocation Seq
+// variants for the two per-element levels.
+func deepIterateWireSeq(b *testing.B, req ExportMetricsServiceRequest) (datapoints int, consumed int) {
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for sm := range scopeSeq {
+			metricSeq, metricErr := sm.Metrics()
+			for m := range metricSeq {
+				for dp, err := range m.DataPointsSeq {
+					if err != nil {
+						b.Fatal(err)
+					}
+					datapoints++
+					ts, err := dp.Timestamp()
+					if err != nil {
+						b.Fatal(err)
+					}
+					consumed += int(ts % 2)
+					for kv, err := range dp.AttributesSeq {
+						if err != nil {
+							b.Fatal(err)
+						}
+						key, err := kv.Key()
+						if err != nil {
+							b.Fatal(err)
+						}
+						val, err := kv.ValueRaw()
+						if err != nil {
+							b.Fatal(err)
+						}
+						consumed += len(key) + len(val)
+					}
+				}
+			}
+			if err := metricErr(); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := scopeErr(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := resErr(); err != nil {
+		b.Fatal(err)
+	}
+	return datapoints, consumed
+}
+
+func BenchmarkMetrics_ScrapeDeepIterationSeq_WireFormat(b *testing.B) {
+	data := createScrapeShapedMetrics()
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(data)
+	require.NoError(b, err)
+
+	req := ExportMetricsServiceRequest(bytes)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		datapoints, _ := deepIterateWireSeq(b, req)
+		if datapoints != 4800 {
+			b.Fatalf("expected 4800 datapoints, got %d", datapoints)
+		}
+	}
+}
+
 // Continuity pair on the existing 5×100 fixture.
 
 func BenchmarkMetrics_DeepIteration_WireFormat(b *testing.B) {

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -223,8 +223,9 @@ Two fixtures are used:
 
 | Benchmark | ns/op | B/op | allocs/op |
 |---|---|---|---|
-| `BenchmarkMetrics_ScrapeDeepIteration_WireFormat` | 806,129 | 460,986 | 19,207 |
-| `BenchmarkMetrics_ScrapeDeepIteration_Unmarshal` | 2,485,069 | 3,507,251 | 105,631 |
+| `BenchmarkMetrics_ScrapeDeepIteration_WireFormat` | 827,544 | 460,987 | 19,207 |
+| `BenchmarkMetrics_ScrapeDeepIterationSeq_WireFormat` | 634,474 | 184 | 7 |
+| `BenchmarkMetrics_ScrapeDeepIteration_Unmarshal` | 2,268,745 | 3,507,250 | 105,631 |
 | `BenchmarkMetrics_DeepIteration_WireFormat` | 42,548 | 20,912 | 1,033 |
 | `BenchmarkMetrics_DeepIteration_Unmarshal` | 87,263 | 159,361 | 5,161 |
 
@@ -232,7 +233,8 @@ Speedup (wire format vs. unmarshal, by ns/op):
 
 | Fixture | Speedup |
 |---|---|
-| Scrape-shaped (4,800 metrics × 1 dp × 4 attrs) | 3.08x |
+| Scrape-shaped, closure-based (4,800 metrics × 1 dp × 4 attrs) | 2.74x |
+| Scrape-shaped, Seq variants (4,800 metrics × 1 dp × 4 attrs) | 3.58x |
 | Continuity (5 × 1 × 1 × 100 dp) | 2.05x |
 
 Wire format still wins on both time and memory (roughly 4-7x less memory, ~2-5x fewer
@@ -252,3 +254,26 @@ per-element cost is still tiny (~24 bytes per iterator open, matching the existi
 lighter than a full unmarshal at every data point count tested, but it no longer
 benefits from the zero-copy, zero-allocation properties that make the shallow
 operations near-free.
+
+### Zero-alloc Seq variants (`DataPointsSeq` / `AttributesSeq`)
+
+The library exposes two APIs at the two hot levels of deep iteration:
+
+- **`(iter.Seq[T], func() error)`** — the original, ergonomic pattern used everywhere
+  else in this library (`ResourceMetrics()`, `ScopeMetrics()`, `Metrics()`, `DataPoints()`,
+  `Attributes()`). Two allocations per iterator open; fine when the level is opened once
+  per batch/scope, but costly when opened once per metric or per data point.
+- **`Metric.DataPointsSeq` / `DataPoint.AttributesSeq`** — additive, zero-allocation
+  variants shaped as `iter.Seq2[T, error]` methods, meant to be ranged over directly
+  (`for dp, err := range m.DataPointsSeq`). Because the method value never escapes to
+  the heap, the compiler keeps the walk entirely on the stack. Errors are yielded
+  inline as the second range value instead of via a separate `func() error`.
+
+`BenchmarkMetrics_ScrapeDeepIterationSeq_WireFormat` confirms the effect: allocations on
+the 4,800-metric scrape fixture drop from 19,207 to 7 (only the three outer
+`ResourceMetrics()`/`ScopeMetrics()`/`Metrics()` opens remain, one per batch/scope, not
+per element), B/op drops from ~461 KB to 184 B, and the speedup vs. a full pdata
+unmarshal improves from 2.74x to 3.58x. Use the closure-based pattern for outer,
+amortized levels and general iteration; use the Seq variants specifically for
+`DataPoints()`/`Attributes()` in code paths that iterate every metric or every data
+point in a batch, such as scrape-shaped or high-cardinality workloads.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -237,8 +237,10 @@ Speedup (wire format vs. unmarshal, by ns/op):
 | Scrape-shaped, Seq variants (4,800 metrics × 1 dp × 4 attrs) | 3.58x |
 | Continuity (5 × 1 × 1 × 100 dp) | 2.05x |
 
-Wire format still wins on both time and memory (roughly 4-7x less memory, ~2-5x fewer
-allocations), but the margin is far narrower than the order-of-magnitude speedups seen
+Wire format still wins on both time and memory (roughly 7.6x less memory on both
+fixtures — 3,507,250/460,987 and 159,361/20,912 — and ~5.0-5.5x fewer allocations —
+105,631/19,207 and 5,161/1,033 — for the closure-based pair), but the margin is far
+narrower than the order-of-magnitude speedups seen
 for counting, shallow iteration, and resource extraction elsewhere in this document.
 The reason is structural rather than a benchmark artifact: a memory profile of
 `BenchmarkMetrics_ScrapeDeepIteration_WireFormat` shows essentially all allocations

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -251,8 +251,9 @@ iteration" cost. Shallow operations (counting, single top-level iteration, resou
 extraction) open an iterator once per batch, so that fixed cost is amortized; deep
 iteration opens a fresh iterator at every level for every element, so the allocation
 count scales with the number of metrics/data points rather than staying constant. The
-per-element cost is still tiny (~24 bytes per iterator open, matching the existing
-"2 allocations, 24 bytes" pattern documented above) and wire format remains faster and
+per-element cost is still tiny (~48 bytes, i.e. 2 allocations of ~24 bytes, per
+iterator open, matching the existing "2 allocations, 24 bytes" pattern documented
+above) and wire format remains faster and
 lighter than a full unmarshal at every data point count tested, but it no longer
 benefits from the zero-copy, zero-allocation properties that make the shallow
 operations near-free.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -193,3 +193,62 @@ All benchmarks use realistic OTLP data:
 - Full scope information (instrumentation library)
 - Complete metadata (timestamps, attributes)
 - Realistic attribute cardinality
+
+---
+
+## Deep iteration (metrics depth, E-2608)
+
+**Test Setup:**
+- Platform: Apple M4
+- Go version: go1.26.1 darwin/arm64
+- `go test -run '^$' -bench 'BenchmarkMetrics_(Scrape)?DeepIteration' -benchmem -count=5 ./...`
+
+These benchmarks drive the full metrics-depth API (`ResourceMetrics.ScopeMetrics()` →
+`ScopeMetrics.Metrics()` → `Metric.DataPoints()` → `DataPoint.Attributes()`) all the way
+down to individual attribute key/value bytes, and compare it against a full pdata
+unmarshal doing the equivalent walk. This is the "marigold" workload from E-2601:
+for every data point, read the timestamp and consume every attribute's key and value
+bytes (a stand-in for feeding them into a hash function).
+
+Two fixtures are used:
+
+- **Scrape-shaped** (`createScrapeShapedMetrics`): 1 resource, 1 scope, 4,800 metrics,
+  1 data point each, 4 attributes per data point — mirrors real Prometheus-receiver
+  scrape traffic (the E-2601 shape).
+- **Continuity** (`createBenchMetrics`, reused from the existing suite): 5 resources,
+  1 scope each, 1 metric each, 100 data points per metric (500 data points total) —
+  kept for continuity with the other benchmarks in this file.
+
+### Results (median of 5 runs)
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| `BenchmarkMetrics_ScrapeDeepIteration_WireFormat` | 806,129 | 460,986 | 19,207 |
+| `BenchmarkMetrics_ScrapeDeepIteration_Unmarshal` | 2,485,069 | 3,507,251 | 105,631 |
+| `BenchmarkMetrics_DeepIteration_WireFormat` | 42,548 | 20,912 | 1,033 |
+| `BenchmarkMetrics_DeepIteration_Unmarshal` | 87,263 | 159,361 | 5,161 |
+
+Speedup (wire format vs. unmarshal, by ns/op):
+
+| Fixture | Speedup |
+|---|---|
+| Scrape-shaped (4,800 metrics × 1 dp × 4 attrs) | 3.08x |
+| Continuity (5 × 1 × 1 × 100 dp) | 2.05x |
+
+Wire format still wins on both time and memory (roughly 4-7x less memory, ~2-5x fewer
+allocations), but the margin is far narrower than the order-of-magnitude speedups seen
+for counting, shallow iteration, and resource extraction elsewhere in this document.
+The reason is structural rather than a benchmark artifact: a memory profile of
+`BenchmarkMetrics_ScrapeDeepIteration_WireFormat` shows essentially all allocations
+(19,207 of them, ~460 KB) coming from the two per-element iterator closures —
+`Metric.DataPoints()` opened once per metric (4,800 times) and `DataPoint.Attributes()`
+opened once per data point (4,800 times), each paying the documented "2 allocations for
+iteration" cost. Shallow operations (counting, single top-level iteration, resource
+extraction) open an iterator once per batch, so that fixed cost is amortized; deep
+iteration opens a fresh iterator at every level for every element, so the allocation
+count scales with the number of metrics/data points rather than staying constant. The
+per-element cost is still tiny (~24 bytes per iterator open, matching the existing
+"2 allocations, 24 bytes" pattern documented above) and wire format remains faster and
+lighter than a full unmarshal at every data point count tested, but it no longer
+benefits from the zero-copy, zero-allocation properties that make the shallow
+operations near-free.

--- a/docs/superpowers/plans/2026-07-15-metrics-depth-iteration.md
+++ b/docs/superpowers/plans/2026-07-15-metrics-depth-iteration.md
@@ -1,0 +1,1096 @@
+# Metrics-Depth Iteration (E-2608) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend otlp-wire's metrics side with zero-copy iteration from `ResourceMetrics` down to datapoint attributes (`ScopeMetrics → Metric → DataPoint → KeyValue`), and benchmark it against pdata unmarshal on a scrape-shaped fixture.
+
+**Architecture:** All public types are views over protobuf wire bytes, navigated with `protowire` by field number. New iterators compose the existing `forEachRepeatedField` helper and follow the `(iter.Seq[T], func() error)` pattern. `DataPoint` is the one struct (not `[]byte` alias) because its `attributes` field number depends on which metric oneof body it came from.
+
+**Tech Stack:** Go, `google.golang.org/protobuf/encoding/protowire`, tests via `pdata` (`go.opentelemetry.io/collector/pdata/pmetric`) + testify.
+
+## Global Constraints
+
+- Single package; all library code in `otlpwire.go`, tests in `otlpwire_test.go`, benchmarks in `benchmark_comparison_test.go`.
+- No new dependencies (library or test).
+- Iterator pattern is exactly `(iter.Seq[T], func() error)` with the error func checked after iteration — never deviate.
+- Zero-copy: accessors return sub-slices of the input buffer, never copies.
+- Test pattern: build with pdata, marshal, feed bytes to otlp-wire, assert.
+- CI gates: `go test -v -race ./...` and `go vet ./...` must pass.
+- Field numbers (from OTLP metrics.proto):
+  - ResourceMetrics: scope_metrics = 2. ScopeMetrics: metrics = 2.
+  - Metric: name = 1, gauge = 5, sum = 7, histogram = 9, exponential_histogram = 10, summary = 11. Each body: repeated data_points = 1.
+  - Datapoint attributes: NumberDataPoint = 7, HistogramDataPoint = 9, ExponentialHistogramDataPoint = 1, SummaryDataPoint = 7. time_unix_nano = 3 (fixed64) for all.
+  - KeyValue: key = 1, value (AnyValue) = 2.
+
+---
+
+### Task 1: ScopeMetrics and Metric iteration
+
+**Files:**
+- Modify: `otlpwire.go` (types near line 30, methods after `ResourceMetrics.WriteTo` around line 77)
+- Test: `otlpwire_test.go`
+
+**Interfaces:**
+- Consumes: existing `forEachRepeatedField`, existing `ResourceMetrics` type.
+- Produces: `type ScopeMetrics []byte`, `type Metric []byte`, `func (r ResourceMetrics) ScopeMetrics() (iter.Seq[ScopeMetrics], func() error)`, `func (s ScopeMetrics) Metrics() (iter.Seq[Metric], func() error)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `otlpwire_test.go` (a helper used by later tasks too):
+
+```go
+// buildScopedMetrics builds a request with the given number of scopes per
+// resource and metrics per scope, all gauges with one datapoint.
+func buildScopedMetrics(t *testing.T, resources, scopes, metricsPerScope int) []byte {
+	t.Helper()
+	metrics := pmetric.NewMetrics()
+	for r := 0; r < resources; r++ {
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("service.name", fmt.Sprintf("service-%d", r))
+		for s := 0; s < scopes; s++ {
+			sm := rm.ScopeMetrics().AppendEmpty()
+			sm.Scope().SetName(fmt.Sprintf("scope-%d", s))
+			for m := 0; m < metricsPerScope; m++ {
+				metric := sm.Metrics().AppendEmpty()
+				metric.SetName(fmt.Sprintf("metric.%d.%d", s, m))
+				dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
+				dp.SetIntValue(int64(m))
+				dp.SetTimestamp(1000000000)
+			}
+		}
+	}
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(metrics)
+	require.NoError(t, err)
+	return bytes
+}
+
+func TestScopeMetricsIteration(t *testing.T) {
+	bytes := buildScopedMetrics(t, 2, 3, 4)
+	req := ExportMetricsServiceRequest(bytes)
+
+	totalScopes := 0
+	totalMetrics := 0
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for sm := range scopeSeq {
+			totalScopes++
+			metricSeq, metricErr := sm.Metrics()
+			for range metricSeq {
+				totalMetrics++
+			}
+			require.NoError(t, metricErr())
+		}
+		require.NoError(t, scopeErr())
+	}
+	require.NoError(t, resErr())
+
+	require.Equal(t, 6, totalScopes)   // 2 resources × 3 scopes
+	require.Equal(t, 24, totalMetrics) // 6 scopes × 4 metrics
+}
+
+func TestScopeMetricsIteration_Malformed(t *testing.T) {
+	// Field 2 (scope_metrics) with wrong wire type: varint instead of bytes.
+	bad := ResourceMetrics{0x10, 0x01}
+	seq, errFn := bad.ScopeMetrics()
+	for range seq {
+	}
+	require.Error(t, errFn())
+}
+```
+
+If `otlpwire_test.go` does not already import `fmt`, add it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run 'TestScopeMetricsIteration' ./...`
+Expected: compile error — `rm.ScopeMetrics undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `otlpwire.go`, add type declarations after `type Span []byte` (line 34):
+
+```go
+// ScopeMetrics represents a single ScopeMetrics message (raw wire bytes).
+type ScopeMetrics []byte
+
+// Metric represents a single Metric message (raw wire bytes).
+type Metric []byte
+```
+
+Add methods after `ResourceMetrics.WriteTo` (around line 77), mirroring `ResourceSpans.ScopeSpans`:
+
+```go
+// ScopeMetrics returns an iterator over ScopeMetrics in this ResourceMetrics.
+// Field 2 in the ResourceMetrics protobuf message.
+// The returned function should be called after iteration to check for errors.
+func (r ResourceMetrics) ScopeMetrics() (iter.Seq[ScopeMetrics], func() error) {
+	var iterErr error
+
+	seq := func(yield func(ScopeMetrics) bool) {
+		forEachRepeatedField([]byte(r), 2, func(rb []byte, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(ScopeMetrics(rb))
+		})
+	}
+
+	errFunc := func() error {
+		return iterErr
+	}
+
+	return seq, errFunc
+}
+
+// Metrics returns an iterator over Metrics in this ScopeMetrics.
+// Field 2 in the ScopeMetrics protobuf message.
+// The returned function should be called after iteration to check for errors.
+func (s ScopeMetrics) Metrics() (iter.Seq[Metric], func() error) {
+	var iterErr error
+
+	seq := func(yield func(Metric) bool) {
+		forEachRepeatedField([]byte(s), 2, func(rb []byte, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(Metric(rb))
+		})
+	}
+
+	errFunc := func() error {
+		return iterErr
+	}
+
+	return seq, errFunc
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -race -run 'TestScopeMetricsIteration' -v ./...`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add otlpwire.go otlpwire_test.go
+git commit -m "feat: add ScopeMetrics and Metric iteration"
+```
+
+---
+
+### Task 2: Metric.Name and extractBytesField helper
+
+**Files:**
+- Modify: `otlpwire.go` (helper next to `extractResourceMessage` around line 514; method after `ScopeMetrics.Metrics`)
+- Test: `otlpwire_test.go`
+
+**Interfaces:**
+- Consumes: `Metric` from Task 1, existing `skipField`.
+- Produces: `func (m Metric) Name() ([]byte, error)`; internal `func extractBytesField(data []byte, fieldNum protowire.Number) ([]byte, error)` (returns `nil, nil` when absent) — reused by Task 4's KeyValue accessors.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestMetricName(t *testing.T) {
+	bytes := buildScopedMetrics(t, 1, 1, 2)
+	req := ExportMetricsServiceRequest(bytes)
+
+	var names []string
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for sm := range scopeSeq {
+			metricSeq, metricErr := sm.Metrics()
+			for m := range metricSeq {
+				name, err := m.Name()
+				require.NoError(t, err)
+				names = append(names, string(name))
+			}
+			require.NoError(t, metricErr())
+		}
+		require.NoError(t, scopeErr())
+	}
+	require.NoError(t, resErr())
+
+	require.Equal(t, []string{"metric.0.0", "metric.0.1"}, names)
+}
+
+func TestMetricName_Absent(t *testing.T) {
+	// A metric message with only a unit (field 3), no name.
+	var m Metric
+	m = protowire.AppendTag(m, 3, protowire.BytesType)
+	m = protowire.AppendBytes(m, []byte("1"))
+	name, err := m.Name()
+	require.NoError(t, err)
+	require.Nil(t, name)
+}
+```
+
+Add `"google.golang.org/protobuf/encoding/protowire"` to the test imports if absent.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run 'TestMetricName' ./...`
+Expected: compile error — `m.Name undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the helper next to `extractResourceMessage`:
+
+```go
+// extractBytesField extracts the first occurrence of a length-delimited
+// field from protobuf data. Returns nil (not an error) if absent.
+// The returned slice aliases data; no copy is made.
+func extractBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
+	pos := 0
+
+	for pos < len(data) {
+		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return nil, errors.New("malformed protobuf tag")
+		}
+		pos += tagLen
+
+		if num == fieldNum {
+			if wireType != protowire.BytesType {
+				return nil, errors.New("wrong wire type for field")
+			}
+			msgBytes, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return nil, errors.New("invalid bytes in field")
+			}
+			return msgBytes, nil
+		}
+
+		n := skipField(data[pos:], wireType)
+		if n < 0 {
+			return nil, errors.New("failed to skip field")
+		}
+		pos += n
+	}
+
+	return nil, nil
+}
+```
+
+Add the method after `ScopeMetrics.Metrics`:
+
+```go
+// Name returns the metric name (field 1) as a view into the underlying
+// buffer. Returns nil if the field is not present.
+func (m Metric) Name() ([]byte, error) {
+	return extractBytesField([]byte(m), 1)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -race -run 'TestMetricName' -v ./...`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add otlpwire.go otlpwire_test.go
+git commit -m "feat: add Metric.Name and extractBytesField helper"
+```
+
+---
+
+### Task 3: MetricType, DataPoint, and Metric.DataPoints iteration
+
+**Files:**
+- Modify: `otlpwire.go`
+- Test: `otlpwire_test.go`
+
+**Interfaces:**
+- Consumes: `Metric` from Task 1, existing `forEachRepeatedField`, `skipField`.
+- Produces:
+  - `type MetricType int` with constants `MetricTypeGauge`, `MetricTypeSum`, `MetricTypeHistogram`, `MetricTypeExponentialHistogram`, `MetricTypeSummary`.
+  - `type DataPoint struct { raw []byte; typ MetricType }` with `func (d DataPoint) Raw() []byte` and `func (d DataPoint) Type() MetricType`.
+  - `func (m Metric) DataPoints() (iter.Seq[DataPoint], func() error)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// buildAllTypesMetrics builds one metric of each of the five types, each
+// with two datapoints carrying attributes {"method":"GET","status":"200"}
+// and timestamp 1000000000.
+func buildAllTypesMetrics(t *testing.T) []byte {
+	t.Helper()
+	metrics := pmetric.NewMetrics()
+	sm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+
+	setNumberDP := func(dp pmetric.NumberDataPoint) {
+		dp.SetIntValue(42)
+		dp.SetTimestamp(1000000000)
+		dp.Attributes().PutStr("method", "GET")
+		dp.Attributes().PutStr("status", "200")
+	}
+
+	gauge := sm.Metrics().AppendEmpty()
+	gauge.SetName("test.gauge")
+	setNumberDP(gauge.SetEmptyGauge().DataPoints().AppendEmpty())
+	setNumberDP(gauge.Gauge().DataPoints().AppendEmpty())
+
+	sum := sm.Metrics().AppendEmpty()
+	sum.SetName("test.sum")
+	setNumberDP(sum.SetEmptySum().DataPoints().AppendEmpty())
+	setNumberDP(sum.Sum().DataPoints().AppendEmpty())
+
+	hist := sm.Metrics().AppendEmpty()
+	hist.SetName("test.histogram")
+	histBody := hist.SetEmptyHistogram()
+	for i := 0; i < 2; i++ {
+		dp := histBody.DataPoints().AppendEmpty()
+		dp.SetCount(10)
+		dp.SetTimestamp(1000000000)
+		dp.Attributes().PutStr("method", "GET")
+		dp.Attributes().PutStr("status", "200")
+	}
+
+	expHist := sm.Metrics().AppendEmpty()
+	expHist.SetName("test.exphistogram")
+	expHistBody := expHist.SetEmptyExponentialHistogram()
+	for i := 0; i < 2; i++ {
+		dp := expHistBody.DataPoints().AppendEmpty()
+		dp.SetCount(10)
+		dp.SetTimestamp(1000000000)
+		dp.Attributes().PutStr("method", "GET")
+		dp.Attributes().PutStr("status", "200")
+	}
+
+	summary := sm.Metrics().AppendEmpty()
+	summary.SetName("test.summary")
+	summaryBody := summary.SetEmptySummary()
+	for i := 0; i < 2; i++ {
+		dp := summaryBody.DataPoints().AppendEmpty()
+		dp.SetCount(10)
+		dp.SetTimestamp(1000000000)
+		dp.Attributes().PutStr("method", "GET")
+		dp.Attributes().PutStr("status", "200")
+	}
+
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(metrics)
+	require.NoError(t, err)
+	return bytes
+}
+
+// forEachTestDataPoint iterates all datapoints in a marshaled request,
+// failing the test on any iterator error.
+func forEachTestDataPoint(t *testing.T, bytes []byte, fn func(metricName string, dp DataPoint)) {
+	t.Helper()
+	req := ExportMetricsServiceRequest(bytes)
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for sm := range scopeSeq {
+			metricSeq, metricErr := sm.Metrics()
+			for m := range metricSeq {
+				name, err := m.Name()
+				require.NoError(t, err)
+				dpSeq, dpErr := m.DataPoints()
+				for dp := range dpSeq {
+					fn(string(name), dp)
+				}
+				require.NoError(t, dpErr())
+			}
+			require.NoError(t, metricErr())
+		}
+		require.NoError(t, scopeErr())
+	}
+	require.NoError(t, resErr())
+}
+
+func TestDataPointsIteration_AllTypes(t *testing.T) {
+	bytes := buildAllTypesMetrics(t)
+
+	typeByMetric := map[string]MetricType{}
+	countByMetric := map[string]int{}
+	forEachTestDataPoint(t, bytes, func(name string, dp DataPoint) {
+		typeByMetric[name] = dp.Type()
+		countByMetric[name]++
+		require.NotEmpty(t, dp.Raw())
+	})
+
+	require.Equal(t, map[string]MetricType{
+		"test.gauge":        MetricTypeGauge,
+		"test.sum":          MetricTypeSum,
+		"test.histogram":    MetricTypeHistogram,
+		"test.exphistogram": MetricTypeExponentialHistogram,
+		"test.summary":      MetricTypeSummary,
+	}, typeByMetric)
+	for name, count := range countByMetric {
+		require.Equal(t, 2, count, "metric %s", name)
+	}
+}
+
+func TestDataPointsIteration_EmptyMetric(t *testing.T) {
+	// Metric with a name but no oneof body.
+	var m Metric
+	m = protowire.AppendTag(m, 1, protowire.BytesType)
+	m = protowire.AppendBytes(m, []byte("empty"))
+	seq, errFn := m.DataPoints()
+	count := 0
+	for range seq {
+		count++
+	}
+	require.NoError(t, errFn())
+	require.Equal(t, 0, count)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run 'TestDataPointsIteration' ./...`
+Expected: compile error — `MetricType` and `m.DataPoints` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add after the `Metric` type declaration:
+
+```go
+// MetricType identifies which oneof body a DataPoint came from.
+type MetricType int
+
+// Metric oneof body field numbers in the Metric protobuf message.
+const (
+	MetricTypeGauge                MetricType = 5
+	MetricTypeSum                  MetricType = 7
+	MetricTypeHistogram            MetricType = 9
+	MetricTypeExponentialHistogram MetricType = 10
+	MetricTypeSummary              MetricType = 11
+)
+
+// DataPoint represents a single datapoint message (raw wire bytes) together
+// with the metric type it came from. The type is needed because the
+// attributes field number differs between datapoint message types.
+type DataPoint struct {
+	raw []byte
+	typ MetricType
+}
+
+// Raw returns the raw datapoint message bytes.
+func (d DataPoint) Raw() []byte { return d.raw }
+
+// Type returns the metric type this datapoint came from.
+func (d DataPoint) Type() MetricType { return d.typ }
+```
+
+Add after `Metric.Name`:
+
+```go
+// DataPoints returns an iterator over datapoints in this Metric, descending
+// whichever oneof body is present (gauge 5, sum 7, histogram 9,
+// exponential_histogram 10, summary 11). Each body holds its datapoints in
+// field 1.
+// The returned function should be called after iteration to check for errors.
+func (m Metric) DataPoints() (iter.Seq[DataPoint], func() error) {
+	var iterErr error
+
+	seq := func(yield func(DataPoint) bool) {
+		data := []byte(m)
+		pos := 0
+
+		for pos < len(data) {
+			fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+			if tagLen < 0 {
+				iterErr = errors.New("malformed protobuf tag in metric")
+				return
+			}
+			pos += tagLen
+
+			typ := MetricType(fieldNum)
+			isBody := typ == MetricTypeGauge || typ == MetricTypeSum ||
+				typ == MetricTypeHistogram || typ == MetricTypeExponentialHistogram ||
+				typ == MetricTypeSummary
+			if isBody && wireType == protowire.BytesType {
+				body, n := protowire.ConsumeBytes(data[pos:])
+				if n < 0 {
+					iterErr = errors.New("invalid bytes in metric data")
+					return
+				}
+				pos += n
+
+				stopped := false
+				forEachRepeatedField(body, 1, func(dpBytes []byte, err error) bool {
+					if err != nil {
+						iterErr = err
+						return false
+					}
+					if !yield(DataPoint{raw: dpBytes, typ: typ}) {
+						stopped = true
+						return false
+					}
+					return true
+				})
+				if iterErr != nil || stopped {
+					return
+				}
+			} else {
+				n := skipField(data[pos:], wireType)
+				if n < 0 {
+					iterErr = errors.New("failed to skip field")
+					return
+				}
+				pos += n
+			}
+		}
+	}
+
+	errFunc := func() error {
+		return iterErr
+	}
+
+	return seq, errFunc
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -race -run 'TestDataPointsIteration' -v ./...`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add otlpwire.go otlpwire_test.go
+git commit -m "feat: add Metric.DataPoints iteration with MetricType tagging"
+```
+
+---
+
+### Task 4: DataPoint.Timestamp, DataPoint.Attributes, KeyValue accessors
+
+**Files:**
+- Modify: `otlpwire.go`
+- Test: `otlpwire_test.go`
+
+**Interfaces:**
+- Consumes: `DataPoint` from Task 3, `extractBytesField` from Task 2, existing `forEachRepeatedField`, `skipField`.
+- Produces:
+  - `type KeyValue []byte` with `func (kv KeyValue) Key() ([]byte, error)` and `func (kv KeyValue) ValueRaw() ([]byte, error)`.
+  - `func (d DataPoint) Timestamp() (uint64, error)` (0 when absent).
+  - `func (d DataPoint) Attributes() (iter.Seq[KeyValue], func() error)`.
+  - Internal `func extractFixed64Field(data []byte, fieldNum protowire.Number) (uint64, error)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestDataPointTimestampAndAttributes_AllTypes(t *testing.T) {
+	bytes := buildAllTypesMetrics(t)
+
+	// Expected AnyValue wire bytes for string values, built independently.
+	anyValueStr := func(s string) []byte {
+		var b []byte
+		b = protowire.AppendTag(b, 1, protowire.BytesType) // AnyValue.string_value = 1
+		b = protowire.AppendBytes(b, []byte(s))
+		return b
+	}
+	expected := map[string][]byte{
+		"method": anyValueStr("GET"),
+		"status": anyValueStr("200"),
+	}
+
+	checked := 0
+	forEachTestDataPoint(t, bytes, func(name string, dp DataPoint) {
+		ts, err := dp.Timestamp()
+		require.NoError(t, err)
+		require.Equal(t, uint64(1000000000), ts)
+
+		attrs := map[string][]byte{}
+		attrSeq, attrErr := dp.Attributes()
+		for kv := range attrSeq {
+			key, err := kv.Key()
+			require.NoError(t, err)
+			val, err := kv.ValueRaw()
+			require.NoError(t, err)
+			attrs[string(key)] = val
+		}
+		require.NoError(t, attrErr())
+		require.Equal(t, expected, attrs, "metric %s", name)
+		checked++
+	})
+	require.Equal(t, 10, checked) // 5 types × 2 datapoints
+}
+
+func TestDataPointAttributes_Empty(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	sm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+	metric := sm.Metrics().AppendEmpty()
+	metric.SetName("no.attrs")
+	dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetIntValue(1)
+
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(metrics)
+	require.NoError(t, err)
+
+	forEachTestDataPoint(t, bytes, func(name string, dp DataPoint) {
+		ts, err := dp.Timestamp()
+		require.NoError(t, err)
+		require.Zero(t, ts)
+
+		count := 0
+		attrSeq, attrErr := dp.Attributes()
+		for range attrSeq {
+			count++
+		}
+		require.NoError(t, attrErr())
+		require.Zero(t, count)
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run 'TestDataPoint' ./...`
+Expected: compile error — `dp.Timestamp`, `dp.Attributes`, `KeyValue` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add after the `DataPoint` type declaration:
+
+```go
+// KeyValue represents a single KeyValue message (raw wire bytes).
+type KeyValue []byte
+
+// Key returns the attribute key (field 1) as a view into the underlying
+// buffer. Returns nil if the field is not present.
+func (kv KeyValue) Key() ([]byte, error) {
+	return extractBytesField([]byte(kv), 1)
+}
+
+// ValueRaw returns the raw AnyValue message bytes (field 2) as a view into
+// the underlying buffer, suitable for type-tagged hashing.
+// Returns nil if the field is not present.
+func (kv KeyValue) ValueRaw() ([]byte, error) {
+	return extractBytesField([]byte(kv), 2)
+}
+```
+
+Add after `DataPoint.Type`:
+
+```go
+// attributesFieldNum returns the field number of the repeated KeyValue
+// attributes for each datapoint message type.
+func (d DataPoint) attributesFieldNum() protowire.Number {
+	switch d.typ {
+	case MetricTypeHistogram:
+		return 9
+	case MetricTypeExponentialHistogram:
+		return 1
+	default: // NumberDataPoint (gauge, sum) and SummaryDataPoint
+		return 7
+	}
+}
+
+// Timestamp returns the datapoint's time_unix_nano (field 3, fixed64).
+// Returns 0 if the field is not present.
+func (d DataPoint) Timestamp() (uint64, error) {
+	return extractFixed64Field(d.raw, 3)
+}
+
+// Attributes returns an iterator over the datapoint's attribute KeyValues.
+// The returned function should be called after iteration to check for errors.
+func (d DataPoint) Attributes() (iter.Seq[KeyValue], func() error) {
+	var iterErr error
+	fieldNum := d.attributesFieldNum()
+
+	seq := func(yield func(KeyValue) bool) {
+		forEachRepeatedField(d.raw, fieldNum, func(rb []byte, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(KeyValue(rb))
+		})
+	}
+
+	errFunc := func() error {
+		return iterErr
+	}
+
+	return seq, errFunc
+}
+```
+
+Add the helper next to `extractBytesField`:
+
+```go
+// extractFixed64Field extracts the first occurrence of a fixed64 field from
+// protobuf data. Returns 0 (not an error) if absent.
+func extractFixed64Field(data []byte, fieldNum protowire.Number) (uint64, error) {
+	pos := 0
+
+	for pos < len(data) {
+		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return 0, errors.New("malformed protobuf tag")
+		}
+		pos += tagLen
+
+		if num == fieldNum {
+			if wireType != protowire.Fixed64Type {
+				return 0, errors.New("wrong wire type for field")
+			}
+			v, n := protowire.ConsumeFixed64(data[pos:])
+			if n < 0 {
+				return 0, errors.New("invalid fixed64 in field")
+			}
+			return v, nil
+		}
+
+		n := skipField(data[pos:], wireType)
+		if n < 0 {
+			return 0, errors.New("failed to skip field")
+		}
+		pos += n
+	}
+
+	return 0, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -race -run 'TestDataPoint' -v ./...`
+Expected: both tests PASS. The all-types test proves the exponential-histogram field-1 attributes and histogram field-9 attributes are handled, since `expected` matches for every metric name.
+
+- [ ] **Step 5: Run the full suite and vet**
+
+Run: `go test -race ./... && go vet ./...`
+Expected: all PASS, no vet findings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add otlpwire.go otlpwire_test.go
+git commit -m "feat: add DataPoint timestamp/attribute access and KeyValue accessors"
+```
+
+---
+
+### Task 5: Scrape-shaped benchmarks vs pdata
+
+**Files:**
+- Modify: `benchmark_comparison_test.go`
+- Modify: `docs/BENCHMARKS.md` (append results section)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4.
+- Produces: `BenchmarkMetrics_ScrapeDeepIteration_WireFormat`, `BenchmarkMetrics_ScrapeDeepIteration_Unmarshal`, `BenchmarkMetrics_DeepIteration_WireFormat`, `BenchmarkMetrics_DeepIteration_Unmarshal`, helper `createScrapeShapedMetrics()`.
+
+- [ ] **Step 1: Add the scrape-shaped fixture and benchmarks**
+
+Append to `benchmark_comparison_test.go`:
+
+```go
+// ========== Metrics: Deep Iteration (E-2608, marigold workload) ==========
+
+// createScrapeShapedMetrics mirrors the traffic shape from E-2601: one
+// resource, one scope, thousands of metrics with a single datapoint each.
+func createScrapeShapedMetrics() pmetric.Metrics {
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "scraped-service")
+	rm.Resource().Attributes().PutStr("host.name", "host-1")
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("prometheus-receiver")
+
+	for i := 0; i < 4800; i++ {
+		metric := sm.Metrics().AppendEmpty()
+		metric.SetName(fmt.Sprintf("process_metric_%d_total", i))
+		var dp pmetric.NumberDataPoint
+		if i%2 == 0 {
+			dp = metric.SetEmptyGauge().DataPoints().AppendEmpty()
+		} else {
+			sum := metric.SetEmptySum()
+			sum.SetIsMonotonic(true)
+			sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+			dp = sum.DataPoints().AppendEmpty()
+		}
+		dp.SetDoubleValue(float64(i))
+		dp.SetTimestamp(1000000000)
+		dp.Attributes().PutStr("job", "node-exporter")
+		dp.Attributes().PutStr("instance", fmt.Sprintf("10.0.0.%d:9100", i%250))
+		dp.Attributes().PutStr("le", "0.5")
+		dp.Attributes().PutStr("quantile", "0.99")
+	}
+	return metrics
+}
+
+// deepIterateWire simulates marigold's zero-copy hashing workload: visit
+// every datapoint, read the timestamp, and consume every attribute's key
+// and raw AnyValue bytes (stand-in for feeding them to xxh3).
+func deepIterateWire(b *testing.B, req ExportMetricsServiceRequest) (datapoints int, consumed int) {
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for sm := range scopeSeq {
+			metricSeq, metricErr := sm.Metrics()
+			for m := range metricSeq {
+				dpSeq, dpErr := m.DataPoints()
+				for dp := range dpSeq {
+					datapoints++
+					ts, err := dp.Timestamp()
+					if err != nil {
+						b.Fatal(err)
+					}
+					consumed += int(ts % 2)
+					attrSeq, attrErr := dp.Attributes()
+					for kv := range attrSeq {
+						key, err := kv.Key()
+						if err != nil {
+							b.Fatal(err)
+						}
+						val, err := kv.ValueRaw()
+						if err != nil {
+							b.Fatal(err)
+						}
+						consumed += len(key) + len(val)
+					}
+					if err := attrErr(); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := dpErr(); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := metricErr(); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := scopeErr(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := resErr(); err != nil {
+		b.Fatal(err)
+	}
+	return datapoints, consumed
+}
+
+// deepIteratePdata is the equivalent workload through pdata: full unmarshal,
+// visit every datapoint, and re-serialize each datapoint's attributes into a
+// buffer for hashing (what marigold does today).
+func deepIteratePdata(b *testing.B, unmarshaler *pmetric.ProtoUnmarshaler, bytes []byte) (datapoints int, consumed int) {
+	metrics, err := unmarshaler.UnmarshalMetrics(bytes)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	buf := make([]byte, 0, 256)
+	rms := metrics.ResourceMetrics()
+	for ri := 0; ri < rms.Len(); ri++ {
+		sms := rms.At(ri).ScopeMetrics()
+		for si := 0; si < sms.Len(); si++ {
+			ms := sms.At(si).Metrics()
+			for mi := 0; mi < ms.Len(); mi++ {
+				m := ms.At(mi)
+				var dps pmetric.NumberDataPointSlice
+				switch m.Type() {
+				case pmetric.MetricTypeGauge:
+					dps = m.Gauge().DataPoints()
+				case pmetric.MetricTypeSum:
+					dps = m.Sum().DataPoints()
+				default:
+					continue
+				}
+				for di := 0; di < dps.Len(); di++ {
+					dp := dps.At(di)
+					datapoints++
+					consumed += int(uint64(dp.Timestamp()) % 2)
+					buf = buf[:0]
+					for k, v := range dp.Attributes().All() {
+						buf = append(buf, k...)
+						buf = append(buf, v.AsString()...)
+					}
+					consumed += len(buf)
+				}
+			}
+		}
+	}
+	return datapoints, consumed
+}
+
+func BenchmarkMetrics_ScrapeDeepIteration_WireFormat(b *testing.B) {
+	data := createScrapeShapedMetrics()
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(data)
+	require.NoError(b, err)
+
+	req := ExportMetricsServiceRequest(bytes)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		datapoints, _ := deepIterateWire(b, req)
+		if datapoints != 4800 {
+			b.Fatalf("expected 4800 datapoints, got %d", datapoints)
+		}
+	}
+}
+
+func BenchmarkMetrics_ScrapeDeepIteration_Unmarshal(b *testing.B) {
+	data := createScrapeShapedMetrics()
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(data)
+	require.NoError(b, err)
+
+	unmarshaler := &pmetric.ProtoUnmarshaler{}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		datapoints, _ := deepIteratePdata(b, unmarshaler, bytes)
+		if datapoints != 4800 {
+			b.Fatalf("expected 4800 datapoints, got %d", datapoints)
+		}
+	}
+}
+
+// Continuity pair on the existing 5×100 fixture.
+
+func BenchmarkMetrics_DeepIteration_WireFormat(b *testing.B) {
+	data := createBenchMetrics()
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(data)
+	require.NoError(b, err)
+
+	req := ExportMetricsServiceRequest(bytes)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		deepIterateWire(b, req)
+	}
+}
+
+func BenchmarkMetrics_DeepIteration_Unmarshal(b *testing.B) {
+	data := createBenchMetrics()
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(data)
+	require.NoError(b, err)
+
+	unmarshaler := &pmetric.ProtoUnmarshaler{}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		deepIteratePdata(b, unmarshaler, bytes)
+	}
+}
+```
+
+Add `"fmt"` to the benchmark file imports.
+
+Note: if `dp.Attributes().All()` does not exist in the pinned pdata version, use `dp.Attributes().Range(func(k string, v pcommon.Value) bool { buf = append(buf, k...); buf = append(buf, v.AsString()...); return true })` with import `go.opentelemetry.io/collector/pdata/pcommon` instead.
+
+- [ ] **Step 2: Verify benchmarks compile and run briefly**
+
+Run: `go test -run '^$' -bench 'BenchmarkMetrics_(Scrape)?DeepIteration' -benchtime=1x ./...`
+Expected: all four benchmarks execute once without failure.
+
+- [ ] **Step 3: Run the real benchmark comparison**
+
+Run: `go test -run '^$' -bench 'BenchmarkMetrics_(Scrape)?DeepIteration' -benchmem -count=5 ./... | tee /tmp/e2608-bench.txt`
+Expected: WireFormat variants show order-of-magnitude lower ns/op and B/op than Unmarshal variants on the scrape shape. If the ratio is under ~10×, investigate before proceeding (check for accidental allocations with `-gcflags='-m'` or a CPU profile).
+
+- [ ] **Step 4: Record results in docs/BENCHMARKS.md**
+
+Append a section to `docs/BENCHMARKS.md` titled `## Deep iteration (metrics depth, E-2608)` containing: the machine/Go version line from the benchmark output, a results table (benchmark, ns/op, B/op, allocs/op, speedup ratio), and one paragraph explaining the scrape-shaped fixture (4,800 metrics × 1 datapoint × 4 attributes) and what each side of the comparison does. Use the median of the 5 counts.
+
+- [ ] **Step 5: Run full suite and vet**
+
+Run: `go test -race ./... && go vet ./...`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add benchmark_comparison_test.go docs/BENCHMARKS.md
+git commit -m "bench: add scrape-shaped deep-iteration benchmarks vs pdata"
+```
+
+---
+
+### Task 6: Documentation and example
+
+**Files:**
+- Modify: `README.md` (API listing/usage section)
+- Modify: `example_test.go`
+
+**Interfaces:**
+- Consumes: full public API from Tasks 1–4.
+- Produces: `ExampleMetric_DataPoints` runnable example.
+
+- [ ] **Step 1: Add a runnable example**
+
+Append to `example_test.go` (match the existing example style in that file; the example builds a small request with pdata, then walks it):
+
+```go
+func ExampleMetric_DataPoints() {
+	metrics := pmetric.NewMetrics()
+	sm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+	metric := sm.Metrics().AppendEmpty()
+	metric.SetName("request.duration")
+	dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetDoubleValue(0.35)
+	dp.SetTimestamp(1000000000)
+	dp.Attributes().PutStr("method", "GET")
+
+	marshaler := &pmetric.ProtoMarshaler{}
+	data, _ := marshaler.MarshalMetrics(metrics)
+
+	req := otlpwire.ExportMetricsServiceRequest(data)
+	resources, _ := req.ResourceMetrics()
+	for rm := range resources {
+		scopes, _ := rm.ScopeMetrics()
+		for sm := range scopes {
+			metricsSeq, _ := sm.Metrics()
+			for m := range metricsSeq {
+				name, _ := m.Name()
+				dps, _ := m.DataPoints()
+				for dp := range dps {
+					ts, _ := dp.Timestamp()
+					attrs, _ := dp.Attributes()
+					for kv := range attrs {
+						key, _ := kv.Key()
+						fmt.Printf("%s ts=%d attr=%s\n", name, ts, key)
+					}
+				}
+			}
+		}
+	}
+	// Output: request.duration ts=1000000000 attr=method
+}
+```
+
+Adjust imports/package prefix to match how `example_test.go` references the package (it may be an external test package `otlpwire_test` importing `go.olly.garden/otlp-wire`, or the internal package — follow the existing file).
+
+- [ ] **Step 2: Run the example**
+
+Run: `go test -run 'ExampleMetric_DataPoints' -v ./...`
+Expected: PASS (output matched).
+
+- [ ] **Step 3: Update README**
+
+Add the new metrics-depth API to README.md wherever the existing API surface is listed (types `ScopeMetrics`, `Metric`, `DataPoint`, `KeyValue`, `MetricType`; the iteration chain; a note that `DataPoint` carries its metric type because attribute field numbers differ per datapoint type). Include the headline benchmark numbers from Task 5.
+
+- [ ] **Step 4: Full suite, vet, commit**
+
+Run: `go test -race ./... && go vet ./...`
+Expected: all PASS.
+
+```bash
+git add example_test.go README.md
+git commit -m "docs: document metrics-depth iteration API with example"
+```

--- a/docs/superpowers/specs/2026-07-15-metrics-depth-iteration-design.md
+++ b/docs/superpowers/specs/2026-07-15-metrics-depth-iteration-design.md
@@ -113,3 +113,23 @@ for continuity with the current benchmark suite. Results table goes into
 
 Success criterion: wire path shows an order-of-magnitude (target 20–50×)
 reduction in ns/op and allocs vs the pdata path on the scrape-shaped fixture.
+
+## Addendum (2026-07-15): zero-alloc Seq variants
+
+The scrape-shaped benchmark measured 19,207 allocs/op on the wire path,
+~99.8% of it coming from the `(iter.Seq[T], func() error)` pattern's 2
+heap allocations per iterator open, paid once per metric (`DataPoints()`)
+and once per datapoint (`Attributes()`) — the two hot, per-element levels
+of deep iteration. This capped the wire-format speedup vs. a full pdata
+unmarshal at ~2.7x, far short of the order-of-magnitude target. With user
+approval, scope was extended to add `Metric.DataPointsSeq` and
+`DataPoint.AttributesSeq` as additive, zero-allocation alternatives shaped
+as `iter.Seq2[T, error]` methods (range-over-func targets), leaving the
+original closure-based pattern unchanged for the rest of the API. Errors
+are yielded inline as the second range value rather than through a
+separate `func() error`, and because the method value never escapes, the
+compiler keeps the entire walk on the stack. The result:
+`TestDataPointsSeq_ZeroAlloc` confirms 0 allocations via
+`testing.AllocsPerRun`, and the scrape-shaped benchmark drops from 19,207
+to 7 allocs/op (only the three outer, per-batch iterator opens remain),
+improving the speedup vs. unmarshal from ~2.7x to ~3.6x.

--- a/docs/superpowers/specs/2026-07-15-metrics-depth-iteration-design.md
+++ b/docs/superpowers/specs/2026-07-15-metrics-depth-iteration-design.md
@@ -1,0 +1,115 @@
+# Design: metrics-depth iteration (E-2608)
+
+Extend otlp-wire's metrics side from `ResourceMetrics` down to datapoint
+attributes, in the same zero-copy protowire-walking style the traces side
+already has (`ScopeSpans → Span → field accessors`). Consumer is marigold
+v0.2.0's zero-copy decode path: combination hash = xxh3 over each datapoint's
+attribute KeyValues, culprit hashes = xxh3 over each AnyValue's raw bytes.
+
+## API
+
+All new code lives in `otlpwire.go`, composing the existing helpers
+(`forEachRepeatedField`, `skipField`, `countOccurrences`).
+
+```go
+// []byte aliases, same as ScopeSpans/Span
+type ScopeMetrics []byte
+type Metric []byte
+type KeyValue []byte
+
+type MetricType int // MetricTypeGauge, MetricTypeSum, MetricTypeHistogram,
+                    // MetricTypeExponentialHistogram, MetricTypeSummary
+
+// DataPoint is a struct, not a []byte alias: the attributes field number
+// differs per datapoint type, so the datapoint must know which oneof body
+// it came from.
+type DataPoint struct {
+    raw []byte
+    typ MetricType
+}
+
+func (r ResourceMetrics) ScopeMetrics() (iter.Seq[ScopeMetrics], func() error) // field 2
+func (s ScopeMetrics) Metrics() (iter.Seq[Metric], func() error)               // field 2
+func (m Metric) Name() ([]byte, error)                                         // field 1
+func (m Metric) DataPoints() (iter.Seq[DataPoint], func() error)               // oneof 5/7/9/10/11 → field 1
+func (d DataPoint) Raw() []byte
+func (d DataPoint) Type() MetricType
+func (d DataPoint) Timestamp() (uint64, error)                                 // field 3, fixed64 (all types)
+func (d DataPoint) Attributes() (iter.Seq[KeyValue], func() error)             // field varies, see below
+func (kv KeyValue) Key() ([]byte, error)                                       // field 1
+func (kv KeyValue) ValueRaw() ([]byte, error)                                  // field 2, raw AnyValue bytes
+```
+
+### Field numbers
+
+Metric oneof bodies: gauge = 5, sum = 7, histogram = 9,
+exponential_histogram = 10, summary = 11. Each body holds
+`repeated data_points = 1`.
+
+Datapoint `attributes` field number varies by type — this is why `DataPoint`
+carries a type tag:
+
+| Datapoint type              | attributes field |
+| --------------------------- | ---------------- |
+| NumberDataPoint (gauge/sum) | 7                |
+| HistogramDataPoint          | 9                |
+| ExponentialHistogramDataPoint | 1              |
+| SummaryDataPoint            | 7                |
+
+`time_unix_nano` is field 3 (fixed64) for all datapoint types.
+
+KeyValue: key = 1 (string), value = 2 (AnyValue message).
+
+### Decisions
+
+- **Attributes as iterator, not raw region.** Repeated KeyValue fields are
+  each a separate tag+length+payload; protobuf does not guarantee adjacency.
+  Marigold streams each KeyValue's raw bytes into xxh3 instead of hashing one
+  contiguous region.
+- **`Metric.Metadata()` (field 12) is out of scope.** Marigold v0.2.0 does not
+  consume it; it is a five-line addition later.
+- **Zero-copy accessors.** `Name()`, `Key()`, `ValueRaw()` return sub-slices
+  of the original buffer via a new `extractBytesField` helper (generalizes
+  `extractResourceMessage`). No copies, no new dependencies.
+- **Allocation budget.** Each iterator costs the same 2 closure allocations as
+  the existing iterators (~2 allocs per metric on the scrape shape for
+  DataPoints + Attributes). Field accessors are zero-alloc. Benchmarks report
+  this honestly.
+- **Error handling.** Same iterator + deferred error-func pattern as every
+  existing iterator. Malformed protobuf surfaces through the error func.
+
+## Tests
+
+Canonical pattern: build with pdata, marshal, feed bytes to otlp-wire, assert.
+
+- All five metric types yield their datapoints with correct `Type()`.
+- Mixed-type batches (multiple metrics of different types in one scope).
+- Attribute key/value round-trip: keys and AnyValue bytes match what pdata
+  produces (compare `ValueRaw()` against independently marshaled AnyValue).
+- Exponential histogram attributes specifically (field 1, the odd one out).
+- Empty attributes, absent timestamp, empty datapoint lists.
+- Malformed input error paths through the error funcs.
+
+## Benchmarks
+
+New scrape-shaped fixture in `benchmark_comparison_test.go`: 1 resource,
+1 scope, 4,800 metrics × 1 datapoint each (mix of gauge and sum, ~4 string
+attributes per datapoint) — the E-2601 traffic shape that hid previous
+marigold regressions.
+
+Headline pair, simulating marigold's workload without adding a hash
+dependency:
+
+- `BenchmarkMetrics_ScrapeDeepIteration_WireFormat`: iterate
+  ResourceMetrics → ScopeMetrics → Metrics → DataPoints, read `Timestamp()`
+  and every `Key()`/`ValueRaw()` (consume the bytes).
+- `BenchmarkMetrics_ScrapeDeepIteration_Unmarshal`: pdata unmarshal + same
+  traversal + per-datapoint attribute re-serialization into a buffer (what
+  marigold does today for hashing).
+
+Plus a `DataPoints`-only deep-iteration pair on the existing 5×100 fixture
+for continuity with the current benchmark suite. Results table goes into
+`docs/BENCHMARKS.md` and the PR description.
+
+Success criterion: wire path shows an order-of-magnitude (target 20–50×)
+reduction in ns/op and allocs vs the pdata path on the scrape-shaped fixture.

--- a/example_test.go
+++ b/example_test.go
@@ -98,6 +98,44 @@ func Example_typeComposition() {
 	// Number of resources: 1
 }
 
+// ExampleMetric_DataPoints demonstrates walking the metrics-depth API down to
+// individual data point attributes.
+func ExampleMetric_DataPoints() {
+	metrics := pmetric.NewMetrics()
+	sm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+	metric := sm.Metrics().AppendEmpty()
+	metric.SetName("request.duration")
+	dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetDoubleValue(0.35)
+	dp.SetTimestamp(1000000000)
+	dp.Attributes().PutStr("method", "GET")
+
+	marshaler := &pmetric.ProtoMarshaler{}
+	data, _ := marshaler.MarshalMetrics(metrics)
+
+	req := otlpwire.ExportMetricsServiceRequest(data)
+	resources, _ := req.ResourceMetrics()
+	for rm := range resources {
+		scopes, _ := rm.ScopeMetrics()
+		for sm := range scopes {
+			metricsSeq, _ := sm.Metrics()
+			for m := range metricsSeq {
+				name, _ := m.Name()
+				dps, _ := m.DataPoints()
+				for dp := range dps {
+					ts, _ := dp.Timestamp()
+					attrs, _ := dp.Attributes()
+					for kv := range attrs {
+						key, _ := kv.Key()
+						fmt.Printf("%s ts=%d attr=%s\n", name, ts, key)
+					}
+				}
+			}
+		}
+	}
+	// Output: request.duration ts=1000000000 attr=method
+}
+
 // Helper functions
 
 func createSampleMetrics(dataPoints int) pmetric.Metrics {

--- a/otlpwire.go
+++ b/otlpwire.go
@@ -65,6 +65,64 @@ func (d DataPoint) Raw() []byte { return d.raw }
 // Type returns the metric type this datapoint came from.
 func (d DataPoint) Type() MetricType { return d.typ }
 
+// KeyValue represents a single KeyValue message (raw wire bytes).
+type KeyValue []byte
+
+// Key returns the attribute key (field 1) as a view into the underlying
+// buffer. Returns nil if the field is not present.
+func (kv KeyValue) Key() ([]byte, error) {
+	return extractBytesField([]byte(kv), 1)
+}
+
+// ValueRaw returns the raw AnyValue message bytes (field 2) as a view into
+// the underlying buffer, suitable for type-tagged hashing.
+// Returns nil if the field is not present.
+func (kv KeyValue) ValueRaw() ([]byte, error) {
+	return extractBytesField([]byte(kv), 2)
+}
+
+// attributesFieldNum returns the field number of the repeated KeyValue
+// attributes for each datapoint message type.
+func (d DataPoint) attributesFieldNum() protowire.Number {
+	switch d.typ {
+	case MetricTypeHistogram:
+		return 9
+	case MetricTypeExponentialHistogram:
+		return 1
+	default: // NumberDataPoint (gauge, sum) and SummaryDataPoint
+		return 7
+	}
+}
+
+// Timestamp returns the datapoint's time_unix_nano (field 3, fixed64).
+// Returns 0 if the field is not present.
+func (d DataPoint) Timestamp() (uint64, error) {
+	return extractFixed64Field(d.raw, 3)
+}
+
+// Attributes returns an iterator over the datapoint's attribute KeyValues.
+// The returned function should be called after iteration to check for errors.
+func (d DataPoint) Attributes() (iter.Seq[KeyValue], func() error) {
+	var iterErr error
+	fieldNum := d.attributesFieldNum()
+
+	seq := func(yield func(KeyValue) bool) {
+		forEachRepeatedField(d.raw, fieldNum, func(rb []byte, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(KeyValue(rb))
+		})
+	}
+
+	errFunc := func() error {
+		return iterErr
+	}
+
+	return seq, errFunc
+}
+
 // DataPointCount returns the total number of metric data points in the batch.
 func (m ExportMetricsServiceRequest) DataPointCount() (int, error) {
 	return countMetricDataPoints([]byte(m))
@@ -725,6 +783,39 @@ func extractBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
 	}
 
 	return nil, nil
+}
+
+// extractFixed64Field extracts the first occurrence of a fixed64 field from
+// protobuf data. Returns 0 (not an error) if absent.
+func extractFixed64Field(data []byte, fieldNum protowire.Number) (uint64, error) {
+	pos := 0
+
+	for pos < len(data) {
+		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return 0, errors.New("malformed protobuf tag")
+		}
+		pos += tagLen
+
+		if num == fieldNum {
+			if wireType != protowire.Fixed64Type {
+				return 0, errors.New("wrong wire type for field")
+			}
+			v, n := protowire.ConsumeFixed64(data[pos:])
+			if n < 0 {
+				return 0, errors.New("invalid fixed64 in field")
+			}
+			return v, nil
+		}
+
+		n := skipField(data[pos:], wireType)
+		if n < 0 {
+			return 0, errors.New("failed to skip field")
+		}
+		pos += n
+	}
+
+	return 0, nil
 }
 
 // writeResourceMessage writes resource data as a valid OTLP export request message.

--- a/otlpwire.go
+++ b/otlpwire.go
@@ -123,6 +123,25 @@ func (d DataPoint) Attributes() (iter.Seq[KeyValue], func() error) {
 	return seq, errFunc
 }
 
+// AttributesSeq is a zero-allocation alternative to Attributes. It has the
+// shape of an iter.Seq2[KeyValue, error] and is meant to be ranged over
+// directly:
+//
+//	for kv, err := range dp.AttributesSeq {
+//		if err != nil { ... }
+//	}
+//
+// On a parse error it yields a nil KeyValue with a non-nil error and stops.
+func (d DataPoint) AttributesSeq(yield func(KeyValue, error) bool) {
+	forEachRepeatedField(d.raw, d.attributesFieldNum(), func(rb []byte, err error) bool {
+		if err != nil {
+			yield(nil, err)
+			return false
+		}
+		return yield(KeyValue(rb), nil)
+	})
+}
+
 // DataPointCount returns the total number of metric data points in the batch.
 func (m ExportMetricsServiceRequest) DataPointCount() (int, error) {
 	return countMetricDataPoints([]byte(m))
@@ -281,6 +300,68 @@ func (m Metric) DataPoints() (iter.Seq[DataPoint], func() error) {
 	}
 
 	return seq, errFunc
+}
+
+// DataPointsSeq is a zero-allocation alternative to DataPoints. It has the
+// shape of an iter.Seq2[DataPoint, error] and is meant to be ranged over
+// directly:
+//
+//	for dp, err := range m.DataPointsSeq {
+//		if err != nil { ... }
+//	}
+//
+// On a parse error it yields a zero DataPoint with a non-nil error and
+// stops. Unlike DataPoints, no closures escape, so iterating allocates
+// nothing.
+func (m Metric) DataPointsSeq(yield func(DataPoint, error) bool) {
+	data := []byte(m)
+	pos := 0
+
+	for pos < len(data) {
+		fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			yield(DataPoint{}, errors.New("malformed protobuf tag in metric"))
+			return
+		}
+		pos += tagLen
+
+		typ := MetricType(fieldNum)
+		isBody := typ == MetricTypeGauge || typ == MetricTypeSum ||
+			typ == MetricTypeHistogram || typ == MetricTypeExponentialHistogram ||
+			typ == MetricTypeSummary
+		if isBody && wireType == protowire.BytesType {
+			body, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				yield(DataPoint{}, errors.New("invalid bytes in metric data"))
+				return
+			}
+			pos += n
+
+			done := false
+			forEachRepeatedField(body, 1, func(dpBytes []byte, err error) bool {
+				if err != nil {
+					done = true
+					yield(DataPoint{}, err)
+					return false
+				}
+				if !yield(DataPoint{raw: dpBytes, typ: typ}, nil) {
+					done = true
+					return false
+				}
+				return true
+			})
+			if done {
+				return
+			}
+		} else {
+			n := skipField(data[pos:], wireType)
+			if n < 0 {
+				yield(DataPoint{}, errors.New("failed to skip field"))
+				return
+			}
+			pos += n
+		}
+	}
 }
 
 // LogRecordCount returns the total number of log records in the batch.

--- a/otlpwire.go
+++ b/otlpwire.go
@@ -128,6 +128,12 @@ func (s ScopeMetrics) Metrics() (iter.Seq[Metric], func() error) {
 	return seq, errFunc
 }
 
+// Name returns the metric name (field 1) as a view into the underlying
+// buffer. Returns nil if the field is not present.
+func (m Metric) Name() ([]byte, error) {
+	return extractBytesField([]byte(m), 1)
+}
+
 // LogRecordCount returns the total number of log records in the batch.
 func (l ExportLogsServiceRequest) LogRecordCount() (int, error) {
 	return countLogRecords([]byte(l))
@@ -594,6 +600,40 @@ func extractResourceMessage(data []byte) ([]byte, error) {
 	}
 
 	return nil, errors.New("resource field not found")
+}
+
+// extractBytesField extracts the first occurrence of a length-delimited
+// field from protobuf data. Returns nil (not an error) if absent.
+// The returned slice aliases data; no copy is made.
+func extractBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
+	pos := 0
+
+	for pos < len(data) {
+		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return nil, errors.New("malformed protobuf tag")
+		}
+		pos += tagLen
+
+		if num == fieldNum {
+			if wireType != protowire.BytesType {
+				return nil, errors.New("wrong wire type for field")
+			}
+			msgBytes, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return nil, errors.New("invalid bytes in field")
+			}
+			return msgBytes, nil
+		}
+
+		n := skipField(data[pos:], wireType)
+		if n < 0 {
+			return nil, errors.New("failed to skip field")
+		}
+		pos += n
+	}
+
+	return nil, nil
 }
 
 // writeResourceMessage writes resource data as a valid OTLP export request message.

--- a/otlpwire.go
+++ b/otlpwire.go
@@ -240,59 +240,21 @@ func (m Metric) Name() ([]byte, error) {
 // DataPoints returns an iterator over datapoints in this Metric, descending
 // whichever oneof body is present (gauge 5, sum 7, histogram 9,
 // exponential_histogram 10, summary 11). Each body holds its datapoints in
-// field 1.
+// field 1. If a malformed metric carries more than one oneof body,
+// datapoints from each are yielded, each tagged with its own type.
 // The returned function should be called after iteration to check for errors.
+// DataPoints is a thin adapter over DataPointsSeq.
 func (m Metric) DataPoints() (iter.Seq[DataPoint], func() error) {
 	var iterErr error
 
 	seq := func(yield func(DataPoint) bool) {
-		data := []byte(m)
-		pos := 0
-
-		for pos < len(data) {
-			fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
-			if tagLen < 0 {
-				iterErr = errors.New("malformed protobuf tag in metric")
-				return
+		m.DataPointsSeq(func(dp DataPoint, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
 			}
-			pos += tagLen
-
-			typ := MetricType(fieldNum)
-			isBody := typ == MetricTypeGauge || typ == MetricTypeSum ||
-				typ == MetricTypeHistogram || typ == MetricTypeExponentialHistogram ||
-				typ == MetricTypeSummary
-			if isBody && wireType == protowire.BytesType {
-				body, n := protowire.ConsumeBytes(data[pos:])
-				if n < 0 {
-					iterErr = errors.New("invalid bytes in metric data")
-					return
-				}
-				pos += n
-
-				stopped := false
-				forEachRepeatedField(body, 1, func(dpBytes []byte, err error) bool {
-					if err != nil {
-						iterErr = err
-						return false
-					}
-					if !yield(DataPoint{raw: dpBytes, typ: typ}) {
-						stopped = true
-						return false
-					}
-					return true
-				})
-				if iterErr != nil || stopped {
-					return
-				}
-			} else {
-				n := skipField(data[pos:], wireType)
-				if n < 0 {
-					iterErr = errors.New("failed to skip field")
-					return
-				}
-				pos += n
-			}
-		}
+			return yield(dp)
+		})
 	}
 
 	errFunc := func() error {
@@ -312,7 +274,8 @@ func (m Metric) DataPoints() (iter.Seq[DataPoint], func() error) {
 //
 // On a parse error it yields a zero DataPoint with a non-nil error and
 // stops. Unlike DataPoints, no closures escape, so iterating allocates
-// nothing.
+// nothing. If a malformed metric carries more than one oneof body,
+// datapoints from each are yielded, each tagged with its own type.
 func (m Metric) DataPointsSeq(yield func(DataPoint, error) bool) {
 	data := []byte(m)
 	pos := 0
@@ -329,7 +292,11 @@ func (m Metric) DataPointsSeq(yield func(DataPoint, error) bool) {
 		isBody := typ == MetricTypeGauge || typ == MetricTypeSum ||
 			typ == MetricTypeHistogram || typ == MetricTypeExponentialHistogram ||
 			typ == MetricTypeSummary
-		if isBody && wireType == protowire.BytesType {
+		if isBody && wireType != protowire.BytesType {
+			yield(DataPoint{}, errors.New("wrong wire type for metric data"))
+			return
+		}
+		if isBody {
 			body, n := protowire.ConsumeBytes(data[pos:])
 			if n < 0 {
 				yield(DataPoint{}, errors.New("invalid bytes in metric data"))

--- a/otlpwire.go
+++ b/otlpwire.go
@@ -33,6 +33,12 @@ type ScopeSpans []byte
 // Span represents a single Span message (raw wire bytes).
 type Span []byte
 
+// ScopeMetrics represents a single ScopeMetrics message (raw wire bytes).
+type ScopeMetrics []byte
+
+// Metric represents a single Metric message (raw wire bytes).
+type Metric []byte
+
 // DataPointCount returns the total number of metric data points in the batch.
 func (m ExportMetricsServiceRequest) DataPointCount() (int, error) {
 	return countMetricDataPoints([]byte(m))
@@ -74,6 +80,52 @@ func (r ResourceMetrics) Resource() ([]byte, error) {
 // Implements io.WriterTo interface.
 func (r ResourceMetrics) WriteTo(w io.Writer) (int64, error) {
 	return writeResourceMessage(w, []byte(r))
+}
+
+// ScopeMetrics returns an iterator over ScopeMetrics in this ResourceMetrics.
+// Field 2 in the ResourceMetrics protobuf message.
+// The returned function should be called after iteration to check for errors.
+func (r ResourceMetrics) ScopeMetrics() (iter.Seq[ScopeMetrics], func() error) {
+	var iterErr error
+
+	seq := func(yield func(ScopeMetrics) bool) {
+		forEachRepeatedField([]byte(r), 2, func(rb []byte, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(ScopeMetrics(rb))
+		})
+	}
+
+	errFunc := func() error {
+		return iterErr
+	}
+
+	return seq, errFunc
+}
+
+// Metrics returns an iterator over Metrics in this ScopeMetrics.
+// Field 2 in the ScopeMetrics protobuf message.
+// The returned function should be called after iteration to check for errors.
+func (s ScopeMetrics) Metrics() (iter.Seq[Metric], func() error) {
+	var iterErr error
+
+	seq := func(yield func(Metric) bool) {
+		forEachRepeatedField([]byte(s), 2, func(rb []byte, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(Metric(rb))
+		})
+	}
+
+	errFunc := func() error {
+		return iterErr
+	}
+
+	return seq, errFunc
 }
 
 // LogRecordCount returns the total number of log records in the batch.

--- a/otlpwire.go
+++ b/otlpwire.go
@@ -39,6 +39,32 @@ type ScopeMetrics []byte
 // Metric represents a single Metric message (raw wire bytes).
 type Metric []byte
 
+// MetricType identifies which oneof body a DataPoint came from.
+type MetricType int
+
+// Metric oneof body field numbers in the Metric protobuf message.
+const (
+	MetricTypeGauge                MetricType = 5
+	MetricTypeSum                  MetricType = 7
+	MetricTypeHistogram            MetricType = 9
+	MetricTypeExponentialHistogram MetricType = 10
+	MetricTypeSummary              MetricType = 11
+)
+
+// DataPoint represents a single datapoint message (raw wire bytes) together
+// with the metric type it came from. The type is needed because the
+// attributes field number differs between datapoint message types.
+type DataPoint struct {
+	raw []byte
+	typ MetricType
+}
+
+// Raw returns the raw datapoint message bytes.
+func (d DataPoint) Raw() []byte { return d.raw }
+
+// Type returns the metric type this datapoint came from.
+func (d DataPoint) Type() MetricType { return d.typ }
+
 // DataPointCount returns the total number of metric data points in the batch.
 func (m ExportMetricsServiceRequest) DataPointCount() (int, error) {
 	return countMetricDataPoints([]byte(m))
@@ -132,6 +158,71 @@ func (s ScopeMetrics) Metrics() (iter.Seq[Metric], func() error) {
 // buffer. Returns nil if the field is not present.
 func (m Metric) Name() ([]byte, error) {
 	return extractBytesField([]byte(m), 1)
+}
+
+// DataPoints returns an iterator over datapoints in this Metric, descending
+// whichever oneof body is present (gauge 5, sum 7, histogram 9,
+// exponential_histogram 10, summary 11). Each body holds its datapoints in
+// field 1.
+// The returned function should be called after iteration to check for errors.
+func (m Metric) DataPoints() (iter.Seq[DataPoint], func() error) {
+	var iterErr error
+
+	seq := func(yield func(DataPoint) bool) {
+		data := []byte(m)
+		pos := 0
+
+		for pos < len(data) {
+			fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+			if tagLen < 0 {
+				iterErr = errors.New("malformed protobuf tag in metric")
+				return
+			}
+			pos += tagLen
+
+			typ := MetricType(fieldNum)
+			isBody := typ == MetricTypeGauge || typ == MetricTypeSum ||
+				typ == MetricTypeHistogram || typ == MetricTypeExponentialHistogram ||
+				typ == MetricTypeSummary
+			if isBody && wireType == protowire.BytesType {
+				body, n := protowire.ConsumeBytes(data[pos:])
+				if n < 0 {
+					iterErr = errors.New("invalid bytes in metric data")
+					return
+				}
+				pos += n
+
+				stopped := false
+				forEachRepeatedField(body, 1, func(dpBytes []byte, err error) bool {
+					if err != nil {
+						iterErr = err
+						return false
+					}
+					if !yield(DataPoint{raw: dpBytes, typ: typ}) {
+						stopped = true
+						return false
+					}
+					return true
+				})
+				if iterErr != nil || stopped {
+					return
+				}
+			} else {
+				n := skipField(data[pos:], wireType)
+				if n < 0 {
+					iterErr = errors.New("failed to skip field")
+					return
+				}
+				pos += n
+			}
+		}
+	}
+
+	errFunc := func() error {
+		return iterErr
+	}
+
+	return seq, errFunc
 }
 
 // LogRecordCount returns the total number of log records in the batch.

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -1481,3 +1481,130 @@ func TestMetricName_Absent(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, name)
 }
+
+// buildAllTypesMetrics builds one metric of each of the five types, each
+// with two datapoints carrying attributes {"method":"GET","status":"200"}
+// and timestamp 1000000000.
+func buildAllTypesMetrics(t *testing.T) []byte {
+	t.Helper()
+	metrics := pmetric.NewMetrics()
+	sm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+
+	setNumberDP := func(dp pmetric.NumberDataPoint) {
+		dp.SetIntValue(42)
+		dp.SetTimestamp(1000000000)
+		dp.Attributes().PutStr("method", "GET")
+		dp.Attributes().PutStr("status", "200")
+	}
+
+	gauge := sm.Metrics().AppendEmpty()
+	gauge.SetName("test.gauge")
+	setNumberDP(gauge.SetEmptyGauge().DataPoints().AppendEmpty())
+	setNumberDP(gauge.Gauge().DataPoints().AppendEmpty())
+
+	sum := sm.Metrics().AppendEmpty()
+	sum.SetName("test.sum")
+	setNumberDP(sum.SetEmptySum().DataPoints().AppendEmpty())
+	setNumberDP(sum.Sum().DataPoints().AppendEmpty())
+
+	hist := sm.Metrics().AppendEmpty()
+	hist.SetName("test.histogram")
+	histBody := hist.SetEmptyHistogram()
+	for i := 0; i < 2; i++ {
+		dp := histBody.DataPoints().AppendEmpty()
+		dp.SetCount(10)
+		dp.SetTimestamp(1000000000)
+		dp.Attributes().PutStr("method", "GET")
+		dp.Attributes().PutStr("status", "200")
+	}
+
+	expHist := sm.Metrics().AppendEmpty()
+	expHist.SetName("test.exphistogram")
+	expHistBody := expHist.SetEmptyExponentialHistogram()
+	for i := 0; i < 2; i++ {
+		dp := expHistBody.DataPoints().AppendEmpty()
+		dp.SetCount(10)
+		dp.SetTimestamp(1000000000)
+		dp.Attributes().PutStr("method", "GET")
+		dp.Attributes().PutStr("status", "200")
+	}
+
+	summary := sm.Metrics().AppendEmpty()
+	summary.SetName("test.summary")
+	summaryBody := summary.SetEmptySummary()
+	for i := 0; i < 2; i++ {
+		dp := summaryBody.DataPoints().AppendEmpty()
+		dp.SetCount(10)
+		dp.SetTimestamp(1000000000)
+		dp.Attributes().PutStr("method", "GET")
+		dp.Attributes().PutStr("status", "200")
+	}
+
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(metrics)
+	require.NoError(t, err)
+	return bytes
+}
+
+// forEachTestDataPoint iterates all datapoints in a marshaled request,
+// failing the test on any iterator error.
+func forEachTestDataPoint(t *testing.T, bytes []byte, fn func(metricName string, dp DataPoint)) {
+	t.Helper()
+	req := ExportMetricsServiceRequest(bytes)
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for sm := range scopeSeq {
+			metricSeq, metricErr := sm.Metrics()
+			for m := range metricSeq {
+				name, err := m.Name()
+				require.NoError(t, err)
+				dpSeq, dpErr := m.DataPoints()
+				for dp := range dpSeq {
+					fn(string(name), dp)
+				}
+				require.NoError(t, dpErr())
+			}
+			require.NoError(t, metricErr())
+		}
+		require.NoError(t, scopeErr())
+	}
+	require.NoError(t, resErr())
+}
+
+func TestDataPointsIteration_AllTypes(t *testing.T) {
+	bytes := buildAllTypesMetrics(t)
+
+	typeByMetric := map[string]MetricType{}
+	countByMetric := map[string]int{}
+	forEachTestDataPoint(t, bytes, func(name string, dp DataPoint) {
+		typeByMetric[name] = dp.Type()
+		countByMetric[name]++
+		require.NotEmpty(t, dp.Raw())
+	})
+
+	require.Equal(t, map[string]MetricType{
+		"test.gauge":        MetricTypeGauge,
+		"test.sum":          MetricTypeSum,
+		"test.histogram":    MetricTypeHistogram,
+		"test.exphistogram": MetricTypeExponentialHistogram,
+		"test.summary":      MetricTypeSummary,
+	}, typeByMetric)
+	for name, count := range countByMetric {
+		require.Equal(t, 2, count, "metric %s", name)
+	}
+}
+
+func TestDataPointsIteration_EmptyMetric(t *testing.T) {
+	// Metric with a name but no oneof body.
+	var m Metric
+	m = protowire.AppendTag(m, 1, protowire.BytesType)
+	m = protowire.AppendBytes(m, []byte("empty"))
+	seq, errFn := m.DataPoints()
+	count := 0
+	for range seq {
+		count++
+	}
+	require.NoError(t, errFn())
+	require.Equal(t, 0, count)
+}

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -1447,3 +1447,37 @@ func TestScopeMetricsIteration_Malformed(t *testing.T) {
 	}
 	require.Error(t, errFn())
 }
+
+func TestMetricName(t *testing.T) {
+	bytes := buildScopedMetrics(t, 1, 1, 2)
+	req := ExportMetricsServiceRequest(bytes)
+
+	var names []string
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for sm := range scopeSeq {
+			metricSeq, metricErr := sm.Metrics()
+			for m := range metricSeq {
+				name, err := m.Name()
+				require.NoError(t, err)
+				names = append(names, string(name))
+			}
+			require.NoError(t, metricErr())
+		}
+		require.NoError(t, scopeErr())
+	}
+	require.NoError(t, resErr())
+
+	require.Equal(t, []string{"metric.0.0", "metric.0.1"}, names)
+}
+
+func TestMetricName_Absent(t *testing.T) {
+	// A metric message with only a unit (field 3), no name.
+	var m Metric
+	m = protowire.AppendTag(m, 3, protowire.BytesType)
+	m = protowire.AppendBytes(m, []byte("1"))
+	name, err := m.Name()
+	require.NoError(t, err)
+	require.Nil(t, name)
+}

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -1717,3 +1717,160 @@ func TestDataPointAttributes_Empty(t *testing.T) {
 		require.Zero(t, count)
 	})
 }
+
+func TestDataPointsSeq_AllTypes(t *testing.T) {
+	bytes := buildAllTypesMetrics(t)
+	req := ExportMetricsServiceRequest(bytes)
+
+	// Expected AnyValue wire bytes for string values, built independently.
+	anyValueStr := func(s string) []byte {
+		var b []byte
+		b = protowire.AppendTag(b, 1, protowire.BytesType)
+		b = protowire.AppendBytes(b, []byte(s))
+		return b
+	}
+	expected := map[string][]byte{
+		"method": anyValueStr("GET"),
+		"status": anyValueStr("200"),
+	}
+
+	typeByMetric := map[string]MetricType{}
+	checked := 0
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for sm := range scopeSeq {
+			metricSeq, metricErr := sm.Metrics()
+			for m := range metricSeq {
+				name, err := m.Name()
+				require.NoError(t, err)
+				for dp, err := range m.DataPointsSeq {
+					require.NoError(t, err)
+					typeByMetric[string(name)] = dp.Type()
+
+					ts, err := dp.Timestamp()
+					require.NoError(t, err)
+					require.Equal(t, uint64(1000000000), ts)
+
+					attrs := map[string][]byte{}
+					for kv, err := range dp.AttributesSeq {
+						require.NoError(t, err)
+						key, err := kv.Key()
+						require.NoError(t, err)
+						val, err := kv.ValueRaw()
+						require.NoError(t, err)
+						attrs[string(key)] = val
+					}
+					require.Equal(t, expected, attrs, "metric %s", name)
+					checked++
+				}
+			}
+			require.NoError(t, metricErr())
+		}
+		require.NoError(t, scopeErr())
+	}
+	require.NoError(t, resErr())
+
+	require.Equal(t, 10, checked) // 5 types × 2 datapoints
+	require.Equal(t, map[string]MetricType{
+		"test.gauge":        MetricTypeGauge,
+		"test.sum":          MetricTypeSum,
+		"test.histogram":    MetricTypeHistogram,
+		"test.exphistogram": MetricTypeExponentialHistogram,
+		"test.summary":      MetricTypeSummary,
+	}, typeByMetric)
+}
+
+func TestDataPointsSeq_EarlyStop(t *testing.T) {
+	bytes := buildAllTypesMetrics(t)
+	forEachTestDataPoint(t, bytes, func(_ string, _ DataPoint) {})
+
+	req := ExportMetricsServiceRequest(bytes)
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for sm := range scopeSeq {
+			metricSeq, metricErr := sm.Metrics()
+			for m := range metricSeq {
+				seen := 0
+				for _, err := range m.DataPointsSeq {
+					require.NoError(t, err)
+					seen++
+					break
+				}
+				require.Equal(t, 1, seen) // every metric has 2 datapoints
+			}
+			require.NoError(t, metricErr())
+		}
+		require.NoError(t, scopeErr())
+	}
+	require.NoError(t, resErr())
+}
+
+func TestDataPointsSeq_CorruptBody(t *testing.T) {
+	// Gauge body (field 5) whose datapoints field (field 1) declares a
+	// length longer than the remaining bytes.
+	var body []byte
+	body = protowire.AppendTag(body, 1, protowire.BytesType)
+	body = protowire.AppendVarint(body, 100)
+
+	var m Metric
+	m = protowire.AppendTag(m, 5, protowire.BytesType)
+	m = protowire.AppendBytes(m, body)
+
+	sawErr := false
+	for _, err := range m.DataPointsSeq {
+		if err != nil {
+			sawErr = true
+		}
+	}
+	require.True(t, sawErr)
+}
+
+func TestDataPointsSeq_ZeroAlloc(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	sm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+	metric := sm.Metrics().AppendEmpty()
+	metric.SetName("alloc.test")
+	dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetIntValue(1)
+	dp.SetTimestamp(1000000000)
+	dp.Attributes().PutStr("method", "GET")
+
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(metrics)
+	require.NoError(t, err)
+
+	var metricBytes Metric
+	req := ExportMetricsServiceRequest(bytes)
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for s := range scopeSeq {
+			metricSeq, metricErr := s.Metrics()
+			for m := range metricSeq {
+				metricBytes = m
+			}
+			require.NoError(t, metricErr())
+		}
+		require.NoError(t, scopeErr())
+	}
+	require.NoError(t, resErr())
+	require.NotEmpty(t, metricBytes)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		for dp, err := range metricBytes.DataPointsSeq {
+			if err != nil {
+				t.Fatal(err)
+			}
+			for kv, err := range dp.AttributesSeq {
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, _ = kv.Key()
+				_, _ = kv.ValueRaw()
+			}
+		}
+	})
+	require.Zero(t, allocs, "DataPointsSeq/AttributesSeq must not allocate")
+}

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -1608,3 +1608,48 @@ func TestDataPointsIteration_EmptyMetric(t *testing.T) {
 	require.NoError(t, errFn())
 	require.Equal(t, 0, count)
 }
+
+func TestDataPointsIteration_EarlyStop(t *testing.T) {
+	bytes := buildAllTypesMetrics(t)
+
+	// Break after the first datapoint of a metric that has two; the error
+	// func must stay nil and iteration must stop cleanly.
+	req := ExportMetricsServiceRequest(bytes)
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for sm := range scopeSeq {
+			metricSeq, metricErr := sm.Metrics()
+			for m := range metricSeq {
+				seen := 0
+				dpSeq, dpErr := m.DataPoints()
+				for range dpSeq {
+					seen++
+					break
+				}
+				require.NoError(t, dpErr())
+				require.Equal(t, 1, seen)
+			}
+			require.NoError(t, metricErr())
+		}
+		require.NoError(t, scopeErr())
+	}
+	require.NoError(t, resErr())
+}
+
+func TestDataPointsIteration_CorruptBody(t *testing.T) {
+	// Metric with a gauge body (field 5) whose datapoints field (field 1)
+	// declares a length longer than the remaining bytes.
+	var body []byte
+	body = protowire.AppendTag(body, 1, protowire.BytesType)
+	body = protowire.AppendVarint(body, 100) // claims 100 bytes, none follow
+
+	var m Metric
+	m = protowire.AppendTag(m, 5, protowire.BytesType)
+	m = protowire.AppendBytes(m, body)
+
+	dpSeq, dpErr := m.DataPoints()
+	for range dpSeq {
+	}
+	require.Error(t, dpErr())
+}

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -1654,6 +1654,41 @@ func TestDataPointsIteration_CorruptBody(t *testing.T) {
 	require.Error(t, dpErr())
 }
 
+func TestDataPointsIteration_WrongWireTypeBody(t *testing.T) {
+	// Gauge oneof (field 5) encoded as varint instead of bytes.
+	var m Metric
+	m = protowire.AppendTag(m, 5, protowire.VarintType)
+	m = protowire.AppendVarint(m, 1)
+
+	seq, errFn := m.DataPoints()
+	for range seq {
+	}
+	require.Error(t, errFn())
+}
+
+func TestDataPointsSeq_WrongWireTypeBody(t *testing.T) {
+	var m Metric
+	m = protowire.AppendTag(m, 5, protowire.VarintType)
+	m = protowire.AppendVarint(m, 1)
+
+	sawErr := false
+	for _, err := range m.DataPointsSeq {
+		if err != nil {
+			sawErr = true
+		}
+	}
+	require.True(t, sawErr)
+}
+
+func TestDataPointTimestamp_WrongWireType(t *testing.T) {
+	var raw []byte
+	raw = protowire.AppendTag(raw, 3, protowire.BytesType)
+	raw = protowire.AppendBytes(raw, []byte("xx"))
+	dp := DataPoint{raw: raw, typ: MetricTypeGauge}
+	_, err := dp.Timestamp()
+	require.Error(t, err)
+}
+
 func TestDataPointTimestampAndAttributes_AllTypes(t *testing.T) {
 	bytes := buildAllTypesMetrics(t)
 

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -1653,3 +1653,67 @@ func TestDataPointsIteration_CorruptBody(t *testing.T) {
 	}
 	require.Error(t, dpErr())
 }
+
+func TestDataPointTimestampAndAttributes_AllTypes(t *testing.T) {
+	bytes := buildAllTypesMetrics(t)
+
+	// Expected AnyValue wire bytes for string values, built independently.
+	anyValueStr := func(s string) []byte {
+		var b []byte
+		b = protowire.AppendTag(b, 1, protowire.BytesType) // AnyValue.string_value = 1
+		b = protowire.AppendBytes(b, []byte(s))
+		return b
+	}
+	expected := map[string][]byte{
+		"method": anyValueStr("GET"),
+		"status": anyValueStr("200"),
+	}
+
+	checked := 0
+	forEachTestDataPoint(t, bytes, func(name string, dp DataPoint) {
+		ts, err := dp.Timestamp()
+		require.NoError(t, err)
+		require.Equal(t, uint64(1000000000), ts)
+
+		attrs := map[string][]byte{}
+		attrSeq, attrErr := dp.Attributes()
+		for kv := range attrSeq {
+			key, err := kv.Key()
+			require.NoError(t, err)
+			val, err := kv.ValueRaw()
+			require.NoError(t, err)
+			attrs[string(key)] = val
+		}
+		require.NoError(t, attrErr())
+		require.Equal(t, expected, attrs, "metric %s", name)
+		checked++
+	})
+	require.Equal(t, 10, checked) // 5 types × 2 datapoints
+}
+
+func TestDataPointAttributes_Empty(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	sm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+	metric := sm.Metrics().AppendEmpty()
+	metric.SetName("no.attrs")
+	dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetIntValue(1)
+
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(metrics)
+	require.NoError(t, err)
+
+	forEachTestDataPoint(t, bytes, func(name string, dp DataPoint) {
+		ts, err := dp.Timestamp()
+		require.NoError(t, err)
+		require.Zero(t, ts)
+
+		count := 0
+		attrSeq, attrErr := dp.Attributes()
+		for range attrSeq {
+			count++
+		}
+		require.NoError(t, attrErr())
+		require.Zero(t, count)
+	})
+}

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -2,6 +2,7 @@ package otlpwire
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1385,4 +1386,64 @@ func BenchmarkLogsData_SplitByResource(b *testing.B) {
 		}
 		_ = getErr()
 	}
+}
+
+// buildScopedMetrics builds a request with the given number of scopes per
+// resource and metrics per scope, all gauges with one datapoint.
+func buildScopedMetrics(t *testing.T, resources, scopes, metricsPerScope int) []byte {
+	t.Helper()
+	metrics := pmetric.NewMetrics()
+	for r := 0; r < resources; r++ {
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("service.name", fmt.Sprintf("service-%d", r))
+		for s := 0; s < scopes; s++ {
+			sm := rm.ScopeMetrics().AppendEmpty()
+			sm.Scope().SetName(fmt.Sprintf("scope-%d", s))
+			for m := 0; m < metricsPerScope; m++ {
+				metric := sm.Metrics().AppendEmpty()
+				metric.SetName(fmt.Sprintf("metric.%d.%d", s, m))
+				dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
+				dp.SetIntValue(int64(m))
+				dp.SetTimestamp(1000000000)
+			}
+		}
+	}
+	marshaler := &pmetric.ProtoMarshaler{}
+	bytes, err := marshaler.MarshalMetrics(metrics)
+	require.NoError(t, err)
+	return bytes
+}
+
+func TestScopeMetricsIteration(t *testing.T) {
+	bytes := buildScopedMetrics(t, 2, 3, 4)
+	req := ExportMetricsServiceRequest(bytes)
+
+	totalScopes := 0
+	totalMetrics := 0
+	resources, resErr := req.ResourceMetrics()
+	for rm := range resources {
+		scopeSeq, scopeErr := rm.ScopeMetrics()
+		for sm := range scopeSeq {
+			totalScopes++
+			metricSeq, metricErr := sm.Metrics()
+			for range metricSeq {
+				totalMetrics++
+			}
+			require.NoError(t, metricErr())
+		}
+		require.NoError(t, scopeErr())
+	}
+	require.NoError(t, resErr())
+
+	require.Equal(t, 6, totalScopes)   // 2 resources × 3 scopes
+	require.Equal(t, 24, totalMetrics) // 6 scopes × 4 metrics
+}
+
+func TestScopeMetricsIteration_Malformed(t *testing.T) {
+	// Field 2 (scope_metrics) with wrong wire type: varint instead of bytes.
+	bad := ResourceMetrics{0x10, 0x01}
+	seq, errFn := bad.ScopeMetrics()
+	for range seq {
+	}
+	require.Error(t, errFn())
 }


### PR DESCRIPTION
Implements [E-2608](https://linear.app/ollygarden/issue/E-2608/otlp-wire-add-metrics-depth-iteration-scopemetrics-metric): extends the metrics side of otlp-wire from `ResourceMetrics` down to datapoint attributes, in the same zero-copy protowire-walking style the traces side already has. Prerequisite for marigold's zero-copy decode path (follow-up to E-2601).

## API

- `ResourceMetrics.ScopeMetrics()` / `ScopeMetrics.Metrics()` — same `(iter.Seq[T], func() error)` pattern as the existing iterators
- `Metric.Name()`, `Metric.DataPoints()` — descends whichever oneof body is present (gauge 5 / sum 7 / histogram 9 / exp-histogram 10 / summary 11)
- `DataPoint` (struct, not `[]byte` alias — it carries its `MetricType` because the attributes field number differs per datapoint type: Number/Summary=7, Histogram=9, ExpHistogram=1): `Raw()`, `Type()`, `Timestamp()`, `Attributes()`
- `KeyValue.Key()` / `KeyValue.ValueRaw()` — raw AnyValue bytes for type-tagged hashing
- **Zero-alloc variants** `Metric.DataPointsSeq` / `DataPoint.AttributesSeq`: `iter.Seq2[T, error]`-shaped methods ranged over directly, so no closures escape — `testing.AllocsPerRun` verifies 0 allocations

## Benchmarks (scrape shape: 4,800 metrics × 1 datapoint × 4 attrs, the E-2601 traffic shape; Apple M4, medians of 5)

| Path | ns/op | B/op | allocs/op |
|---|---|---|---|
| pdata unmarshal + traversal | ~2,269,000 | 3,507,250 | 105,631 |
| wire, closure iterators | ~828,000 | 460,987 | 19,207 |
| wire, Seq variants | ~634,000 | ~370 | **7** |

~3.6× CPU and a near-total elimination of allocation garbage (7 vs 105,631 allocs/op) — the pdata materialization cost that dominates marigold's per-message profile. The pdata side of the comparison deliberately understates marigold's real re-serialization cost, so the production win should be larger. Full analysis in `docs/BENCHMARKS.md`.

## Notes

- Malformed input posture: a metric oneof body with a wrong wire type now surfaces an error through both walkers (negative tests through both entry points). The pre-existing counting path (`DataPointCount`) keeps its lenient skip behavior — unchanged by this PR.
- `Metric.Metadata()` (field 12) intentionally out of scope; five-line addition when marigold needs it.
- Design spec and implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aYYxZEwth9PBEtzbuQR2u