### PR TITLE
feat(logs): add wire-level severity iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,19 @@ func (r Resource) StringAttribute(key string) ([]byte, bool, error)
 
 `Resource.StringAttribute` is zero-copy and returns a separate `found` value,
 so a missing resource attribute can be distinguished from a present empty
-string. Convert the existing resource bytes without copying:
-`attrs := otlpwire.Resource(resourceBytes)`.
+string. It inspects one Resource message; convert the existing resource bytes
+without copying: `attrs := otlpwire.Resource(resourceBytes)`.
+
+`ResourceLogs.StringAttribute` is the preferred accessor when starting from a
+`ResourceLogs`: it merges every encoded singular Resource message in wire
+order, validates later Resource messages, and matches pdata by retaining the
+first value for duplicate attribute keys.
+
+`KeyValue.ValueRaw` remains a lightweight view of the first encoded AnyValue
+field for hashing-oriented hot paths. `KeyValue.StringValue` fully parses
+AnyValue and follows protobuf oneof behavior, so a later non-string oneof
+member makes `StringValue` report `found=false` even if an earlier encoded
+member was a string.
 
 `DataPoint` carries its `MetricType` because the attribute field number differs
 per data point wire type (histograms and exponential histograms encode

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ ExportMetricsServiceRequest (OTLP message bytes)
 
 ExportLogsServiceRequest (OTLP message bytes)
   └─ ResourceLogs[] (one per resource)
+       └─ ScopeLogs[] (one per instrumentation scope)
+            └─ LogRecord[]
+                 └─ SeverityNumber()
 
 ExportTracesServiceRequest (OTLP message bytes)
   └─ ResourceSpans[] (one per resource)
@@ -152,6 +155,8 @@ type ResourceLogs []byte
 func (r ResourceLogs) LogRecordCount() (int, error)
 func (r ResourceLogs) Resource() ([]byte, error)
 func (r ResourceLogs) WriteTo(w io.Writer) (int64, error)
+func (r ResourceLogs) ScopeLogs() (iter.Seq[ScopeLogs], func() error)
+func (r ResourceLogs) StringAttribute(key string) ([]byte, bool, error)
 
 type ResourceSpans []byte
 func (r ResourceSpans) SpanCount() (int, error)
@@ -195,6 +200,7 @@ func (d DataPoint) AttributesSeq(yield func(KeyValue, error) bool)   // zero-all
 type KeyValue []byte
 func (kv KeyValue) Key() ([]byte, error)
 func (kv KeyValue) ValueRaw() ([]byte, error)
+func (kv KeyValue) StringValue() ([]byte, bool, error)
 
 type MetricType int
 const (
@@ -205,6 +211,26 @@ const (
 	MetricTypeSummary              MetricType = 11
 )
 ```
+
+**Log-level operations and resource attributes:**
+```go
+type ScopeLogs []byte
+func (s ScopeLogs) LogRecords() (iter.Seq[LogRecord], func() error) // ergonomic, 2 allocs per open
+func (s ScopeLogs) LogRecordsSeq(yield func(LogRecord, error) bool) // zero-alloc, range directly
+
+type LogRecord []byte
+func (r LogRecord) SeverityNumber() (int32, error)
+
+type Resource []byte
+func (r Resource) Attributes() (iter.Seq[KeyValue], func() error)
+func (r Resource) AttributesSeq(yield func(KeyValue, error) bool)
+func (r Resource) StringAttribute(key string) ([]byte, bool, error)
+```
+
+`Resource.StringAttribute` is zero-copy and returns a separate `found` value,
+so a missing resource attribute can be distinguished from a present empty
+string. Convert the existing resource bytes without copying:
+`attrs := otlpwire.Resource(resourceBytes)`.
 
 `DataPoint` carries its `MetricType` because the attribute field number differs
 per data point wire type (histograms and exponential histograms encode

--- a/benchmark_comparison_test.go
+++ b/benchmark_comparison_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -277,6 +278,153 @@ func BenchmarkLogs_Split_UnmarshalRemarshal(b *testing.B) {
 	}
 }
 
+// benchmarkLogSeveritySink prevents severity classification and service-context
+// reads from being optimized away in the paired benchmarks below.
+var benchmarkLogSeveritySink int
+
+// BenchmarkLogs_SeverityClassification_WireFormat measures the complete
+// resource-context, record-iteration, and severity-classification path used by
+// log insight consumers without unmarshaling the OTLP payload.
+func BenchmarkLogs_SeverityClassification_WireFormat(b *testing.B) {
+	data := createSeverityClassificationBenchLogs()
+	bytes, err := (&plog.ProtoMarshaler{}).MarshalLogs(data)
+	require.NoError(b, err)
+	request := ExportLogsServiceRequest(bytes)
+	wireResult, err := classifyWireLogSeverities(request)
+	require.NoError(b, err)
+	pdataResult, err := classifyPdataLogSeverities(bytes, &plog.ProtoUnmarshaler{})
+	require.NoError(b, err)
+	require.Equal(b, pdataResult, wireResult, "wire and pdata paths must classify the same fixture identically")
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result, err := classifyWireLogSeverities(request)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkLogSeveritySink = result.score()
+	}
+}
+
+// BenchmarkLogs_SeverityClassification_Unmarshal measures the same work as
+// BenchmarkLogs_SeverityClassification_WireFormat after full pdata unmarshal.
+func BenchmarkLogs_SeverityClassification_Unmarshal(b *testing.B) {
+	data := createSeverityClassificationBenchLogs()
+	bytes, err := (&plog.ProtoMarshaler{}).MarshalLogs(data)
+	require.NoError(b, err)
+	unmarshaler := &plog.ProtoUnmarshaler{}
+	wireResult, err := classifyWireLogSeverities(ExportLogsServiceRequest(bytes))
+	require.NoError(b, err)
+	pdataResult, err := classifyPdataLogSeverities(bytes, unmarshaler)
+	require.NoError(b, err)
+	require.Equal(b, wireResult, pdataResult, "wire and pdata paths must classify the same fixture identically")
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result, err := classifyPdataLogSeverities(bytes, unmarshaler)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkLogSeveritySink = result.score()
+	}
+}
+
+type logSeverityClassification struct {
+	counts          [6]int
+	contextStrings  int
+	contextByteSize int
+}
+
+func (result logSeverityClassification) score() int {
+	score := result.contextStrings + result.contextByteSize
+	for class, count := range result.counts {
+		score += class * count
+	}
+	return score
+}
+
+func classifyWireLogSeverities(request ExportLogsServiceRequest) (logSeverityClassification, error) {
+	var result logSeverityClassification
+	resources, resourceErr := request.ResourceLogs()
+	for resource := range resources {
+		for _, key := range []string{"service.name", "deployment.environment"} {
+			value, found, err := resource.StringAttribute(key)
+			if err != nil {
+				return logSeverityClassification{}, err
+			}
+			if found {
+				result.contextStrings++
+				result.contextByteSize += len(value)
+			}
+		}
+
+		scopes, scopeErr := resource.ScopeLogs()
+		for scope := range scopes {
+			for record, err := range scope.LogRecordsSeq {
+				if err != nil {
+					return logSeverityClassification{}, err
+				}
+				severity, err := record.SeverityNumber()
+				if err != nil {
+					return logSeverityClassification{}, err
+				}
+				result.counts[logSeverityClass(severity)]++
+			}
+		}
+		if err := scopeErr(); err != nil {
+			return logSeverityClassification{}, err
+		}
+	}
+	if err := resourceErr(); err != nil {
+		return logSeverityClassification{}, err
+	}
+	return result, nil
+}
+
+func classifyPdataLogSeverities(data []byte, unmarshaler *plog.ProtoUnmarshaler) (logSeverityClassification, error) {
+	logs, err := unmarshaler.UnmarshalLogs(data)
+	if err != nil {
+		return logSeverityClassification{}, err
+	}
+	var result logSeverityClassification
+	for resourceIndex := 0; resourceIndex < logs.ResourceLogs().Len(); resourceIndex++ {
+		resource := logs.ResourceLogs().At(resourceIndex)
+		for _, key := range []string{"service.name", "deployment.environment"} {
+			if value, ok := resource.Resource().Attributes().Get(key); ok && value.Type() == pcommon.ValueTypeStr {
+				result.contextStrings++
+				result.contextByteSize += len(value.Str())
+			}
+		}
+		for scopeIndex := 0; scopeIndex < resource.ScopeLogs().Len(); scopeIndex++ {
+			scope := resource.ScopeLogs().At(scopeIndex)
+			for recordIndex := 0; recordIndex < scope.LogRecords().Len(); recordIndex++ {
+				record := scope.LogRecords().At(recordIndex)
+				result.counts[logSeverityClass(int32(record.SeverityNumber()))]++
+			}
+		}
+	}
+	return result, nil
+}
+
+func logSeverityClass(severity int32) int {
+	switch {
+	case severity < 1:
+		return 0
+	case severity <= 4:
+		return 1
+	case severity <= 8:
+		return 2
+	case severity <= 12:
+		return 3
+	case severity <= 16:
+		return 4
+	default:
+		return 5
+	}
+}
+
 // ========== Helper Functions ==========
 
 func createBenchMetrics() pmetric.Metrics {
@@ -353,6 +501,54 @@ func createBenchLogs() plog.Logs {
 			lr.SetSeverityText("INFO")
 			lr.Attributes().PutStr("log.level", "info")
 			lr.Attributes().PutStr("logger.name", "test.logger")
+		}
+	}
+	return logs
+}
+
+// createSeverityClassificationBenchLogs covers every severity class plus
+// absent, empty, and non-string resource context values. The paired benchmark
+// asserts wire/pdata parity before timing this representative consumer path.
+func createSeverityClassificationBenchLogs() plog.Logs {
+	logs := plog.NewLogs()
+	severities := []plog.SeverityNumber{
+		plog.SeverityNumberUnspecified,
+		plog.SeverityNumberTrace,
+		plog.SeverityNumberDebug,
+		plog.SeverityNumberInfo,
+		plog.SeverityNumberWarn,
+		plog.SeverityNumberError,
+	}
+
+	for resourceIndex := 0; resourceIndex < 5; resourceIndex++ {
+		resource := logs.ResourceLogs().AppendEmpty()
+		switch resourceIndex {
+		case 0:
+			resource.Resource().Attributes().PutStr("service.name", "checkout")
+			resource.Resource().Attributes().PutStr("deployment.environment", "production")
+		case 1:
+			resource.Resource().Attributes().PutStr("service.name", "")
+			resource.Resource().Attributes().PutStr("deployment.environment", "staging")
+		case 2:
+			resource.Resource().Attributes().PutInt("service.name", 42)
+			resource.Resource().Attributes().PutStr("deployment.environment", "development")
+		case 3:
+			resource.Resource().Attributes().PutStr("service.name", "payments")
+			resource.Resource().Attributes().PutInt("deployment.environment", 7)
+		case 4:
+			// Deliberately omit both attributes.
+		}
+
+		scope := resource.ScopeLogs().AppendEmpty()
+		for recordIndex := 0; recordIndex < 120; recordIndex++ {
+			record := scope.LogRecords().AppendEmpty()
+			record.Body().SetStr("representative application log message")
+			record.Attributes().PutStr("logger.name", "checkout.handler")
+			record.Attributes().PutStr("http.request.method", "GET")
+			severity := severities[recordIndex%len(severities)]
+			if severity != plog.SeverityNumberUnspecified {
+				record.SetSeverityNumber(severity)
+			}
 		}
 	}
 	return logs

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -280,3 +280,31 @@ unmarshal improves from 2.74x to 3.58x. Use the closure-based pattern for outer,
 amortized levels and general iteration; use the Seq variants specifically for
 `DataPoints()`/`Attributes()` in code paths that iterate every metric or every data
 point in a batch, such as scrape-shaped or high-cardinality workloads.
+
+---
+
+## Log severity classification (E-2892)
+
+This benchmark models an insight consumer that reads resource context through
+`ResourceLogs.StringAttribute`, walks every LogRecord, and classifies severity
+without needing log bodies or record attributes. `createSeverityClassificationBenchLogs`
+contains 5 resources and 600 records, covers unspecified/trace/debug/info/warn/error
+severities, and includes present, empty, non-string, and absent `service.name`
+and `deployment.environment` values. Each benchmark first computes the complete
+classification through both wire and pdata paths outside the timed section and
+fails if the results differ.
+
+**Environment-specific result:** Apple M4, darwin/arm64, Go 1.26.3;
+`go test -run '^$' -bench 'BenchmarkLogs_SeverityClassification' -benchmem ./...`.
+Measurements vary by machine and toolchain; do not treat these values as a
+portable performance guarantee.
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---:|---:|---:|
+| `BenchmarkLogs_SeverityClassification_WireFormat` | 49,044 | 488 | 15 |
+| `BenchmarkLogs_SeverityClassification_Unmarshal` | 117,241 | 257,906 | 6,690 |
+
+The wire path is approximately 2.4x faster in this environment and avoids the
+full pdata object graph. Its 15 allocations are the established outer iterator
+error-closure cost; `ScopeLogs.LogRecordsSeq` itself remains zero-allocation on
+the per-record path.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -111,7 +111,7 @@ func (r ResourceMetrics) WriteTo(w io.Writer) (int64, error)
 - `ScopeLogs.LogRecordsSeq(func(LogRecord, error) bool)`
 - `LogRecord.SeverityNumber() (int32, error)`
 
-## Log Depth and Resource Attribute Access (E-2892)
+## Log Depth and Resource Attribute Access
 
 Logs expose the same raw-byte progression used by traces and metrics:
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -17,14 +17,16 @@ Current approaches require full unmarshaling, which is expensive:
 
 1. **Fast signal counting** without unmarshaling
 2. **Resource-level batch splitting** for sharding/parallel processing
-3. **Metadata extraction** (Resource bytes) for routing decisions
+3. **Metadata extraction** (Resource bytes and selected string attributes) for routing decisions
 4. **Minimal API** - provide tools, not opinions
 5. **Zero-copy where possible** - work on raw bytes
 
 ## Non-Goals
 
 1. **Not a complete OTLP parser** - use official libraries for full deserialization
-2. **Not attribute-aware** - we don't read/filter by attribute values
+2. **Not a general attribute query engine** - selected resource strings can be
+   read for routing, but arbitrary attribute transformations remain the job of
+   the official pdata APIs
 3. **Not scope/metric-level splitting** - only resource-level granularity is provided
 4. **Not a query language** - no path expressions or complex filters
 
@@ -68,6 +70,11 @@ type ExportTracesServiceRequest []byte
 type ResourceMetrics []byte
 type ResourceLogs []byte
 type ResourceSpans []byte
+
+// Depth and attribute-aware wire views
+type Resource []byte
+type ScopeLogs []byte
+type LogRecord []byte
 ```
 
 **ExportMetricsServiceRequest methods:**
@@ -99,6 +106,48 @@ func (r ResourceMetrics) WriteTo(w io.Writer) (int64, error)
 - `ExportTracesServiceRequest.ResourceSpans() (iter.Seq[ResourceSpans], func() error)`
 - `ResourceLogs.LogRecordCount() (int, error)`
 - `ResourceSpans.SpanCount() (int, error)`
+- `ResourceLogs.ScopeLogs() (iter.Seq[ScopeLogs], func() error)`
+- `ScopeLogs.LogRecords() (iter.Seq[LogRecord], func() error)`
+- `ScopeLogs.LogRecordsSeq(func(LogRecord, error) bool)`
+- `LogRecord.SeverityNumber() (int32, error)`
+
+## Log Depth and Resource Attribute Access (E-2892)
+
+Logs expose the same raw-byte progression used by traces and metrics:
+
+```text
+ExportLogsServiceRequest
+  └─ ResourceLogs
+       └─ ScopeLogs
+            └─ LogRecord
+```
+
+`ScopeLogs.LogRecords` follows the package-wide `(iter.Seq[T], func() error)`
+contract. `LogRecordsSeq` is the per-record, zero-allocation variant: it emits
+`(LogRecord, error)` directly and stops after a parse error. `SeverityNumber`
+reads field 2 as an `int32`, scans the whole LogRecord, and uses protobuf's
+last-scalar-value behavior while still surfacing trailing malformed data.
+
+`Resource` is an explicit zero-copy wrapper around the bytes returned from the
+existing `Resource()` methods. `Attributes`/`AttributesSeq` expose raw
+KeyValues, while `Resource.StringAttribute(key)` is the intentionally narrow
+semantic accessor for one Resource message. `ResourceLogs.StringAttribute(key)`
+is the preferred generic accessor for a ResourceLogs message: it merges every
+encoded singular Resource field in wire order, preserves pdata's first
+duplicate-attribute behavior, and validates later Resource messages. Both
+return `(value, found, error)` so missing and empty strings remain distinct.
+
+The older `KeyValue.Key` and `ValueRaw` remain lightweight first-encoded-field
+views for existing metric hashing paths. `KeyValue.StringValue` and
+`Resource.StringAttribute` are separate complete parsers: they validate
+KeyValue/AnyValue wire structure, apply AnyValue oneof ordering, and continue
+through later fields so corruption is not hidden by an early match. Semantic
+nested values use a conservative 64-message depth budget and fail with a
+stable limit error before unbounded stack growth. Resource entity references
+are also structurally checked. `LogRecord.SeverityNumber` validates all known
+pdata LogRecord field wire types, including nested body and attributes, while
+using final-value-wins severity semantics. Unknown protobuf groups are skipped
+with matching end-group validation, preserving forward compatibility.
 
 ## Use Cases
 
@@ -504,4 +553,3 @@ API is designed to be additive:
 2. **DESIGN.md** - This document (architecture, decisions)
 3. **example_test.go** - Runnable examples for godoc
 4. **Inline docs** - Method documentation with use cases
-

--- a/example_test.go
+++ b/example_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"go.olly.garden/otlp-wire"
@@ -134,6 +135,61 @@ func ExampleMetric_DataPoints() {
 		}
 	}
 	// Output: request.duration ts=1000000000 attr=method
+}
+
+// ExampleResourceLogs_StringAttribute walks resource context and log records
+// without unmarshaling the OTLP request.
+func ExampleResourceLogs_StringAttribute() {
+	logs := plog.NewLogs()
+	resource := logs.ResourceLogs().AppendEmpty()
+	resource.Resource().Attributes().PutStr("service.name", "checkout")
+	scope := resource.ScopeLogs().AppendEmpty()
+	scope.LogRecords().AppendEmpty().SetSeverityNumber(plog.SeverityNumberWarn)
+
+	data, err := (&plog.ProtoMarshaler{}).MarshalLogs(logs)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	request := otlpwire.ExportLogsServiceRequest(data)
+	resources, resourceErr := request.ResourceLogs()
+	for resource := range resources {
+		service, found, err := resource.StringAttribute("service.name")
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		if !found {
+			fmt.Println("service.name missing")
+			return
+		}
+
+		scopes, scopeErr := resource.ScopeLogs()
+		for scope := range scopes {
+			for record, err := range scope.LogRecordsSeq {
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
+				severity, err := record.SeverityNumber()
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
+				fmt.Printf("%s severity=%d\n", service, severity)
+			}
+		}
+		if err := scopeErr(); err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+	if err := resourceErr(); err != nil {
+		fmt.Println(err)
+	}
+
+	// Output: checkout severity=13
 }
 
 // Helper functions

--- a/example_test.go
+++ b/example_test.go
@@ -141,9 +141,9 @@ func ExampleMetric_DataPoints() {
 // without unmarshaling the OTLP request.
 func ExampleResourceLogs_StringAttribute() {
 	logs := plog.NewLogs()
-	resource := logs.ResourceLogs().AppendEmpty()
-	resource.Resource().Attributes().PutStr("service.name", "checkout")
-	scope := resource.ScopeLogs().AppendEmpty()
+	pdataResource := logs.ResourceLogs().AppendEmpty()
+	pdataResource.Resource().Attributes().PutStr("service.name", "checkout")
+	scope := pdataResource.ScopeLogs().AppendEmpty()
 	scope.LogRecords().AppendEmpty().SetSeverityNumber(plog.SeverityNumberWarn)
 
 	data, err := (&plog.ProtoMarshaler{}).MarshalLogs(logs)
@@ -154,8 +154,8 @@ func ExampleResourceLogs_StringAttribute() {
 
 	request := otlpwire.ExportLogsServiceRequest(data)
 	resources, resourceErr := request.ResourceLogs()
-	for resource := range resources {
-		service, found, err := resource.StringAttribute("service.name")
+	for resourceLogs := range resources {
+		service, found, err := resourceLogs.StringAttribute("service.name")
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -165,7 +165,7 @@ func ExampleResourceLogs_StringAttribute() {
 			return
 		}
 
-		scopes, scopeErr := resource.ScopeLogs()
+		scopes, scopeErr := resourceLogs.ScopeLogs()
 		for scope := range scopes {
 			for record, err := range scope.LogRecordsSeq {
 				if err != nil {

--- a/log_iteration_test.go
+++ b/log_iteration_test.go
@@ -109,7 +109,9 @@ func TestLogTraversalAndResourceAttributes(t *testing.T) {
 	request := ExportLogsServiceRequest(marshalLogs(t, logs))
 	resources, resourceErr := request.ResourceLogs()
 	seen := 0
+	resourceCount := 0
 	for resource := range resources {
+		resourceCount++
 		scopes, scopeErr := resource.ScopeLogs()
 		for scope := range scopes {
 			records, recordErr := scope.LogRecords()
@@ -148,6 +150,7 @@ func TestLogTraversalAndResourceAttributes(t *testing.T) {
 		}
 	}
 	require.NoError(t, resourceErr())
+	require.Equal(t, 2, resourceCount)
 	require.Equal(t, 2, seen)
 }
 
@@ -159,7 +162,9 @@ func TestResourceStringAttribute_EmptyAndNonString(t *testing.T) {
 
 	request := ExportLogsServiceRequest(marshalLogs(t, logs))
 	resources, resourceErr := request.ResourceLogs()
+	resourceCount := 0
 	for resource := range resources {
+		resourceCount++
 		raw, err := resource.Resource()
 		require.NoError(t, err)
 		attrs := Resource(raw)
@@ -176,6 +181,7 @@ func TestResourceStringAttribute_EmptyAndNonString(t *testing.T) {
 		require.Nil(t, value)
 	}
 	require.NoError(t, resourceErr())
+	require.Equal(t, 1, resourceCount)
 }
 
 func TestKeyValueRawAccessors_PreserveFirstEncodedOccurrence(t *testing.T) {
@@ -475,7 +481,9 @@ func TestScopeLogsLogRecords_EarlyStop(t *testing.T) {
 
 	request := ExportLogsServiceRequest(marshalLogs(t, logs))
 	resources, resourceErr := request.ResourceLogs()
+	resourceCount := 0
 	for resource := range resources {
+		resourceCount++
 		scopes, scopeErr := resource.ScopeLogs()
 		for scope := range scopes {
 			sequence, recordErr := scope.LogRecords()
@@ -490,6 +498,7 @@ func TestScopeLogsLogRecords_EarlyStop(t *testing.T) {
 		require.NoError(t, scopeErr())
 	}
 	require.NoError(t, resourceErr())
+	require.Equal(t, 1, resourceCount)
 }
 
 func TestLogWireAccessors_MalformedAndWrongWire(t *testing.T) {

--- a/log_iteration_test.go
+++ b/log_iteration_test.go
@@ -1,0 +1,699 @@
+package otlpwire
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+func TestLogRecordSeverityNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		set      bool
+		severity plog.SeverityNumber
+		expected int32
+	}{
+		{name: "unset", expected: 0},
+		{name: "trace minimum", set: true, severity: plog.SeverityNumberTrace, expected: 1},
+		{name: "trace maximum", set: true, severity: plog.SeverityNumberTrace4, expected: 4},
+		{name: "debug minimum", set: true, severity: plog.SeverityNumberDebug, expected: 5},
+		{name: "debug maximum", set: true, severity: plog.SeverityNumberDebug4, expected: 8},
+		{name: "info minimum", set: true, severity: plog.SeverityNumberInfo, expected: 9},
+		{name: "info maximum", set: true, severity: plog.SeverityNumberInfo4, expected: 12},
+		{name: "warn minimum", set: true, severity: plog.SeverityNumberWarn, expected: 13},
+		{name: "warn maximum", set: true, severity: plog.SeverityNumberWarn4, expected: 16},
+		{name: "error minimum", set: true, severity: plog.SeverityNumberError, expected: 17},
+		{name: "error maximum", set: true, severity: plog.SeverityNumberFatal4, expected: 24},
+		{name: "unexpected negative", set: true, severity: plog.SeverityNumber(-1), expected: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := plog.NewLogs()
+			record := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+			if tt.set {
+				record.SetSeverityNumber(tt.severity)
+			}
+
+			wireRecord := onlyLogRecord(t, marshalLogs(t, logs))
+			got, err := wireRecord.SeverityNumber()
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestLogRecordSeverityNumber_CompleteMessageSemantics(t *testing.T) {
+	var record LogRecord
+	record = appendUnknownGroup(record, 90)
+	record = protowire.AppendTag(record, 2, protowire.VarintType)
+	record = protowire.AppendVarint(record, uint64(plog.SeverityNumberInfo))
+	record = protowire.AppendTag(record, 91, protowire.VarintType)
+	record = protowire.AppendVarint(record, 1)
+	record = protowire.AppendTag(record, 2, protowire.VarintType)
+	record = protowire.AppendVarint(record, uint64(plog.SeverityNumberError))
+	record = appendUnknownGroup(record, 92)
+
+	severity, err := record.SeverityNumber()
+	require.NoError(t, err)
+	require.Equal(t, int32(plog.SeverityNumberError), severity, "protobuf singular scalars are last-value-wins")
+
+	trailingMalformed := append(append(LogRecord(nil), record...), 0x80)
+	_, err = trailingMalformed.SeverityNumber()
+	require.Error(t, err, "a valid early severity must not hide malformed trailing data")
+
+	trailingWrongWire := append(append(LogRecord(nil), record...), protowire.AppendTag(nil, 2, protowire.BytesType)...)
+	trailingWrongWire = protowire.AppendBytes(trailingWrongWire, []byte("bad"))
+	_, err = trailingWrongWire.SeverityNumber()
+	require.Error(t, err, "every severity occurrence must use the enum varint wire type")
+}
+
+func TestLogRecordSeverityNumber_PdataMalformedParity(t *testing.T) {
+	tests := []struct {
+		name   string
+		record LogRecord
+	}{
+		{name: "malformed body any value", record: LogRecord{0x2a, 0x02, 0x0a, 0x80}},
+		{name: "malformed attribute key value", record: LogRecord{0x32, 0x02, 0x08, 0x01}},
+		{name: "timestamp wrong wire type", record: LogRecord{0x0a, 0x01, 0x00}},
+		{name: "flags wrong wire type", record: LogRecord{0x40, 0x01}},
+		{name: "trace id wrong wire type", record: LogRecord{0x48, 0x01}},
+		{name: "event name wrong wire type", record: LogRecord{0x60, 0x01}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, wireErr := tt.record.SeverityNumber()
+			_, pdataErr := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithRecord(tt.record))
+			require.Error(t, wireErr)
+			require.Error(t, pdataErr)
+		})
+	}
+}
+
+func TestLogTraversalAndResourceAttributes(t *testing.T) {
+	logs := plog.NewLogs()
+	withContext := logs.ResourceLogs().AppendEmpty()
+	withContext.Resource().Attributes().PutStr("service.name", "checkout")
+	withContext.Resource().Attributes().PutStr("service.namespace", "storefront")
+	withContext.Resource().Attributes().PutStr("service.version", "1.2.3")
+	withContext.Resource().Attributes().PutStr("deployment.environment", "production")
+	withContext.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().SetSeverityNumber(plog.SeverityNumberWarn)
+
+	withoutContext := logs.ResourceLogs().AppendEmpty()
+	withoutContext.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().SetSeverityNumber(plog.SeverityNumberError)
+
+	request := ExportLogsServiceRequest(marshalLogs(t, logs))
+	resources, resourceErr := request.ResourceLogs()
+	seen := 0
+	for resource := range resources {
+		scopes, scopeErr := resource.ScopeLogs()
+		for scope := range scopes {
+			records, recordErr := scope.LogRecords()
+			for record := range records {
+				severity, err := record.SeverityNumber()
+				require.NoError(t, err)
+				if seen == 0 {
+					require.Equal(t, int32(plog.SeverityNumberWarn), severity)
+				} else {
+					require.Equal(t, int32(plog.SeverityNumberError), severity)
+				}
+				seen++
+			}
+			require.NoError(t, recordErr())
+		}
+		require.NoError(t, scopeErr())
+
+		raw, err := resource.Resource()
+		require.NoError(t, err)
+		attrs := Resource(raw)
+		for key, expected := range map[string]string{
+			"service.name":           "checkout",
+			"service.namespace":      "storefront",
+			"service.version":        "1.2.3",
+			"deployment.environment": "production",
+		} {
+			value, found, err := attrs.StringAttribute(key)
+			require.NoError(t, err)
+			if seen == 1 {
+				require.True(t, found, key)
+				require.Equal(t, expected, string(value))
+			} else {
+				require.False(t, found, key)
+				require.Nil(t, value)
+			}
+		}
+	}
+	require.NoError(t, resourceErr())
+	require.Equal(t, 2, seen)
+}
+
+func TestResourceStringAttribute_EmptyAndNonString(t *testing.T) {
+	logs := plog.NewLogs()
+	resource := logs.ResourceLogs().AppendEmpty().Resource()
+	resource.Attributes().PutStr("empty", "")
+	resource.Attributes().PutInt("not.string", 42)
+
+	request := ExportLogsServiceRequest(marshalLogs(t, logs))
+	resources, resourceErr := request.ResourceLogs()
+	for resource := range resources {
+		raw, err := resource.Resource()
+		require.NoError(t, err)
+		attrs := Resource(raw)
+
+		value, found, err := attrs.StringAttribute("empty")
+		require.NoError(t, err)
+		require.True(t, found)
+		require.NotNil(t, value)
+		require.Empty(t, value)
+
+		value, found, err = attrs.StringAttribute("not.string")
+		require.NoError(t, err)
+		require.False(t, found)
+		require.Nil(t, value)
+	}
+	require.NoError(t, resourceErr())
+}
+
+func TestKeyValueRawAccessors_PreserveFirstEncodedOccurrence(t *testing.T) {
+	var firstAnyValue []byte
+	firstAnyValue = protowire.AppendTag(firstAnyValue, 1, protowire.BytesType)
+	firstAnyValue = protowire.AppendBytes(firstAnyValue, []byte("first"))
+	var secondAnyValue []byte
+	secondAnyValue = protowire.AppendTag(secondAnyValue, 3, protowire.VarintType)
+	secondAnyValue = protowire.AppendVarint(secondAnyValue, 7)
+
+	var raw KeyValue
+	raw = protowire.AppendTag(raw, 1, protowire.BytesType)
+	raw = protowire.AppendBytes(raw, []byte("first.key"))
+	raw = protowire.AppendTag(raw, 1, protowire.BytesType)
+	raw = protowire.AppendBytes(raw, []byte("last.key"))
+	raw = protowire.AppendTag(raw, 2, protowire.BytesType)
+	raw = protowire.AppendBytes(raw, firstAnyValue)
+	raw = protowire.AppendTag(raw, 2, protowire.BytesType)
+	raw = protowire.AppendBytes(raw, secondAnyValue)
+
+	key, err := raw.Key()
+	require.NoError(t, err)
+	require.Equal(t, "first.key", string(key))
+	valueRaw, err := raw.ValueRaw()
+	require.NoError(t, err)
+	require.Equal(t, firstAnyValue, valueRaw)
+
+	// StringValue is intentionally separate: it fully parses the merged
+	// KeyValue/AnyValue and observes the final non-string oneof member.
+	value, found, err := raw.StringValue()
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Nil(t, value)
+}
+
+func TestResourceStringAttribute_PdataParity(t *testing.T) {
+	stringAnyValue := func(value string) []byte {
+		var raw []byte
+		raw = protowire.AppendTag(raw, 1, protowire.BytesType)
+		return protowire.AppendBytes(raw, []byte(value))
+	}
+	intAnyValue := func(value uint64) []byte {
+		var raw []byte
+		raw = protowire.AppendTag(raw, 3, protowire.VarintType)
+		return protowire.AppendVarint(raw, value)
+	}
+	keyValue := func(key string, values ...[]byte) []byte {
+		var raw []byte
+		raw = protowire.AppendTag(raw, 1, protowire.BytesType)
+		raw = protowire.AppendBytes(raw, []byte(key))
+		for _, value := range values {
+			raw = protowire.AppendTag(raw, 2, protowire.BytesType)
+			raw = protowire.AppendBytes(raw, value)
+		}
+		return raw
+	}
+	resource := func(attributes ...[]byte) []byte {
+		var raw []byte
+		for _, attribute := range attributes {
+			raw = protowire.AppendTag(raw, 1, protowire.BytesType)
+			raw = protowire.AppendBytes(raw, attribute)
+		}
+		return raw
+	}
+
+	tests := []struct {
+		name     string
+		resource []byte
+		want     string
+		found    bool
+	}{
+		{
+			name:     "final any value oneof member overrides string",
+			resource: resource(keyValue("service.name", append(stringAnyValue("first"), intAnyValue(7)...))),
+			found:    false,
+		},
+		{
+			name:     "repeated singular value messages merge in wire order",
+			resource: resource(keyValue("service.name", stringAnyValue("first"), intAnyValue(7))),
+			found:    false,
+		},
+		{
+			name:     "duplicate resource key first value wins",
+			resource: resource(keyValue("service.name", stringAnyValue("first")), keyValue("service.name", intAnyValue(7))),
+			want:     "first",
+			found:    true,
+		},
+		{
+			name:     "duplicate resource key first non string wins",
+			resource: resource(keyValue("service.name", intAnyValue(7)), keyValue("service.name", stringAnyValue("final"))),
+			found:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, found, err := Resource(tt.resource).StringAttribute("service.name")
+			require.NoError(t, err)
+			require.Equal(t, tt.found, found)
+			if found {
+				require.Equal(t, tt.want, string(value))
+			}
+
+			logs, err := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithResource(tt.resource))
+			require.NoError(t, err)
+			attribute, pdataPresent := logs.ResourceLogs().At(0).Resource().Attributes().Get("service.name")
+			pdataFound := pdataPresent && attribute.Type() == pcommon.ValueTypeStr
+			require.Equal(t, tt.found, pdataFound)
+			if pdataFound {
+				require.Equal(t, tt.want, attribute.Str())
+			}
+		})
+	}
+
+	trailingCorruption := resource(keyValue("service.name", append(stringAnyValue("valid"), 0x80)))
+	_, _, wireErr := Resource(trailingCorruption).StringAttribute("service.name")
+	require.Error(t, wireErr)
+	_, pdataErr := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithResource(trailingCorruption))
+	require.Error(t, pdataErr)
+}
+
+func TestResourceStringAttribute_EntityRefPdataParity(t *testing.T) {
+	resourceWithEntityRef := func(entityRef []byte) []byte {
+		var resource []byte
+		resource = protowire.AppendTag(resource, 3, protowire.BytesType)
+		return protowire.AppendBytes(resource, entityRef)
+	}
+	validEntityRef := func() []byte {
+		var entityRef []byte
+		for fieldNum, value := range map[protowire.Number]string{
+			1: "https://example.test/schema",
+			2: "service",
+			3: "service.name",
+			4: "service.version",
+		} {
+			entityRef = protowire.AppendTag(entityRef, fieldNum, protowire.BytesType)
+			entityRef = protowire.AppendBytes(entityRef, []byte(value))
+		}
+		return entityRef
+	}
+
+	tests := []struct {
+		name      string
+		entityRef []byte
+		wantError bool
+	}{
+		{name: "all known fields are strings", entityRef: validEntityRef()},
+		{name: "known field wrong wire type", entityRef: []byte{0x08, 0x01}, wantError: true},
+		{name: "known field truncated length", entityRef: []byte{0x0a, 0x80}, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := resourceWithEntityRef(tt.entityRef)
+			_, _, wireErr := Resource(resource).StringAttribute("service.name")
+			_, pdataErr := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithResource(resource))
+			require.Equal(t, tt.wantError, wireErr != nil)
+			require.Equal(t, tt.wantError, pdataErr != nil)
+		})
+	}
+}
+
+func TestResourceLogsStringAttribute_MergedResourcesPdataParity(t *testing.T) {
+	stringAttribute := func(key, value string) []byte {
+		var anyValue []byte
+		anyValue = protowire.AppendTag(anyValue, 1, protowire.BytesType)
+		anyValue = protowire.AppendBytes(anyValue, []byte(value))
+		var keyValue []byte
+		keyValue = protowire.AppendTag(keyValue, 1, protowire.BytesType)
+		keyValue = protowire.AppendBytes(keyValue, []byte(key))
+		keyValue = protowire.AppendTag(keyValue, 2, protowire.BytesType)
+		keyValue = protowire.AppendBytes(keyValue, anyValue)
+		var resource []byte
+		resource = protowire.AppendTag(resource, 1, protowire.BytesType)
+		return protowire.AppendBytes(resource, keyValue)
+	}
+	appendResource := func(raw []byte, resource []byte) []byte {
+		raw = protowire.AppendTag(raw, 1, protowire.BytesType)
+		return protowire.AppendBytes(raw, resource)
+	}
+
+	first := stringAttribute("service.name", "checkout")
+	second := stringAttribute("service.name", "payments")
+	merged := appendResource(appendResource(nil, first), second)
+	value, found, err := ResourceLogs(merged).StringAttribute("service.name")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "checkout", string(value), "pdata retains the first duplicate key across merged Resources")
+
+	logs, err := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithResourceLogs(merged))
+	require.NoError(t, err)
+	pdataValue, pdataFound := logs.ResourceLogs().At(0).Resource().Attributes().Get("service.name")
+	require.True(t, pdataFound)
+	require.Equal(t, "checkout", pdataValue.Str())
+
+	malformedLaterResource := appendResource(merged, []byte{0x08, 0x01})
+	_, _, wireErr := ResourceLogs(malformedLaterResource).StringAttribute("service.name")
+	_, pdataErr := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithResourceLogs(malformedLaterResource))
+	require.Error(t, wireErr)
+	require.Error(t, pdataErr)
+}
+
+func TestSemanticParserDepthLimit(t *testing.T) {
+	var leaf []byte
+	leaf = protowire.AppendTag(leaf, 1, protowire.BytesType)
+	leaf = protowire.AppendBytes(leaf, []byte("leaf"))
+	nestedArray := func(levels int) []byte {
+		value := leaf
+		for range levels {
+			var array []byte
+			array = protowire.AppendTag(array, 1, protowire.BytesType)
+			array = protowire.AppendBytes(array, value)
+			value = nil
+			value = protowire.AppendTag(value, 5, protowire.BytesType)
+			value = protowire.AppendBytes(value, array)
+		}
+		return value
+	}
+
+	var parsed parsedAnyValue
+	require.NoError(t, parseAnyValue(nestedArray(4), &parsed))
+	require.NoError(t, parseAnyValueDepth(nestedArray(2), &parsed, semanticParseMaxDepth-2))
+	require.ErrorIs(t, parseAnyValueDepth(nestedArray(3), &parsed, semanticParseMaxDepth-2), errSemanticParseDepth)
+	require.ErrorIs(t, parseAnyValueDepth(leaf, &parsedAnyValue{}, semanticParseMaxDepth+1), errSemanticParseDepth)
+	require.ErrorIs(t, parseAnyValue(nestedArray(semanticParseMaxDepth+2), &parsed), errSemanticParseDepth)
+}
+
+func TestUnknownGroupsAreSkippedInLogTraversalAndResourceAttributes(t *testing.T) {
+	var record LogRecord
+	record = appendUnknownGroup(record, 70)
+	record = protowire.AppendTag(record, 2, protowire.VarintType)
+	record = protowire.AppendVarint(record, uint64(plog.SeverityNumberInfo))
+	record = appendUnknownGroup(record, 71)
+	record = protowire.AppendTag(record, 2, protowire.VarintType)
+	record = protowire.AppendVarint(record, uint64(plog.SeverityNumberWarn))
+	record = appendUnknownGroup(record, 72)
+
+	var scope ScopeLogs
+	scope = appendUnknownGroup(scope, 60)
+	scope = protowire.AppendTag(scope, 2, protowire.BytesType)
+	scope = protowire.AppendBytes(scope, record)
+	scope = appendUnknownGroup(scope, 61)
+	scope = protowire.AppendTag(scope, 2, protowire.BytesType)
+	scope = protowire.AppendBytes(scope, record)
+
+	var resourceLogs ResourceLogs
+	resourceLogs = appendUnknownGroup(resourceLogs, 50)
+	resourceLogs = protowire.AppendTag(resourceLogs, 2, protowire.BytesType)
+	resourceLogs = protowire.AppendBytes(resourceLogs, scope)
+	resourceLogs = appendUnknownGroup(resourceLogs, 51)
+	resourceLogs = protowire.AppendTag(resourceLogs, 2, protowire.BytesType)
+	resourceLogs = protowire.AppendBytes(resourceLogs, scope)
+
+	var resource Resource
+	resource = appendUnknownGroup(resource, 40)
+	var keyValue []byte
+	keyValue = protowire.AppendTag(keyValue, 1, protowire.BytesType)
+	keyValue = protowire.AppendBytes(keyValue, []byte("service.name"))
+	var anyValue []byte
+	anyValue = appendUnknownGroup(anyValue, 30)
+	anyValue = protowire.AppendTag(anyValue, 1, protowire.BytesType)
+	anyValue = protowire.AppendBytes(anyValue, []byte("checkout"))
+	anyValue = appendUnknownGroup(anyValue, 31)
+	keyValue = protowire.AppendTag(keyValue, 2, protowire.BytesType)
+	keyValue = protowire.AppendBytes(keyValue, anyValue)
+	resource = protowire.AppendTag(resource, 1, protowire.BytesType)
+	resource = protowire.AppendBytes(resource, keyValue)
+	resource = appendUnknownGroup(resource, 41)
+	resource = protowire.AppendTag(resource, 1, protowire.BytesType)
+	resource = protowire.AppendBytes(resource, keyValue)
+
+	value, found, err := resource.StringAttribute("service.name")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "checkout", string(value))
+
+	scopes, scopeErr := resourceLogs.ScopeLogs()
+	records := 0
+	for parsedScope := range scopes {
+		for parsedRecord, err := range parsedScope.LogRecordsSeq {
+			require.NoError(t, err)
+			severity, err := parsedRecord.SeverityNumber()
+			require.NoError(t, err)
+			require.Equal(t, int32(plog.SeverityNumberWarn), severity)
+			records++
+		}
+	}
+	require.NoError(t, scopeErr())
+	require.Equal(t, 4, records)
+}
+
+func TestScopeLogsLogRecords_EarlyStop(t *testing.T) {
+	logs := plog.NewLogs()
+	records := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords()
+	records.AppendEmpty().SetSeverityNumber(plog.SeverityNumberInfo)
+	records.AppendEmpty().SetSeverityNumber(plog.SeverityNumberWarn)
+
+	request := ExportLogsServiceRequest(marshalLogs(t, logs))
+	resources, resourceErr := request.ResourceLogs()
+	for resource := range resources {
+		scopes, scopeErr := resource.ScopeLogs()
+		for scope := range scopes {
+			sequence, recordErr := scope.LogRecords()
+			seen := 0
+			for range sequence {
+				seen++
+				break
+			}
+			require.Equal(t, 1, seen)
+			require.NoError(t, recordErr())
+		}
+		require.NoError(t, scopeErr())
+	}
+	require.NoError(t, resourceErr())
+}
+
+func TestLogWireAccessors_MalformedAndWrongWire(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "scope logs wrong wire type",
+			test: func(t *testing.T) {
+				var scope ScopeLogs
+				scope = protowire.AppendTag(scope, 2, protowire.VarintType)
+				scope = protowire.AppendVarint(scope, 1)
+				sequence, errFn := scope.LogRecords()
+				for range sequence {
+				}
+				require.Error(t, errFn())
+			},
+		},
+		{
+			name: "scope logs malformed record length",
+			test: func(t *testing.T) {
+				scope := ScopeLogs{0x12, 0x02, 0x01}
+				sawErr := false
+				for _, err := range scope.LogRecordsSeq {
+					if err != nil {
+						sawErr = true
+					}
+				}
+				require.True(t, sawErr)
+			},
+		},
+		{
+			name: "severity wrong wire type",
+			test: func(t *testing.T) {
+				var record LogRecord
+				record = protowire.AppendTag(record, 2, protowire.BytesType)
+				record = protowire.AppendBytes(record, []byte("bad"))
+				_, err := record.SeverityNumber()
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "severity malformed varint",
+			test: func(t *testing.T) {
+				record := LogRecord{0x10, 0x80}
+				_, err := record.SeverityNumber()
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "resource attributes wrong wire type",
+			test: func(t *testing.T) {
+				resource := Resource{0x08, 0x01}
+				_, _, err := resource.StringAttribute("service.name")
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "any value string field wrong wire type",
+			test: func(t *testing.T) {
+				var keyValue []byte
+				keyValue = protowire.AppendTag(keyValue, 1, protowire.BytesType)
+				keyValue = protowire.AppendBytes(keyValue, []byte("service.name"))
+				var anyValue []byte
+				anyValue = protowire.AppendTag(anyValue, 1, protowire.VarintType)
+				anyValue = protowire.AppendVarint(anyValue, 1)
+				keyValue = protowire.AppendTag(keyValue, 2, protowire.BytesType)
+				keyValue = protowire.AppendBytes(keyValue, anyValue)
+				var resource []byte
+				resource = protowire.AppendTag(resource, 1, protowire.BytesType)
+				resource = protowire.AppendBytes(resource, keyValue)
+
+				_, _, err := Resource(resource).StringAttribute("service.name")
+				require.Error(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.test)
+	}
+}
+
+func TestScopeLogsLogRecordsSeq_ZeroAllocations(t *testing.T) {
+	logs := plog.NewLogs()
+	records := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords()
+	for i := 0; i < 4; i++ {
+		records.AppendEmpty().SetSeverityNumber(plog.SeverityNumberInfo)
+	}
+
+	request := ExportLogsServiceRequest(marshalLogs(t, logs))
+	resources, resourceErr := request.ResourceLogs()
+	resource, ok := nextResource(resources)
+	require.True(t, ok)
+	require.NoError(t, resourceErr())
+	scopes, scopeErr := resource.ScopeLogs()
+	scope, ok := nextScopeLogs(scopes)
+	require.True(t, ok)
+	require.NoError(t, scopeErr())
+
+	allocations := testing.AllocsPerRun(1_000, func() {
+		count := 0
+		for record, err := range scope.LogRecordsSeq {
+			if err != nil {
+				t.Fatal(err)
+			}
+			severity, err := record.SeverityNumber()
+			if err != nil {
+				t.Fatal(err)
+			}
+			count += int(severity)
+		}
+		if count == 0 {
+			t.Fatal("expected log records")
+		}
+	})
+	require.Zero(t, allocations)
+}
+
+func marshalLogs(t *testing.T, logs plog.Logs) []byte {
+	t.Helper()
+	data, err := (&plog.ProtoMarshaler{}).MarshalLogs(logs)
+	require.NoError(t, err)
+	return data
+}
+
+func exportLogsWithResource(resource []byte) []byte {
+	var resourceLogs []byte
+	resourceLogs = protowire.AppendTag(resourceLogs, 1, protowire.BytesType)
+	resourceLogs = protowire.AppendBytes(resourceLogs, resource)
+	return exportLogsWithResourceLogs(resourceLogs)
+}
+
+func exportLogsWithRecord(record []byte) []byte {
+	var scopeLogs []byte
+	scopeLogs = protowire.AppendTag(scopeLogs, 2, protowire.BytesType)
+	scopeLogs = protowire.AppendBytes(scopeLogs, record)
+	var resourceLogs []byte
+	resourceLogs = protowire.AppendTag(resourceLogs, 2, protowire.BytesType)
+	resourceLogs = protowire.AppendBytes(resourceLogs, scopeLogs)
+	return exportLogsWithResourceLogs(resourceLogs)
+}
+
+func exportLogsWithResourceLogs(resourceLogs []byte) []byte {
+	var request []byte
+	request = protowire.AppendTag(request, 1, protowire.BytesType)
+	return protowire.AppendBytes(request, resourceLogs)
+}
+
+func appendUnknownGroup(data []byte, fieldNum protowire.Number) []byte {
+	data = protowire.AppendTag(data, fieldNum, protowire.StartGroupType)
+	data = protowire.AppendTag(data, fieldNum+1, protowire.VarintType)
+	data = protowire.AppendVarint(data, 1)
+	return protowire.AppendTag(data, fieldNum, protowire.EndGroupType)
+}
+
+func onlyLogRecord(t *testing.T, data []byte) LogRecord {
+	t.Helper()
+	request := ExportLogsServiceRequest(data)
+	resources, resourceErr := request.ResourceLogs()
+	resource, ok := nextResource(resources)
+	require.True(t, ok)
+	require.NoError(t, resourceErr())
+	scopes, scopeErr := resource.ScopeLogs()
+	scope, ok := nextScopeLogs(scopes)
+	require.True(t, ok)
+	require.NoError(t, scopeErr())
+	records, recordErr := scope.LogRecords()
+	record, ok := nextLogRecord(records)
+	require.True(t, ok)
+	require.NoError(t, recordErr())
+	return record
+}
+
+func nextResource(sequence func(func(ResourceLogs) bool)) (ResourceLogs, bool) {
+	var resource ResourceLogs
+	found := false
+	sequence(func(candidate ResourceLogs) bool {
+		resource = candidate
+		found = true
+		return false
+	})
+	return resource, found
+}
+
+func nextScopeLogs(sequence func(func(ScopeLogs) bool)) (ScopeLogs, bool) {
+	var scope ScopeLogs
+	found := false
+	sequence(func(candidate ScopeLogs) bool {
+		scope = candidate
+		found = true
+		return false
+	})
+	return scope, found
+}
+
+func nextLogRecord(sequence func(func(LogRecord) bool)) (LogRecord, bool) {
+	var record LogRecord
+	found := false
+	sequence(func(candidate LogRecord) bool {
+		record = candidate
+		found = true
+		return false
+	})
+	return record, found
+}

--- a/otlpwire.go
+++ b/otlpwire.go
@@ -24,6 +24,20 @@ type ResourceMetrics []byte
 // ResourceLogs represents a single ResourceLogs message.
 type ResourceLogs []byte
 
+// Resource represents a Resource message (raw wire bytes).
+//
+// Resource values are normally obtained by converting the bytes returned by a
+// ResourceMetrics, ResourceLogs, or ResourceSpans Resource method. This keeps
+// those established methods source-compatible while providing attribute
+// accessors for callers that need resource context.
+type Resource []byte
+
+// ScopeLogs represents a single ScopeLogs message (raw wire bytes).
+type ScopeLogs []byte
+
+// LogRecord represents a single LogRecord message (raw wire bytes).
+type LogRecord []byte
+
 // ResourceSpans represents a single ResourceSpans message.
 type ResourceSpans []byte
 
@@ -79,6 +93,120 @@ func (kv KeyValue) Key() ([]byte, error) {
 // Returns nil if the field is not present.
 func (kv KeyValue) ValueRaw() ([]byte, error) {
 	return extractBytesField([]byte(kv), 2)
+}
+
+// StringValue returns the string value in the KeyValue's AnyValue, if it has
+// one. The bool reports whether a string value was present; an empty string is
+// present and is returned as a non-nil, zero-length slice. The returned slice
+// aliases the underlying buffer.
+func (kv KeyValue) StringValue() ([]byte, bool, error) {
+	_, _, value, err := parseKeyValue([]byte(kv))
+	if err != nil || value.kind != anyValueString {
+		return nil, false, err
+	}
+	return value.stringValue, true, nil
+}
+
+// Attributes returns an iterator over the Resource's attribute KeyValues.
+// The returned function should be called after iteration to check for errors.
+func (r Resource) Attributes() (iter.Seq[KeyValue], func() error) {
+	var iterErr error
+
+	seq := func(yield func(KeyValue) bool) {
+		forEachRepeatedField([]byte(r), 1, func(rb []byte, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(KeyValue(rb))
+		})
+	}
+
+	return seq, func() error { return iterErr }
+}
+
+// AttributesSeq is a zero-allocation alternative to Attributes. It has the
+// shape of an iter.Seq2[KeyValue, error] and is meant to be ranged over
+// directly. On a parse error it yields a nil KeyValue with a non-nil error and
+// stops.
+func (r Resource) AttributesSeq(yield func(KeyValue, error) bool) {
+	forEachRepeatedField([]byte(r), 1, func(rb []byte, err error) bool {
+		if err != nil {
+			yield(nil, err)
+			return false
+		}
+		return yield(KeyValue(rb), nil)
+	})
+}
+
+// StringAttribute returns the string value of the first resource attribute
+// named key. The bool reports whether that attribute had a string value; it
+// distinguishes an absent attribute from a present-but-empty string. The
+// returned slice aliases the underlying buffer.
+func (r Resource) StringAttribute(key string) ([]byte, bool, error) {
+	var state resourceStringAttributeState
+	if err := scanResourceStringAttribute([]byte(r), key, &state); err != nil {
+		return nil, false, err
+	}
+	return state.value, state.found, nil
+}
+
+// StringAttribute returns a string resource attribute from all Resource
+// messages encoded in this ResourceLogs. Singular Resource messages merge in
+// wire order; resource attributes retain pdata's first-value-wins behavior for
+// duplicate keys across the merged messages.
+func (r ResourceLogs) StringAttribute(key string) ([]byte, bool, error) {
+	var state resourceStringAttributeState
+	data := []byte(r)
+	pos := 0
+	for pos < len(data) {
+		fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return nil, false, errors.New("malformed protobuf tag")
+		}
+		pos += tagLen
+
+		switch fieldNum {
+		case 1: // Resource.attributes
+			if wireType != protowire.BytesType {
+				return nil, false, errors.New("wrong wire type for resource logs resource")
+			}
+			resource, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return nil, false, errors.New("invalid bytes in resource logs resource")
+			}
+			pos += n
+			if err := scanResourceStringAttribute(resource, key, &state); err != nil {
+				return nil, false, err
+			}
+		case 2: // ResourceLogs.scope_logs
+			if wireType != protowire.BytesType {
+				return nil, false, errors.New("wrong wire type for resource logs scope logs")
+			}
+			_, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return nil, false, errors.New("invalid bytes in resource logs scope logs")
+			}
+			pos += n
+		case 3: // ResourceLogs.schema_url
+			if wireType != protowire.BytesType {
+				return nil, false, errors.New("wrong wire type for resource logs schema url")
+			}
+			_, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return nil, false, errors.New("invalid bytes in resource logs schema url")
+			}
+			pos += n
+		default:
+			n := skipField(data[pos:], fieldNum, wireType)
+			if n < 0 {
+				return nil, false, errors.New("failed to skip field")
+			}
+			pos += n
+		}
+	}
+
+	return state.value, state.found, nil
 }
 
 // attributesFieldNum returns the field number of the repeated KeyValue
@@ -321,7 +449,7 @@ func (m Metric) DataPointsSeq(yield func(DataPoint, error) bool) {
 				return
 			}
 		} else {
-			n := skipField(data[pos:], wireType)
+			n := skipField(data[pos:], fieldNum, wireType)
 			if n < 0 {
 				yield(DataPoint{}, errors.New("failed to skip field"))
 				return
@@ -372,6 +500,67 @@ func (r ResourceLogs) Resource() ([]byte, error) {
 // Implements io.WriterTo interface.
 func (r ResourceLogs) WriteTo(w io.Writer) (int64, error) {
 	return writeResourceMessage(w, []byte(r))
+}
+
+// ScopeLogs returns an iterator over ScopeLogs in this ResourceLogs.
+// Field 2 in the ResourceLogs protobuf message.
+// The returned function should be called after iteration to check for errors.
+func (r ResourceLogs) ScopeLogs() (iter.Seq[ScopeLogs], func() error) {
+	var iterErr error
+
+	seq := func(yield func(ScopeLogs) bool) {
+		forEachRepeatedField([]byte(r), 2, func(rb []byte, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(ScopeLogs(rb))
+		})
+	}
+
+	return seq, func() error { return iterErr }
+}
+
+// LogRecords returns an iterator over LogRecords in this ScopeLogs.
+// Field 2 in the ScopeLogs protobuf message. The returned function should be
+// called after iteration to check for errors. LogRecords is a thin adapter over
+// LogRecordsSeq.
+func (s ScopeLogs) LogRecords() (iter.Seq[LogRecord], func() error) {
+	var iterErr error
+
+	seq := func(yield func(LogRecord) bool) {
+		s.LogRecordsSeq(func(record LogRecord, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(record)
+		})
+	}
+
+	return seq, func() error { return iterErr }
+}
+
+// LogRecordsSeq is a zero-allocation alternative to LogRecords. It has the
+// shape of an iter.Seq2[LogRecord, error] and is meant to be ranged over
+// directly. On a parse error it yields a nil LogRecord with a non-nil error and
+// stops.
+func (s ScopeLogs) LogRecordsSeq(yield func(LogRecord, error) bool) {
+	forEachRepeatedField([]byte(s), 2, func(rb []byte, err error) bool {
+		if err != nil {
+			yield(nil, err)
+			return false
+		}
+		return yield(LogRecord(rb), nil)
+	})
+}
+
+// SeverityNumber returns the LogRecord severity_number enum (field 2).
+// It returns 0 when the field is absent. Values are represented as int32 so
+// that unexpected negative protobuf enum values remain distinguishable from
+// the positive OTLP severity ranges.
+func (r LogRecord) SeverityNumber() (int32, error) {
+	return parseLogRecordSeverity([]byte(r))
 }
 
 // SpanCount returns the total number of spans in the batch.
@@ -597,7 +786,7 @@ func countInMetric(data []byte) (int, error) {
 			}
 			count += c
 		} else {
-			n := skipField(data[pos:], wireType)
+			n := skipField(data[pos:], fieldNum, wireType)
 			if n < 0 {
 				return 0, errors.New("failed to skip field")
 			}
@@ -612,25 +801,11 @@ func countDataPoints(data []byte) (int, error) {
 	return countOccurrences(data, 1)
 }
 
-// skipField skips a field based on its wire type.
-// Returns the number of bytes skipped. Returns negative value on error.
-func skipField(data []byte, wireType protowire.Type) int {
-	switch wireType {
-	case protowire.VarintType:
-		_, n := protowire.ConsumeVarint(data)
-		return n
-	case protowire.Fixed64Type:
-		_, n := protowire.ConsumeFixed64(data)
-		return n
-	case protowire.BytesType:
-		_, n := protowire.ConsumeBytes(data)
-		return n
-	case protowire.Fixed32Type:
-		_, n := protowire.ConsumeFixed32(data)
-		return n
-	default:
-		return -1
-	}
+// skipField skips a field value after its tag has been consumed. The field
+// number is required for groups so ConsumeFieldValue can verify the matching
+// end-group marker and recursively validate its contents.
+func skipField(data []byte, fieldNum protowire.Number, wireType protowire.Type) int {
+	return protowire.ConsumeFieldValue(fieldNum, wireType, data)
 }
 
 // countRepeatedField counts items in a repeated field by delegating to countFunc
@@ -662,7 +837,7 @@ func countRepeatedField(data []byte, fieldNum protowire.Number, countFunc func([
 			}
 			count += c
 		} else {
-			n := skipField(data[pos:], wireType)
+			n := skipField(data[pos:], num, wireType)
 			if n < 0 {
 				return 0, errors.New("failed to skip field")
 			}
@@ -696,7 +871,7 @@ func countOccurrences(data []byte, fieldNum protowire.Number) (int, error) {
 			pos += n
 			count++
 		} else {
-			n := skipField(data[pos:], wireType)
+			n := skipField(data[pos:], num, wireType)
 			if n < 0 {
 				return 0, errors.New("failed to skip field")
 			}
@@ -736,7 +911,7 @@ func forEachRepeatedField(data []byte, fieldNum protowire.Number, fn func([]byte
 				return
 			}
 		} else {
-			n := skipField(data[pos:], wireType)
+			n := skipField(data[pos:], num, wireType)
 			if n < 0 {
 				fn(nil, errors.New("failed to skip field"))
 				return
@@ -789,7 +964,7 @@ func extractResourceMessage(data []byte) ([]byte, error) {
 		}
 
 		// Skip other fields
-		n := skipField(data[pos:], wireType)
+		n := skipField(data[pos:], fieldNum, wireType)
 		if n < 0 {
 			return nil, errors.New("failed to skip field")
 		}
@@ -823,7 +998,7 @@ func extractBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
 			return msgBytes, nil
 		}
 
-		n := skipField(data[pos:], wireType)
+		n := skipField(data[pos:], num, wireType)
 		if n < 0 {
 			return nil, errors.New("failed to skip field")
 		}
@@ -856,7 +1031,7 @@ func extractFixed64Field(data []byte, fieldNum protowire.Number) (uint64, error)
 			return v, nil
 		}
 
-		n := skipField(data[pos:], wireType)
+		n := skipField(data[pos:], num, wireType)
 		if n < 0 {
 			return 0, errors.New("failed to skip field")
 		}
@@ -864,6 +1039,502 @@ func extractFixed64Field(data []byte, fieldNum protowire.Number) (uint64, error)
 	}
 
 	return 0, nil
+}
+
+// parseLogRecordSeverity validates every known LogRecord field in pdata v1.64.0
+// while extracting severity_number with protobuf last-scalar-value semantics.
+// This is intentionally schema-aware: an early valid severity cannot conceal a
+// malformed body, attribute, timestamp, identifier, or trailing known field.
+func parseLogRecordSeverity(data []byte) (int32, error) {
+	pos := 0
+	var result int32
+
+	for pos < len(data) {
+		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return 0, errors.New("malformed protobuf tag")
+		}
+		pos += tagLen
+
+		switch num {
+		case 1, 11: // time_unix_nano, observed_time_unix_nano
+			if wireType != protowire.Fixed64Type {
+				return 0, errors.New("wrong wire type for log record timestamp")
+			}
+			_, n := protowire.ConsumeFixed64(data[pos:])
+			if n < 0 {
+				return 0, errors.New("invalid fixed64 in log record timestamp")
+			}
+			pos += n
+		case 2: // severity_number
+			if wireType != protowire.VarintType {
+				return 0, errors.New("wrong wire type for log record severity number")
+			}
+			value, n := protowire.ConsumeVarint(data[pos:])
+			if n < 0 {
+				return 0, errors.New("invalid varint in log record severity number")
+			}
+			result = int32(value)
+			pos += n
+		case 3, 12: // severity_text, event_name
+			if wireType != protowire.BytesType {
+				return 0, errors.New("wrong wire type for log record string")
+			}
+			_, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return 0, errors.New("invalid bytes in log record string")
+			}
+			pos += n
+		case 5: // body
+			if wireType != protowire.BytesType {
+				return 0, errors.New("wrong wire type for log record body")
+			}
+			body, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return 0, errors.New("invalid bytes in log record body")
+			}
+			if err := parseAnyValue(body, &parsedAnyValue{}); err != nil {
+				return 0, err
+			}
+			pos += n
+		case 6: // attributes
+			if wireType != protowire.BytesType {
+				return 0, errors.New("wrong wire type for log record attributes")
+			}
+			attribute, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return 0, errors.New("invalid bytes in log record attributes")
+			}
+			if _, _, _, err := parseKeyValue(attribute); err != nil {
+				return 0, err
+			}
+			pos += n
+		case 7: // dropped_attributes_count
+			if wireType != protowire.VarintType {
+				return 0, errors.New("wrong wire type for log record dropped attributes count")
+			}
+			_, n := protowire.ConsumeVarint(data[pos:])
+			if n < 0 {
+				return 0, errors.New("invalid varint in log record dropped attributes count")
+			}
+			pos += n
+		case 8: // flags
+			if wireType != protowire.Fixed32Type {
+				return 0, errors.New("wrong wire type for log record flags")
+			}
+			_, n := protowire.ConsumeFixed32(data[pos:])
+			if n < 0 {
+				return 0, errors.New("invalid fixed32 in log record flags")
+			}
+			pos += n
+		case 9, 10: // trace_id, span_id
+			if wireType != protowire.BytesType {
+				return 0, errors.New("wrong wire type for log record identifier")
+			}
+			identifier, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return 0, errors.New("invalid bytes in log record identifier")
+			}
+			expectedSize := 16
+			if num == 10 {
+				expectedSize = 8
+			}
+			if len(identifier) != 0 && len(identifier) != expectedSize {
+				return 0, errors.New("log record identifier has unexpected size")
+			}
+			pos += n
+		default:
+			n := skipField(data[pos:], num, wireType)
+			if n < 0 {
+				return 0, errors.New("failed to skip field in log record")
+			}
+			pos += n
+		}
+	}
+
+	return result, nil
+}
+
+type anyValueKind uint8
+
+const (
+	anyValueUnset anyValueKind = iota
+	anyValueString
+	anyValueBool
+	anyValueInt
+	anyValueDouble
+	anyValueArray
+	anyValueKeyValueList
+	anyValueBytes
+	anyValueStringIndex
+)
+
+type parsedAnyValue struct {
+	kind        anyValueKind
+	stringValue []byte
+}
+
+const semanticParseMaxDepth = 64
+
+var errSemanticParseDepth = errors.New("protobuf semantic parse nesting limit exceeded")
+
+// parseKeyValue parses the complete KeyValue message using pdata's singular
+// field behavior: scalar key fields and AnyValue oneofs are last-value-wins,
+// while repeated Value messages merge by processing their contents in order.
+func parseKeyValue(data []byte) ([]byte, []byte, parsedAnyValue, error) {
+	return parseKeyValueDepth(data, 0)
+}
+
+func parseKeyValueDepth(data []byte, depth int) ([]byte, []byte, parsedAnyValue, error) {
+	if depth > semanticParseMaxDepth {
+		return nil, nil, parsedAnyValue{}, errSemanticParseDepth
+	}
+	var key []byte
+	var valueRaw []byte
+	var value parsedAnyValue
+	pos := 0
+
+	for pos < len(data) {
+		fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return nil, nil, parsedAnyValue{}, errors.New("malformed protobuf tag in key value")
+		}
+		pos += tagLen
+
+		switch fieldNum {
+		case 1: // KeyValue.key
+			if wireType != protowire.BytesType {
+				return nil, nil, parsedAnyValue{}, errors.New("wrong wire type for key value key")
+			}
+			var n int
+			key, n = protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return nil, nil, parsedAnyValue{}, errors.New("invalid bytes in key value key")
+			}
+			pos += n
+		case 2: // KeyValue.value
+			if wireType != protowire.BytesType {
+				return nil, nil, parsedAnyValue{}, errors.New("wrong wire type for key value value")
+			}
+			var n int
+			valueRaw, n = protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return nil, nil, parsedAnyValue{}, errors.New("invalid bytes in key value value")
+			}
+			pos += n
+			if err := parseAnyValueDepth(valueRaw, &value, depth); err != nil {
+				return nil, nil, parsedAnyValue{}, err
+			}
+		case 3: // KeyValue.key_strindex
+			if wireType != protowire.VarintType {
+				return nil, nil, parsedAnyValue{}, errors.New("wrong wire type for key value key string index")
+			}
+			_, n := protowire.ConsumeVarint(data[pos:])
+			if n < 0 {
+				return nil, nil, parsedAnyValue{}, errors.New("invalid varint in key value key string index")
+			}
+			pos += n
+		default:
+			n := skipField(data[pos:], fieldNum, wireType)
+			if n < 0 {
+				return nil, nil, parsedAnyValue{}, errors.New("failed to skip field in key value")
+			}
+			pos += n
+		}
+	}
+
+	return key, valueRaw, value, nil
+}
+
+// parseAnyValue applies the AnyValue oneof in wire order. It parses every
+// field, including fields superseded by a later oneof member, so malformed
+// trailing data is never hidden by an earlier string value.
+func parseAnyValue(data []byte, value *parsedAnyValue) error {
+	return parseAnyValueDepth(data, value, 0)
+}
+
+func parseAnyValueDepth(data []byte, value *parsedAnyValue, depth int) error {
+	if depth > semanticParseMaxDepth {
+		return errSemanticParseDepth
+	}
+	pos := 0
+	for pos < len(data) {
+		fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return errors.New("malformed protobuf tag in any value")
+		}
+		pos += tagLen
+
+		switch fieldNum {
+		case 1: // string_value
+			if wireType != protowire.BytesType {
+				return errors.New("wrong wire type for any value string")
+			}
+			stringValue, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return errors.New("invalid bytes in any value string")
+			}
+			value.kind = anyValueString
+			value.stringValue = stringValue
+			pos += n
+		case 2, 3, 8: // bool_value, int_value, string_value_strindex
+			if wireType != protowire.VarintType {
+				return errors.New("wrong wire type for any value varint")
+			}
+			_, n := protowire.ConsumeVarint(data[pos:])
+			if n < 0 {
+				return errors.New("invalid varint in any value")
+			}
+			switch fieldNum {
+			case 2:
+				value.kind = anyValueBool
+			case 3:
+				value.kind = anyValueInt
+			case 8:
+				value.kind = anyValueStringIndex
+			}
+			value.stringValue = nil
+			pos += n
+		case 4: // double_value
+			if wireType != protowire.Fixed64Type {
+				return errors.New("wrong wire type for any value double")
+			}
+			_, n := protowire.ConsumeFixed64(data[pos:])
+			if n < 0 {
+				return errors.New("invalid fixed64 in any value double")
+			}
+			value.kind = anyValueDouble
+			value.stringValue = nil
+			pos += n
+		case 5, 6, 7: // array_value, kvlist_value, bytes_value
+			if wireType != protowire.BytesType {
+				return errors.New("wrong wire type for any value bytes")
+			}
+			message, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return errors.New("invalid bytes in any value")
+			}
+			if fieldNum == 5 {
+				if err := validateArrayValueDepth(message, depth+1); err != nil {
+					return err
+				}
+				value.kind = anyValueArray
+			} else if fieldNum == 6 {
+				if err := validateKeyValueListDepth(message, depth+1); err != nil {
+					return err
+				}
+				value.kind = anyValueKeyValueList
+			} else {
+				value.kind = anyValueBytes
+			}
+			value.stringValue = nil
+			pos += n
+		default:
+			n := skipField(data[pos:], fieldNum, wireType)
+			if n < 0 {
+				return errors.New("failed to skip field in any value")
+			}
+			pos += n
+		}
+	}
+	return nil
+}
+
+func validateArrayValue(data []byte) error {
+	return validateArrayValueDepth(data, 0)
+}
+
+func validateArrayValueDepth(data []byte, depth int) error {
+	if depth > semanticParseMaxDepth {
+		return errSemanticParseDepth
+	}
+	pos := 0
+	for pos < len(data) {
+		fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return errors.New("malformed protobuf tag in array value")
+		}
+		pos += tagLen
+		if fieldNum == 1 {
+			if wireType != protowire.BytesType {
+				return errors.New("wrong wire type for array value values")
+			}
+			item, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return errors.New("invalid bytes in array value values")
+			}
+			if err := parseAnyValueDepth(item, &parsedAnyValue{}, depth); err != nil {
+				return err
+			}
+			pos += n
+			continue
+		}
+		n := skipField(data[pos:], fieldNum, wireType)
+		if n < 0 {
+			return errors.New("failed to skip field in array value")
+		}
+		pos += n
+	}
+	return nil
+}
+
+func validateKeyValueList(data []byte) error {
+	return validateKeyValueListDepth(data, 0)
+}
+
+func validateKeyValueListDepth(data []byte, depth int) error {
+	if depth > semanticParseMaxDepth {
+		return errSemanticParseDepth
+	}
+	pos := 0
+	for pos < len(data) {
+		fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return errors.New("malformed protobuf tag in key value list")
+		}
+		pos += tagLen
+		if fieldNum == 1 {
+			if wireType != protowire.BytesType {
+				return errors.New("wrong wire type for key value list values")
+			}
+			item, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return errors.New("invalid bytes in key value list values")
+			}
+			if _, _, _, err := parseKeyValueDepth(item, depth); err != nil {
+				return err
+			}
+			pos += n
+			continue
+		}
+		n := skipField(data[pos:], fieldNum, wireType)
+		if n < 0 {
+			return errors.New("failed to skip field in key value list")
+		}
+		pos += n
+	}
+	return nil
+}
+
+type resourceStringAttributeState struct {
+	value   []byte
+	found   bool
+	matched bool
+}
+
+// scanResourceStringAttribute validates a complete Resource message and
+// records the first matching attribute only. pdata's resource map keeps that
+// first duplicate key, including when multiple singular Resource messages are
+// merged by ResourceLogs.StringAttribute.
+func scanResourceStringAttribute(data []byte, key string, state *resourceStringAttributeState) error {
+	pos := 0
+	for pos < len(data) {
+		fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return errors.New("malformed protobuf tag in resource")
+		}
+		pos += tagLen
+
+		switch fieldNum {
+		case 1: // Resource.attributes
+			if wireType != protowire.BytesType {
+				return errors.New("wrong wire type for resource attributes")
+			}
+			attribute, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return errors.New("invalid bytes in resource attributes")
+			}
+			attributeKey, _, anyValue, err := parseKeyValue(attribute)
+			if err != nil {
+				return err
+			}
+			if !state.matched && equalBytesString(attributeKey, key) {
+				state.matched = true
+				state.found = anyValue.kind == anyValueString
+				state.value = nil
+				if state.found {
+					state.value = anyValue.stringValue
+				}
+			}
+			pos += n
+		case 2: // Resource.dropped_attributes_count
+			if wireType != protowire.VarintType {
+				return errors.New("wrong wire type for resource dropped attributes count")
+			}
+			_, n := protowire.ConsumeVarint(data[pos:])
+			if n < 0 {
+				return errors.New("invalid varint in resource dropped attributes count")
+			}
+			pos += n
+		case 3: // Resource.entity_refs
+			if wireType != protowire.BytesType {
+				return errors.New("wrong wire type for resource entity refs")
+			}
+			entityRef, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return errors.New("invalid bytes in resource entity refs")
+			}
+			if err := validateEntityRef(entityRef); err != nil {
+				return err
+			}
+			pos += n
+		default:
+			n := skipField(data[pos:], fieldNum, wireType)
+			if n < 0 {
+				return errors.New("failed to skip field in resource")
+			}
+			pos += n
+		}
+	}
+	return nil
+}
+
+// validateEntityRef matches pdata v1.64.0's EntityRef wire contract. Its four
+// known fields (schema_url, type, id_keys, and description_keys) are all
+// length-delimited strings; unknown fields remain forward-compatible and are
+// skipped with full group validation.
+func validateEntityRef(data []byte) error {
+	pos := 0
+	for pos < len(data) {
+		fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return errors.New("malformed protobuf tag in entity reference")
+		}
+		pos += tagLen
+
+		if fieldNum >= 1 && fieldNum <= 4 {
+			if wireType != protowire.BytesType {
+				return errors.New("wrong wire type for entity reference field")
+			}
+			_, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return errors.New("invalid bytes in entity reference field")
+			}
+			pos += n
+			continue
+		}
+
+		n := skipField(data[pos:], fieldNum, wireType)
+		if n < 0 {
+			return errors.New("failed to skip field in entity reference")
+		}
+		pos += n
+	}
+	return nil
+}
+
+// equalBytesString reports whether b contains exactly s without converting b
+// to a string or allocating a temporary byte slice for s.
+func equalBytesString(b []byte, s string) bool {
+	if len(b) != len(s) {
+		return false
+	}
+	for i := range b {
+		if b[i] != s[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // writeResourceMessage writes resource data as a valid OTLP export request message.
@@ -911,7 +1582,7 @@ func extractFixedBytesField(data []byte, fieldNum protowire.Number, size int) ([
 			return msgBytes, nil
 		}
 
-		n := skipField(data[pos:], wireType)
+		n := skipField(data[pos:], num, wireType)
 		if n < 0 {
 			return nil, errors.New("failed to skip field")
 		}

--- a/otlpwire.go
+++ b/otlpwire.go
@@ -167,7 +167,7 @@ func (r ResourceLogs) StringAttribute(key string) ([]byte, bool, error) {
 		pos += tagLen
 
 		switch fieldNum {
-		case 1: // Resource.attributes
+		case 1: // ResourceLogs.resource
 			if wireType != protowire.BytesType {
 				return nil, false, errors.New("wrong wire type for resource logs resource")
 			}
@@ -1340,10 +1340,6 @@ func parseAnyValueDepth(data []byte, value *parsedAnyValue, depth int) error {
 	return nil
 }
 
-func validateArrayValue(data []byte) error {
-	return validateArrayValueDepth(data, 0)
-}
-
 func validateArrayValueDepth(data []byte, depth int) error {
 	if depth > semanticParseMaxDepth {
 		return errSemanticParseDepth
@@ -1376,10 +1372,6 @@ func validateArrayValueDepth(data []byte, depth int) error {
 		pos += n
 	}
 	return nil
-}
-
-func validateKeyValueList(data []byte) error {
-	return validateKeyValueListDepth(data, 0)
 }
 
 func validateKeyValueListDepth(data []byte, depth int) error {


### PR DESCRIPTION
## Summary

- add zero-copy `ResourceLogs → ScopeLogs → LogRecord` traversal with ergonomic and zero-allocation record iterators
- add strict wire-level `SeverityNumber` parsing and resource string-attribute access with protobuf merge semantics
- validate malformed nested OTLP values, bound semantic nesting, and preserve existing metrics hot-path behavior
- add pdata parity fixtures, malformed-wire coverage, executable examples, and design/benchmark documentation

## Why

E-2892 enables Bindweed severity-distribution detectors to avoid full pdata unmarshalling in their hot path while preserving pdata-equivalent severity classification and service context.

## Validation

- `go test -count=1 -race ./...`
- `go vet ./...`
- `git diff --check origin/main...HEAD`
- four adversarial review rounds; final Sol review clean
- existing metrics deep-iteration allocation profiles unchanged

## Benchmark

Apple M4, Go 1.26.3:

| Path | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Wire traversal | 50,017–50,678 | 488 | 15 |
| Full pdata unmarshal | 117,312–140,185 | 257,904–257,905 | 6,690 |

The benchmark asserts behavioral parity before timing and covers all severity classes plus absent, empty, and non-string resource context.

Linear: E-2892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added efficient OTLP log traversal without requiring full unmarshaling.
  - Added access to log severity, resource attributes, string values, scopes, and log records.
  - Added robust handling for malformed data, duplicate attributes, nested values, and unknown fields.

- **Documentation**
  - Expanded API and design documentation with traversal, resource access, error behavior, and zero-copy guidance.
  - Added an example demonstrating resource attribute and severity access.

- **Performance**
  - Added benchmarks comparing wire-format access with full unmarshaling and allocation measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->