### PR TITLE
docs: remove redundant metric counting detail

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -163,11 +163,6 @@ types in typed accessors and iterators surface as errors. Semantic nested-value
 parsing has a finite depth budget so adversarial data cannot recurse without
 bound.
 
-`DataPointCount` and the data-point iterators apply the same wire-type checks
-to recognized metric-body fields. A non-length-delimited gauge, sum,
-histogram, exponential histogram or summary is rejected rather than silently
-skipped.
-
 There are two intentional semantic levels:
 
 - lightweight field views such as `KeyValue.Key` and `ValueRaw`, which return


### PR DESCRIPTION
## Summary

- remove the five-line `DataPointCount` paragraph from `docs/DESIGN.md`
- rely on the surrounding strict-known-field design rule
- retain the precise v0.0.4 compatibility note in `docs/specification.md`

Follow-up to #24 and the final human review comment.

## Validation

- `git diff --check`
- `go build ./...`
- `go vet ./...`
- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run`
- adversarial documentation review: no findings

## Tracking

- [E-2934](https://linear.app/ollygarden/issue/E-2934/otlp-wire-remove-redundant-metric-counting-paragraph)

## Agent disclosure

Implemented and validated with Codex. The final scope and merge decision remain human-owned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated design notes related to metric-body field validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->