### PR TITLE
feat(resource)!: make Resource() typed, absence-tolerant, and merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,19 +148,18 @@ func (t ExportTracesServiceRequest) ResourceSpans() (iter.Seq[ResourceSpans], fu
 ```go
 type ResourceMetrics []byte
 func (r ResourceMetrics) DataPointCount() (int, error)
-func (r ResourceMetrics) Resource() ([]byte, error)
+func (r ResourceMetrics) Resource() (Resource, error)
 func (r ResourceMetrics) WriteTo(w io.Writer) (int64, error)
 
 type ResourceLogs []byte
 func (r ResourceLogs) LogRecordCount() (int, error)
-func (r ResourceLogs) Resource() ([]byte, error)
+func (r ResourceLogs) Resource() (Resource, error)
 func (r ResourceLogs) WriteTo(w io.Writer) (int64, error)
 func (r ResourceLogs) ScopeLogs() (iter.Seq[ScopeLogs], func() error)
-func (r ResourceLogs) StringAttribute(key string) ([]byte, bool, error)
 
 type ResourceSpans []byte
 func (r ResourceSpans) SpanCount() (int, error)
-func (r ResourceSpans) Resource() ([]byte, error)
+func (r ResourceSpans) Resource() (Resource, error)
 func (r ResourceSpans) WriteTo(w io.Writer) (int64, error)
 func (r ResourceSpans) ScopeSpans() (iter.Seq[ScopeSpans], func() error)
 ```
@@ -229,13 +228,25 @@ func (r Resource) StringAttribute(key string) ([]byte, bool, error)
 
 `Resource.StringAttribute` is zero-copy and returns a separate `found` value,
 so a missing resource attribute can be distinguished from a present empty
-string. It inspects one Resource message; convert the existing resource bytes
-without copying: `attrs := otlpwire.Resource(resourceBytes)`.
+string. It inspects one Resource message obtained from a `ResourceMetrics`,
+`ResourceLogs`, or `ResourceSpans` `Resource()` method.
 
-`ResourceLogs.StringAttribute` is the preferred accessor when starting from a
-`ResourceLogs`: it merges every encoded singular Resource message in wire
-order, validates later Resource messages, and matches pdata by retaining the
-first value for duplicate attribute keys.
+Each container type — `ResourceMetrics`, `ResourceLogs`, `ResourceSpans` — has
+exactly one `Resource`, matching pdata's object model. `Resource()` returns
+`(nil, nil)` when the field is absent (OTLP declares it optional), aliases the
+input with no copy for the single occurrence every real producer emits, and
+merges 2+ occurrences by concatenating their encoded bodies into a new buffer
+— byte-equivalent to protobuf's merge for singular message fields. To read a
+resource string attribute starting from a `ResourceLogs`/`ResourceMetrics`/`ResourceSpans`,
+call `Resource()` then `Resource.StringAttribute`:
+
+```go
+resource, err := resourceLogs.Resource()
+if err != nil {
+    return err
+}
+value, found, err := resource.StringAttribute("service.name")
+```
 
 `KeyValue.ValueRaw` remains a lightweight view of the first encoded AnyValue
 field for hashing-oriented hot paths. `KeyValue.StringValue` fully parses

--- a/attributes.go
+++ b/attributes.go
@@ -64,64 +64,6 @@ func (r Resource) StringAttribute(key string) ([]byte, bool, error) {
 	return state.value, state.found, nil
 }
 
-// StringAttribute returns a string resource attribute from all Resource
-// messages encoded in this ResourceLogs. Singular Resource messages merge in
-// wire order; resource attributes retain pdata's first-value-wins behavior for
-// duplicate keys across the merged messages.
-func (r ResourceLogs) StringAttribute(key string) ([]byte, bool, error) {
-	var state resourceStringAttributeState
-	data := []byte(r)
-	pos := 0
-	for pos < len(data) {
-		fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
-		if tagLen < 0 {
-			return nil, false, errors.New("malformed protobuf tag")
-		}
-		pos += tagLen
-
-		switch fieldNum {
-		case 1: // ResourceLogs.resource
-			if wireType != protowire.BytesType {
-				return nil, false, errors.New("wrong wire type for resource logs resource")
-			}
-			resource, n := protowire.ConsumeBytes(data[pos:])
-			if n < 0 {
-				return nil, false, errors.New("invalid bytes in resource logs resource")
-			}
-			pos += n
-			if err := scanResourceStringAttribute(resource, key, &state); err != nil {
-				return nil, false, err
-			}
-		case 2: // ResourceLogs.scope_logs
-			if wireType != protowire.BytesType {
-				return nil, false, errors.New("wrong wire type for resource logs scope logs")
-			}
-			_, n := protowire.ConsumeBytes(data[pos:])
-			if n < 0 {
-				return nil, false, errors.New("invalid bytes in resource logs scope logs")
-			}
-			pos += n
-		case 3: // ResourceLogs.schema_url
-			if wireType != protowire.BytesType {
-				return nil, false, errors.New("wrong wire type for resource logs schema url")
-			}
-			_, n := protowire.ConsumeBytes(data[pos:])
-			if n < 0 {
-				return nil, false, errors.New("invalid bytes in resource logs schema url")
-			}
-			pos += n
-		default:
-			n := skipField(data[pos:], fieldNum, wireType)
-			if n < 0 {
-				return nil, false, errors.New("failed to skip field")
-			}
-			pos += n
-		}
-	}
-
-	return state.value, state.found, nil
-}
-
 type anyValueKind uint8
 
 const (
@@ -384,8 +326,11 @@ type resourceStringAttributeState struct {
 
 // scanResourceStringAttribute validates a complete Resource message and
 // records the first matching attribute only. pdata's resource map keeps that
-// first duplicate key, including when multiple singular Resource messages are
-// merged by ResourceLogs.StringAttribute.
+// first duplicate key. When the caller's Resource value came from merging 2+
+// wire occurrences (see extractResourceMessage), the merged bytes already
+// hold every occurrence's attributes concatenated in wire order, so this
+// single pass reproduces the merge's first-value-wins behavior without any
+// extra merge-aware logic here.
 func scanResourceStringAttribute(data []byte, key string, state *resourceStringAttributeState) error {
 	pos := 0
 	for pos < len(data) {

--- a/benchmark_comparison_test.go
+++ b/benchmark_comparison_test.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 // ========== Metrics: Count Comparison ==========
@@ -349,8 +350,12 @@ func classifyWireLogSeverities(request ExportLogsServiceRequest) (logSeverityCla
 	var result logSeverityClassification
 	resources, resourceErr := request.ResourceLogs()
 	for resource := range resources {
+		res, err := resource.Resource()
+		if err != nil {
+			return logSeverityClassification{}, err
+		}
 		for _, key := range []string{"service.name", "deployment.environment"} {
-			value, found, err := resource.StringAttribute(key)
+			value, found, err := res.StringAttribute(key)
 			if err != nil {
 				return logSeverityClassification{}, err
 			}
@@ -723,6 +728,43 @@ func BenchmarkMetrics_ResourceExtraction_Unmarshal(b *testing.B) {
 	}
 }
 
+// BenchmarkResource_SingleOccurrence isolates ResourceMetrics.Resource()
+// itself (no outer iterator cost) on the common, single-Resource-occurrence
+// container that every real producer emits. E-2941's hard performance gate is
+// that this path stays zero-allocation: extracting the Resource returns a
+// slice aliasing the input instead of copying it, even though the underlying
+// extractor now scans the complete container (to find every Resource
+// occurrence for merging) rather than returning as soon as it finds the
+// field.
+func BenchmarkResource_SingleOccurrence(b *testing.B) {
+	container := containerWithResource(resourceWithStringAttr("service.name", "checkout"))
+	rm := ResourceMetrics(container)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = rm.Resource()
+	}
+}
+
+// BenchmarkResource_MultipleOccurrences is the paired benchmark for the
+// documented exception: 2+ Resource occurrences require concatenating the
+// encoded bodies into a new buffer, so this path allocates.
+func BenchmarkResource_MultipleOccurrences(b *testing.B) {
+	container := containerWithResources(
+		resourceWithStringAttr("service.name", "checkout"),
+		resourceWithStringAttr("deployment.environment", "prod"),
+		resourceWithStringAttr("host.name", "host-1"),
+	)
+	rm := ResourceMetrics(container)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = rm.Resource()
+	}
+}
+
 // ========== Metrics: Deep Iteration (E-2608, marigold workload) ==========
 
 // createScrapeShapedMetrics mirrors the traffic shape from E-2601: one
@@ -984,5 +1026,42 @@ func BenchmarkMetrics_DeepIteration_Unmarshal(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		deepIteratePdata(b, unmarshaler, bytes)
+	}
+}
+
+// containerWithScopes builds a resource container holding one Resource
+// followed by n scope entries, so the cost of locating the Resource can be
+// measured against the container's top-level field count.
+func containerWithScopes(n int) []byte {
+	res := resourceWithStringAttr("service.name", "checkout")
+	out := protowire.AppendTag(nil, 1, protowire.BytesType)
+	out = protowire.AppendVarint(out, uint64(len(res)))
+	out = append(out, res...)
+
+	scope := make([]byte, 64)
+	for i := 0; i < n; i++ {
+		out = protowire.AppendTag(out, 2, protowire.BytesType)
+		out = protowire.AppendVarint(out, uint64(len(scope)))
+		out = append(out, scope...)
+	}
+	return out
+}
+
+// BenchmarkResource_ScanScaling pins the complexity of Resource(). Merging
+// repeated occurrences requires scanning every top-level field of the
+// container, so the cost grows with the number of scope entries rather than
+// staying constant the way the pre-v0.1.0 first-match-and-return
+// implementation did. These numbers are the evidence behind the scaling note
+// in docs/BENCHMARKS.md; keep them honest if the traversal changes.
+func BenchmarkResource_ScanScaling(b *testing.B) {
+	for _, scopes := range []int{1, 10, 50} {
+		b.Run(fmt.Sprintf("scopes=%d", scopes), func(b *testing.B) {
+			rm := ResourceMetrics(containerWithScopes(scopes))
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = rm.Resource()
+			}
+		})
 	}
 }

--- a/benchmark_comparison_test.go
+++ b/benchmark_comparison_test.go
@@ -728,14 +728,8 @@ func BenchmarkMetrics_ResourceExtraction_Unmarshal(b *testing.B) {
 	}
 }
 
-// BenchmarkResource_SingleOccurrence isolates ResourceMetrics.Resource()
-// itself (no outer iterator cost) on the common, single-Resource-occurrence
-// container that every real producer emits. E-2941's hard performance gate is
-// that this path stays zero-allocation: extracting the Resource returns a
-// slice aliasing the input instead of copying it, even though the underlying
-// extractor now scans the complete container (to find every Resource
-// occurrence for merging) rather than returning as soon as it finds the
-// field.
+// BenchmarkResource_SingleOccurrence covers the common single-occurrence
+// container. The performance gate is that this path stays zero-allocation.
 func BenchmarkResource_SingleOccurrence(b *testing.B) {
 	container := containerWithResource(resourceWithStringAttr("service.name", "checkout"))
 	rm := ResourceMetrics(container)
@@ -1047,12 +1041,9 @@ func containerWithScopes(n int) []byte {
 	return out
 }
 
-// BenchmarkResource_ScanScaling pins the complexity of Resource(). Merging
-// repeated occurrences requires scanning every top-level field of the
-// container, so the cost grows with the number of scope entries rather than
-// staying constant the way the pre-v0.1.0 first-match-and-return
-// implementation did. These numbers are the evidence behind the scaling note
-// in docs/BENCHMARKS.md; keep them honest if the traversal changes.
+// BenchmarkResource_ScanScaling pins the complexity of Resource(): merging
+// requires scanning every top-level field, so cost grows with the scope count
+// instead of staying constant. Backs the scaling table in docs/BENCHMARKS.md.
 func BenchmarkResource_ScanScaling(b *testing.B) {
 	for _, scopes := range []int{1, 10, 50} {
 		b.Run(fmt.Sprintf("scopes=%d", scopes), func(b *testing.B) {

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -131,6 +131,112 @@ Speedup: 879x faster
 
 ---
 
+## Resource() absence, aliasing, and merge (E-2941)
+
+`Resource()` on `ResourceMetrics`/`ResourceLogs`/`ResourceSpans` changed in
+three ways: it returns `(nil, nil)` instead of an error for an absent
+Resource field, it merges repeated Resource occurrences instead of returning
+only the first, and it returns the typed `Resource` rather than `[]byte`.
+Merging requires scanning the complete container instead of returning as soon
+as the first Resource field is found, which is a small but real cost even in
+the common single-occurrence case; these benchmarks quantify that cost and
+confirm the hard performance gate that the single-occurrence path still
+allocates nothing.
+
+**Environment:** 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz, linux/amd64,
+Go 1.25.12. Compared with two checkouts on the same machine: this change
+(feature branch) and `upstream/main` at commit `8c0e9b4` (pre-E-2941).
+
+**Commands** (medians of 10 runs for the pair below, 5 for the scaling table):
+
+```bash
+go test -run '^$' -bench 'BenchmarkResource_(SingleOccurrence|MultipleOccurrences)$' -benchmem -count=10 ./...
+go test -run '^$' -bench 'BenchmarkResource_ScanScaling' -benchmem -count=5 ./...
+```
+
+The `upstream/main` side was measured in a detached worktree of `8c0e9b4`
+with the same fixtures ported verbatim, since the benchmarks themselves are
+new in this change.
+
+**Fixture:** a `ResourceMetrics` container built directly with `protowire`
+(not through pdata, since pdata's API cannot produce a container with 2+
+Resource occurrences) holding either one `service.name` Resource occurrence
+(single-occurrence case) or three occurrences with distinct keys
+(`service.name`, `deployment.environment`, `host.name`) for the
+multi-occurrence case. The pre-E-2941 checkout returns only the first
+occurrence regardless of how many are present, so its "multiple occurrences"
+number measures the same raw extraction cost on the same bytes, not a merge
+(it does not merge).
+
+| Benchmark | Revision | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| `BenchmarkResource_SingleOccurrence` | pre-E-2941 (`upstream/main`) | 6.72 | 0 | 0 |
+| `BenchmarkResource_SingleOccurrence` | this change | 17.6 | 0 | 0 |
+| `BenchmarkResource_MultipleOccurrences` | pre-E-2941 (`upstream/main`, returns 1st occurrence only) | 6.65 | 0 | 0 |
+| `BenchmarkResource_MultipleOccurrences` | this change (merges all occurrences) | ~205 (160–253) | 144 | 2 |
+
+Single-occurrence figures are medians of 10 runs and are stable to within
+about 0.7 ns. The multi-occurrence figure varies run to run because it
+allocates; the range observed across 10 runs is given rather than a single
+median, since quoting one number there would overstate the precision.
+
+### Scan cost scales with the container (`BenchmarkResource_ScanScaling`)
+
+The single-occurrence table above uses a container with one scope entry, which
+undersells the change. Merging requires scanning every top-level field, so the
+cost grows with the container's scope count where the previous
+first-match-and-return implementation was flat. Measured on the same machine
+with `-count=5`, one Resource followed by *n* 64-byte scope entries:
+
+| scope entries | pre-E-2941 | this change |
+|---:|---:|---:|
+| 1 | 6.8 ns | 17.4 ns |
+| 10 | 6.8 ns | 88.5 ns |
+| 50 | 6.8 ns | 412 ns |
+
+Findings:
+
+- **The hard performance gate holds:** the single-occurrence path — what
+  every real producer emits — remains zero-allocation after this change, at
+  every container size measured.
+- **This is a complexity change, not a constant-factor one.** The previous
+  implementation returned at the first Resource field, which in practice is
+  the container's first field, making it O(1) in container size. This one is
+  O(number of top-level fields), roughly 8 ns per additional scope entry on
+  this machine.
+- Each skipped field is still cheap: `protowire.ConsumeFieldValue` on a
+  length-delimited field reads the length prefix and steps over the body
+  without descending into it, so the walk covers the container's tags and
+  never its payload. The growth is in the number of tags, not their size.
+- Scanning fully is what parity with pdata costs — pdata parses the whole
+  message too — and there is no way to prove a second occurrence is absent
+  without looking. The absolute numbers stay well under a microsecond for
+  realistic containers, but consumers calling `Resource()` once per container
+  on every message should be aware the cost now tracks container shape.
+- Merging 2+ occurrences allocates (144 B, 2 allocs in this fixture: one
+  slice growth for the second and later occurrences, one for the
+  concatenated buffer) where the pre-E-2941 code allocated nothing — because
+  it silently returned only the first occurrence instead of merging. This is
+  the documented, intentional exception to the zero-copy accessor contract;
+  see [DESIGN.md](DESIGN.md) and the "Resources and attributes" section of
+  [specification.md](specification.md).
+
+### Log severity classification (E-2892) — unaffected by E-2941
+
+`classifyWireLogSeverities` was updated to call the new `ResourceLogs.Resource()`
+once per resource and `Resource.StringAttribute` per key, replacing calls to
+the removed `ResourceLogs.StringAttribute` per key. Re-running
+`BenchmarkLogs_SeverityClassification_WireFormat` on the same machine (11th
+Gen Intel i7-11800H, linux/amd64, Go 1.25.12; command:
+`go test -run '^$' -bench 'BenchmarkLogs_SeverityClassification' -benchmem -count=5 ./...`)
+shows no meaningful change: pre-E-2941 and this change both measure
+approximately 80,000 ns/op, 488 B/op, 15 allocs/op (median of 5 runs on this
+machine; this machine's absolute numbers differ from the Apple M4 figures
+recorded for this benchmark above since they are different hardware, but the
+before/after comparison on identical hardware is what matters here).
+
+---
+
 ## Implementation Details
 
 ### Counting Performance

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -200,10 +200,12 @@ Findings:
   every real producer emits — remains zero-allocation after this change, at
   every container size measured.
 - **This is a complexity change, not a constant-factor one.** The previous
-  implementation returned at the first Resource field, which in practice is
-  the container's first field, making it O(1) in container size. This one is
-  O(number of top-level fields), roughly 8 ns per additional scope entry on
-  this machine.
+  implementation returned at the first Resource field, so its cost was
+  proportional to the number of fields preceding that field — O(1) only for a
+  Resource-first container like this fixture, which is the ordering real
+  producers emit but not one the wire format guarantees. This one is
+  O(number of top-level fields) unconditionally, roughly 8 ns per additional
+  scope entry on this machine.
 - Each skipped field is still cheap: `protowire.ConsumeFieldValue` on a
   length-delimited field reads the length prefix and steps over the body
   without descending into it, so the walk covers the container's tags and

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -129,11 +129,12 @@ the whole known LogRecord structure so an early severity field cannot hide
 trailing corruption, and it implements protobuf last-value-wins scalar
 semantics.
 
-`ResourceLogs.StringAttribute` works on the enclosing ResourceLogs rather than
-only the first Resource field. This is intentional: protobuf singular message
-fields merge when repeated. The implementation scans all occurrences, retains
-the first duplicate attribute key as pdata does, and still validates later
-messages.
+Resource context comes from `ResourceLogs.Resource()`, which merges every
+Resource occurrence for this container (see "Resource extraction" below) so
+callers get pdata-compatible resource attributes without a bespoke
+per-container-type accessor. `ResourceLogs.StringAttribute` (removed in
+E-2941) previously played that role directly; its replacement is
+`rl.Resource()` followed by `Resource.StringAttribute`.
 
 ### Traces
 
@@ -148,12 +149,67 @@ Resource containers share the same outer protobuf shape across metrics, logs
 and traces: Resource is field 1, the repeated scope container is field 2, and
 the export request repeats resource containers in field 1.
 
-The three `Resource()` methods therefore share one extractor. The three
-`WriteTo` methods share one writer that prefixes the unchanged resource
-container with an export-request field tag and length. Direct `io.Writer`
-output avoids an intermediate request buffer and preserves the writer's byte
-count and error. In v0.0.4, a short byte count with a nil error is returned as
-reported; `WriteTo` does not synthesize `io.ErrShortWrite`.
+The three `Resource()` methods therefore share one extractor,
+`extractResourceMessage`. Its contract, decided for E-2941:
+
+- **Absence is not an error.** OTLP declares the Resource field optional, and
+  pdata accepts a container without it, reporting an empty Resource. The
+  extractor returns `(nil, nil)` for absence, matching the convention already
+  used by `extractBytesField`, `extractFixed64Field`, and
+  `extractFixedBytesField` elsewhere in `wire.go`. A malformed occurrence
+  (wrong wire type, bad length) is still an error.
+- **Exactly one Resource, merged.** `ResourceMetrics`/`ResourceLogs`/
+  `ResourceSpans` have exactly one pdata-visible Resource, matching pdata's
+  object model. Protobuf merges repeated occurrences of a singular message
+  field, and pdata performs that merge, so `Resource()` does too instead of
+  returning only the first occurrence (the pre-E-2941 behavior).
+- **Zero-copy for the case that matters.** A single Resource occurrence is
+  what every real producer emits. That case returns a slice aliasing the
+  input, with no allocation — this is a hard performance gate, verified by
+  `testing.AllocsPerRun` in `resource_test.go` and by
+  `BenchmarkResource_SingleOccurrence`. Two or more occurrences are merged by
+  concatenating their encoded bodies into one new buffer. Concatenation was
+  verified byte-equivalent to protobuf's field-by-field merge for singular
+  message fields (distinct keys, duplicate keys, 3+ occurrences), so it
+  reproduces pdata's result without a general recursive merge implementation.
+  This is the one documented exception to "accessors never allocate for
+  valid, real-world input": multi-occurrence Resource is a real but marginal
+  wire shape, and the alternative (a recursive field-by-field merge to stay
+  zero-copy) would add real complexity for a case no known producer emits.
+- **Occurrences are validated before they are joined.** Concatenation must not
+  manufacture validity that was never on the wire. A Resource split across two
+  occurrences — the first declaring a length it does not carry, the second
+  supplying the remainder — has two halves that each fail to parse alone but
+  concatenate into a valid message. pdata parses occurrences independently and
+  rejects that payload; joining unchecked would make the wire path accept what
+  the pdata fallback refuses. `validateMessageFraming` therefore walks each
+  occurrence first. It is structural only and allocation-free, and it runs
+  exclusively on the multi-occurrence path, so the single-occurrence hot path
+  keeps its measured cost. `TestResource_SplicedOccurrencesRejected` pins the
+  behavior against pdata; `TestResource_ValidOccurrencesStillMerge` guards
+  against it becoming over-strict.
+
+**Validation-scope change.** Finding every occurrence to merge correctly
+requires scanning the complete container, so `extractResourceMessage` can no
+longer return as soon as it finds the first Resource field the way the
+pre-E-2941 version did (and the way the other single-field extractors in
+`wire.go` still do for fields that do not merge). One consequence: a
+malformed field located *after* the last Resource occurrence in the container
+is now reported as an error, where the shallow, first-match extractor never
+reached it. This is an intentional, narrow expansion of validation scope for
+this one accessor — see the "Resources and attributes" section of
+[specification.md](specification.md) — not a general change to the "iterators
+validate operation-scoped" contract. The added scan is cheap:
+`protowire.ConsumeFieldValue` on a length-delimited field only reads the
+length prefix and skips the body, so scanning the remaining top-level tags is
+O(1) per tag regardless of payload size, confirmed by
+`BenchmarkResource_SingleOccurrence` (see [BENCHMARKS.md](BENCHMARKS.md)).
+
+The three `WriteTo` methods share one writer that prefixes the unchanged
+resource container with an export-request field tag and length. Direct
+`io.Writer` output avoids an intermediate request buffer and preserves the
+writer's byte count and error. In v0.0.4, a short byte count with a nil error
+is returned as reported; `WriteTo` does not synthesize `io.ErrShortWrite`.
 
 ## Error and compatibility strategy
 
@@ -177,8 +233,12 @@ they do not need while giving routing and detector paths a parity-oriented API.
 ## Performance design
 
 Counting uses direct tag walks and remains allocation-free. Returned byte
-slices alias the input. Ordinary iterator cost is explicit and amortized at
-outer levels; zero-allocation yield variants cover repeated inner levels.
+slices alias the input, with one documented exception: `Resource()` allocates
+a concatenated buffer when a container carries 2+ Resource occurrences (see
+"Resource extraction and WriteTo" above); the single-occurrence case every
+real producer emits stays zero-copy. Ordinary iterator cost is explicit and
+amortized at outer levels; zero-allocation yield variants cover repeated
+inner levels.
 
 No production path imports pdata or generated OTLP message types. Benchmarks
 compare equivalent work, use pdata as the full-decode baseline, report

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -3,9 +3,15 @@
 ## Status and authority
 
 This document specifies the product boundary and compatibility contract of
-`go.olly.garden/otlp-wire` as of v0.0.4. It is the canonical reference for
-what the library is for, which behavior consumers may rely on, and what must
-remain true through a refactor.
+`go.olly.garden/otlp-wire` as of v0.0.4, plus one unreleased breaking change
+(E-2941, targeting v0.1.0) described in the "Resources and attributes"
+section below: `Resource()` on `ResourceMetrics`/`ResourceLogs`/`ResourceSpans`
+now returns the typed `Resource`, tolerates an absent Resource field, and
+merges repeated Resource occurrences; `ResourceLogs.StringAttribute` is
+removed. Update the version boundary in this line when that change is
+released. This document is otherwise the canonical reference for what the
+library is for, which behavior consumers may rely on, and what must remain
+true through a refactor.
 
 The other repository documents have narrower roles:
 
@@ -169,20 +175,97 @@ iterators, preventing corrupt input from being reported as a valid
 zero-data-point metric. Update this document's version boundary when that
 change is released.
 
+The unreleased E-2941 change narrows this operation-scoping for one accessor:
+`Resource()` must scan the complete container (not just up to the first
+Resource field) to find every occurrence to merge, so a malformed field after
+the last Resource occurrence is now reported as an error where it previously
+was not. See "Resources and attributes" below for the full contract.
+
 ### Resources and attributes
 
-`Resource()` returns the raw embedded Resource message without copying it.
-The current API reports an error when that field is absent or malformed.
+`ResourceMetrics.Resource()`, `ResourceLogs.Resource()`, and
+`ResourceSpans.Resource()` each return `(Resource, error)`: exactly one typed
+Resource per container, matching pdata's object model. `Resource` is declared
+as `[]byte` (`type Resource []byte`), so this stays source-compatible with
+code written against the previous `([]byte, error)` signature.
+
+**Absence is not an error (unreleased, E-2941, v0.1.0).** OTLP declares the
+Resource field optional (`ResourceSpans.resource`, `ResourceLogs.resource`,
+`ResourceMetrics.resource`: "If this field is not set then no resource info is
+known"), and pdata accepts such a container, reporting an empty Resource.
+`Resource()` returns `(nil, nil)` for an absent field, matching the existing
+convention for other optional fields in this library. A malformed *framing* of
+the Resource field — wrong wire type, or a length that overruns the container —
+still returns an error.
+
+Be precise about how far that error checking reaches. With a single occurrence,
+`Resource()` returns a view of the field's bytes without inspecting their
+contents, so a lone occurrence whose interior is corrupt is returned without an
+error and fails later, when a semantic accessor such as `StringAttribute` reads
+it. That is the same lightweight-view behavior the field had before v0.1.0. With
+two or more occurrences the contents of each are checked structurally before
+merging, for the correctness reason given below, so the identical corrupt bytes
+are rejected there. The asymmetry is deliberate: the library never promised to
+validate bytes a caller has not traversed, but it must not assemble a valid
+message out of invalid parts.
+
+**Repeated occurrences merge (unreleased, E-2941, v0.1.0).** Protobuf merges
+repeated occurrences of a singular message field, and pdata performs this
+merge; `Resource()` does too, rather than returning only the first occurrence.
+A single occurrence — what every real producer emits — returns a slice
+aliasing the container, with no allocation. Two or more occurrences are merged
+by concatenating their encoded bodies into one new buffer, which has been
+verified byte-equivalent to protobuf's field-by-field merge for singular
+message fields. This is the one allocating case in an otherwise zero-copy
+accessor; see the amended performance contract below.
+
+**Each occurrence must stand alone.** Before concatenating, every occurrence is
+checked to be a structurally well-formed protobuf message on its own. This is a
+correctness requirement, not a convenience: a Resource can be split across two
+occurrences so that neither half parses independently while their
+concatenation does. pdata parses each occurrence separately and rejects such a
+payload, so concatenating unchecked would let the wire path accept input the
+pdata fallback rejects — exactly the parity consumers running a wire fast path
+beside a pdata fallback depend on. The check is structural only (tags parse,
+values are contained, the walk ends exactly at the end); it does not
+semantically validate the Resource, consistent with the lightweight-view versus
+semantic-accessor split described above. It runs only on the multi-occurrence
+path, so the single-occurrence hot path is unaffected in both time and
+allocations.
+
+**Validation-scope change (unreleased, E-2941, v0.1.0).** Finding every
+Resource occurrence to merge correctly requires scanning the complete
+container instead of returning as soon as the first Resource field is found.
+Consequently, a malformed field located *after* the last Resource occurrence
+in the container is now reported as an error, where the previous
+first-match-and-return implementation never reached it. This is a narrow,
+intentional expansion of validation scope for this one accessor: other
+single-field extractors in this library (used for fields that do not merge)
+keep the shallow, first-match behavior described under "Parsing and protobuf
+behavior" above.
 
 `Resource.Attributes` and `AttributesSeq` expose KeyValues from one Resource
 message. `Resource.StringAttribute` parses one Resource and distinguishes a
 missing or non-string attribute from a present empty string with its `found`
-result.
+result. Because `Resource()` already performs the merge described above,
+`Resource.StringAttribute` sees every merged occurrence's attributes and
+naturally preserves pdata's first-value-wins behavior for duplicate keys
+without any merge-specific logic of its own.
 
-`ResourceLogs.StringAttribute` operates on a complete `ResourceLogs` message.
-It merges repeated singular Resource fields in wire order and preserves the
-first value for duplicate attribute keys, matching the pdata behavior required
-by log consumers. Later Resource occurrences are still validated.
+**`ResourceLogs.StringAttribute` is removed (unreleased, E-2941, v0.1.0,
+breaking).** It predated `Resource()` returning a merged, typed `Resource` and
+skipped a level (`ResourceLogs` straight to attribute) with no pdata
+analogue. Callers migrate by calling `Resource()` first:
+
+```go
+// before
+value, found, err := resourceLogs.StringAttribute("service.name")
+
+// after
+resource, err := resourceLogs.Resource()
+if err != nil { /* ... */ }
+value, found, err := resource.StringAttribute("service.name")
+```
 
 `KeyValue.Key` and `ValueRaw` are lightweight views of the first matching
 encoded field. `KeyValue.StringValue` is the semantic string accessor: it
@@ -244,7 +327,14 @@ is part of this library's purpose and compatibility surface.
 - Ordinary iterator opens have the documented small closure cost.
 - `DataPointsSeq`, `AttributesSeq`, and `LogRecordsSeq` remain zero-allocation
   on their per-element paths.
-- Accessors return aliased slices rather than copying payload data.
+- Accessors return aliased slices rather than copying payload data, with one
+  documented exception: `Resource()` aliases the input when a container holds
+  a single Resource occurrence (the case every real producer emits) and
+  allocates a concatenated buffer only when merging 2+ occurrences
+  (unreleased, E-2941, v0.1.0). See "Resources and attributes" above and
+  `BenchmarkResource_SingleOccurrence` /
+  `BenchmarkResource_MultipleOccurrences` in
+  [BENCHMARKS.md](BENCHMARKS.md).
 - Production code must not introduce pdata or generated-message unmarshaling.
 
 Exact timings are environment-specific, not API guarantees. Any performance
@@ -282,6 +372,7 @@ Past feature rollouts established the following sequence:
 | v0.0.2 | Span-level trace access (PR #2) | Adopt partial trace processing in detector services |
 | v0.0.3 | Metrics-depth traversal and zero-allocation variants (E-2608, PR #18) | Release the primitive first, then migrate metrics consumers such as Marigold with parity and production evidence |
 | v0.0.4 | Log traversal, severity and resource strings (E-2892, PR #22) | Release the primitive first, then use separate Bindweed, Mulch and Sage adoption issues (E-2900, E-2905, E-2906) |
+| v0.1.0 (unreleased) | Typed, absence-tolerant, merged `Resource()`; removes `ResourceLogs.StringAttribute` (E-2941) | Breaking: `Resource()` now returns `(Resource, error)` (source-compatible with `[]byte` callers) and no longer errors on an absent Resource field; `rl.StringAttribute(k)` callers migrate to `rl.Resource()` then `res.StringAttribute(k)`. Release the primitive, then coordinate consumer releases per the acceptance gates below before broad upgrades |
 
 Future capabilities and refactors should follow the same staged model:
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -185,9 +185,16 @@ was not. See "Resources and attributes" below for the full contract.
 
 `ResourceMetrics.Resource()`, `ResourceLogs.Resource()`, and
 `ResourceSpans.Resource()` each return `(Resource, error)`: exactly one typed
-Resource per container, matching pdata's object model. `Resource` is declared
-as `[]byte` (`type Resource []byte`), so this stays source-compatible with
-code written against the previous `([]byte, error)` signature.
+Resource per container, matching pdata's object model.
+
+`Resource` is declared as `[]byte` (`type Resource []byte`), so a returned
+value assigns to a `[]byte` variable, passes to a `[]byte` parameter, and
+appends to a `[][]byte` without conversion. That covers how callers use the
+method directly, and every consumer surveyed for E-2941 compiles unchanged.
+It is not general source compatibility, though: the *method signature* changed,
+so an interface declaring `Resource() ([]byte, error)` is no longer satisfied,
+and a method value cannot be assigned to a `func() ([]byte, error)` variable.
+Code doing either must be updated.
 
 **Absence is not an error (unreleased, E-2941, v0.1.0).** OTLP declares the
 Resource field optional (`ResourceSpans.resource`, `ResourceLogs.resource`,
@@ -372,7 +379,7 @@ Past feature rollouts established the following sequence:
 | v0.0.2 | Span-level trace access (PR #2) | Adopt partial trace processing in detector services |
 | v0.0.3 | Metrics-depth traversal and zero-allocation variants (E-2608, PR #18) | Release the primitive first, then migrate metrics consumers such as Marigold with parity and production evidence |
 | v0.0.4 | Log traversal, severity and resource strings (E-2892, PR #22) | Release the primitive first, then use separate Bindweed, Mulch and Sage adoption issues (E-2900, E-2905, E-2906) |
-| v0.1.0 (unreleased) | Typed, absence-tolerant, merged `Resource()`; removes `ResourceLogs.StringAttribute` (E-2941) | Breaking: `Resource()` now returns `(Resource, error)` (source-compatible with `[]byte` callers) and no longer errors on an absent Resource field; `rl.StringAttribute(k)` callers migrate to `rl.Resource()` then `res.StringAttribute(k)`. Release the primitive, then coordinate consumer releases per the acceptance gates below before broad upgrades |
+| v0.1.0 (unreleased) | Typed, absence-tolerant, merged `Resource()`; removes `ResourceLogs.StringAttribute` (E-2941) | Breaking: `Resource()` now returns `(Resource, error)` (direct calls stay compatible since `Resource` assigns to `[]byte`, but interfaces and method values typed on the old signature must be updated) and no longer errors on an absent Resource field; `rl.StringAttribute(k)` callers migrate to `rl.Resource()` then `res.StringAttribute(k)`. Release the primitive, then coordinate consumer releases per the acceptance gates below before broad upgrades |
 
 Future capabilities and refactors should follow the same staged model:
 

--- a/example_test.go
+++ b/example_test.go
@@ -137,9 +137,11 @@ func ExampleMetric_DataPoints() {
 	// Output: request.duration ts=1000000000 attr=method
 }
 
-// ExampleResourceLogs_StringAttribute walks resource context and log records
-// without unmarshaling the OTLP request.
-func ExampleResourceLogs_StringAttribute() {
+// ExampleResourceLogs_Resource walks resource context and log records
+// without unmarshaling the OTLP request. It replaces the removed
+// ResourceLogs.StringAttribute: call Resource() to get the one, merged
+// Resource for this container, then StringAttribute on that Resource.
+func ExampleResourceLogs_Resource() {
 	logs := plog.NewLogs()
 	pdataResource := logs.ResourceLogs().AppendEmpty()
 	pdataResource.Resource().Attributes().PutStr("service.name", "checkout")
@@ -155,7 +157,12 @@ func ExampleResourceLogs_StringAttribute() {
 	request := otlpwire.ExportLogsServiceRequest(data)
 	resources, resourceErr := request.ResourceLogs()
 	for resourceLogs := range resources {
-		service, found, err := resourceLogs.StringAttribute("service.name")
+		resource, err := resourceLogs.Resource()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		service, found, err := resource.StringAttribute("service.name")
 		if err != nil {
 			fmt.Println(err)
 			return

--- a/log_iteration_test.go
+++ b/log_iteration_test.go
@@ -344,7 +344,13 @@ func TestResourceStringAttribute_EntityRefPdataParity(t *testing.T) {
 	}
 }
 
-func TestResourceLogsStringAttribute_MergedResourcesPdataParity(t *testing.T) {
+// TestResourceLogsResource_MergedResourcesPdataParity covers the migration
+// path documented for the removed ResourceLogs.StringAttribute:
+// rl.Resource() then res.StringAttribute(key). ResourceLogs.Resource() merges
+// repeated singular Resource occurrences (see extractResourceMessage), and
+// Resource.StringAttribute retains pdata's first-duplicate-key-wins behavior
+// over the merged bytes.
+func TestResourceLogsResource_MergedResourcesPdataParity(t *testing.T) {
 	stringAttribute := func(key, value string) []byte {
 		var anyValue []byte
 		anyValue = protowire.AppendTag(anyValue, 1, protowire.BytesType)
@@ -366,7 +372,10 @@ func TestResourceLogsStringAttribute_MergedResourcesPdataParity(t *testing.T) {
 	first := stringAttribute("service.name", "checkout")
 	second := stringAttribute("service.name", "payments")
 	merged := appendResource(appendResource(nil, first), second)
-	value, found, err := ResourceLogs(merged).StringAttribute("service.name")
+
+	resource, err := ResourceLogs(merged).Resource()
+	require.NoError(t, err)
+	value, found, err := resource.StringAttribute("service.name")
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Equal(t, "checkout", string(value), "pdata retains the first duplicate key across merged Resources")
@@ -377,10 +386,20 @@ func TestResourceLogsStringAttribute_MergedResourcesPdataParity(t *testing.T) {
 	require.True(t, pdataFound)
 	require.Equal(t, "checkout", pdataValue.Str())
 
+	// A third Resource occurrence with malformed content (a wrong wire type
+	// for Resource.attributes) is not caught by Resource() itself: extraction
+	// only concatenates raw occurrence bytes and does not parse Resource
+	// internals, the same as the other shallow field extractors in wire.go.
+	// The error surfaces one step later, when the semantic accessor parses
+	// the merged bytes -- exactly the rl.Resource() + res.StringAttribute()
+	// sequence that replaces the removed ResourceLogs.StringAttribute.
 	malformedLaterResource := appendResource(merged, []byte{0x08, 0x01})
-	_, _, wireErr := ResourceLogs(malformedLaterResource).StringAttribute("service.name")
+	malformedResourceView, wireErr := ResourceLogs(malformedLaterResource).Resource()
+	require.NoError(t, wireErr, "extraction concatenates raw bytes without validating occurrence internals")
+	_, _, attrErr := malformedResourceView.StringAttribute("service.name")
+	require.Error(t, attrErr, "the semantic accessor parses the merged bytes and reports the malformed occurrence")
+
 	_, pdataErr := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithResourceLogs(malformedLaterResource))
-	require.Error(t, wireErr)
 	require.Error(t, pdataErr)
 }
 

--- a/logs.go
+++ b/logs.go
@@ -24,9 +24,16 @@ func (r ResourceLogs) LogRecordCount() (int, error) {
 	return countInResourceLogs([]byte(r))
 }
 
-// Resource returns the raw Resource message bytes.
-func (r ResourceLogs) Resource() ([]byte, error) {
-	return extractResourceMessage([]byte(r))
+// Resource returns the Resource message for this ResourceLogs. It returns
+// (nil, nil) when the field is absent, aliases the input for the single
+// occurrence every real producer emits, and merges 2+ occurrences into a new
+// buffer. See extractResourceMessage for the full contract.
+func (r ResourceLogs) Resource() (Resource, error) {
+	raw, err := extractResourceMessage([]byte(r))
+	if err != nil {
+		return nil, err
+	}
+	return Resource(raw), nil
 }
 
 // WriteTo writes the ResourceLogs as a valid ExportLogsServiceRequest to w.

--- a/metrics.go
+++ b/metrics.go
@@ -74,9 +74,16 @@ func (r ResourceMetrics) DataPointCount() (int, error) {
 	return countInResourceMetrics([]byte(r))
 }
 
-// Resource returns the raw Resource message bytes.
-func (r ResourceMetrics) Resource() ([]byte, error) {
-	return extractResourceMessage([]byte(r))
+// Resource returns the Resource message for this ResourceMetrics. It returns
+// (nil, nil) when the field is absent, aliases the input for the single
+// occurrence every real producer emits, and merges 2+ occurrences into a new
+// buffer. See extractResourceMessage for the full contract.
+func (r ResourceMetrics) Resource() (Resource, error) {
+	raw, err := extractResourceMessage([]byte(r))
+	if err != nil {
+		return nil, err
+	}
+	return Resource(raw), nil
 }
 
 // WriteTo writes the ResourceMetrics as a valid ExportMetricsServiceRequest to w.

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -1141,7 +1141,9 @@ func TestResourceMetrics_Resource_WrongWireType(t *testing.T) {
 }
 
 func TestResourceMetrics_Resource_Missing(t *testing.T) {
-	// Craft ResourceMetrics without Resource field (only ScopeMetrics)
+	// Craft ResourceMetrics without Resource field (only ScopeMetrics). OTLP
+	// declares Resource optional, so this is valid and Resource() reports it
+	// as absent rather than erroring.
 	buf := []byte{}
 
 	// Field 2 = ScopeMetrics (empty)
@@ -1149,9 +1151,9 @@ func TestResourceMetrics_Resource_Missing(t *testing.T) {
 	buf = protowire.AppendBytes(buf, []byte{})
 
 	rm := ResourceMetrics(buf)
-	_, err := rm.Resource()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	got, err := rm.Resource()
+	require.NoError(t, err)
+	assert.Nil(t, got)
 }
 
 func TestResourceLogs_Resource_WrongWireType(t *testing.T) {
@@ -1166,14 +1168,16 @@ func TestResourceLogs_Resource_WrongWireType(t *testing.T) {
 }
 
 func TestResourceLogs_Resource_Missing(t *testing.T) {
+	// OTLP declares Resource optional; absence is valid and reported as
+	// (nil, nil), not an error.
 	buf := []byte{}
 	buf = protowire.AppendTag(buf, 2, protowire.BytesType)
 	buf = protowire.AppendBytes(buf, []byte{})
 
 	rl := ResourceLogs(buf)
-	_, err := rl.Resource()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	got, err := rl.Resource()
+	require.NoError(t, err)
+	assert.Nil(t, got)
 }
 
 func TestResourceSpans_Resource_WrongWireType(t *testing.T) {
@@ -1188,14 +1192,16 @@ func TestResourceSpans_Resource_WrongWireType(t *testing.T) {
 }
 
 func TestResourceSpans_Resource_Missing(t *testing.T) {
+	// OTLP declares Resource optional; absence is valid and reported as
+	// (nil, nil), not an error.
 	buf := []byte{}
 	buf = protowire.AppendTag(buf, 2, protowire.BytesType)
 	buf = protowire.AppendBytes(buf, []byte{})
 
 	rs := ResourceSpans(buf)
-	_, err := rs.Resource()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	got, err := rs.Resource()
+	require.NoError(t, err)
+	assert.Nil(t, got)
 }
 
 // ========== Benchmarks ==========

--- a/resource_test.go
+++ b/resource_test.go
@@ -1,12 +1,9 @@
 package otlpwire
 
-// Differential and structural tests for Resource(), covering E-2941: the
-// container's single Resource is optional (absence is not an error) and
-// repeated singular Resource occurrences merge, matching pdata's object
-// model. Fixtures are built directly with protowire because pdata's public
-// API cannot emit the omitted-field, present-but-empty, or repeated-singular-
-// field shapes under test; pdata is still used as the oracle for what those
-// wire bytes mean once parsed.
+// Tests for Resource(): the container's single Resource is optional, and
+// repeated singular occurrences merge, matching pdata. Fixtures are built with
+// protowire because pdata's API cannot emit the omitted, empty, or
+// repeated-singular shapes under test; pdata remains the oracle for meaning.
 
 import (
 	"bytes"
@@ -86,9 +83,8 @@ type resourceGetter interface {
 type signalFixture struct {
 	name string
 	wrap func([]byte) resourceGetter
-	// attrs unmarshals payload (a full export request) with the matching
-	// pdata OTLP package and returns the single resource container's
-	// Resource attributes, the oracle for merge and absence behavior.
+	// attrs returns the container's Resource attributes via pdata, the oracle
+	// for merge and absence behavior.
 	attrs func(t *testing.T, payload []byte) pcommon.Map
 }
 
@@ -131,8 +127,7 @@ var signalFixtures = []signalFixture{
 // ---------- absence and empty-but-present ----------
 
 // TestResource_AbsentField proves the omitted-Resource payload is valid OTLP
-// -- pdata unmarshals it and reports zero attributes -- and that Resource()
-// now agrees: (nil, nil), not an error.
+// and that Resource() now agrees: (nil, nil), not an error.
 func TestResource_AbsentField(t *testing.T) {
 	container := scopeContainerNoResource()
 	payload := wrapAsRequest(container)
@@ -169,11 +164,9 @@ func TestResource_PresentButEmpty(t *testing.T) {
 
 // ---------- single occurrence: the hot, zero-copy path ----------
 
-// TestResource_SingleOccurrence_IsZeroCopy proves the common case -- exactly
-// one Resource occurrence, what every real producer emits -- returns a slice
-// that aliases the source buffer rather than a copy. Mutating the source
-// buffer's resource region is observed through the returned slice, which
-// only holds if they share the same backing array.
+// TestResource_SingleOccurrence_IsZeroCopy proves the common case returns a
+// slice aliasing the source buffer rather than a copy, and that the returned
+// view cannot be appended into its neighbours.
 func TestResource_SingleOccurrence_IsZeroCopy(t *testing.T) {
 	res := resourceWithStringAttr("service.name", "checkout")
 	baseContainer := containerWithResource(res)
@@ -201,9 +194,8 @@ func TestResource_SingleOccurrence_IsZeroCopy(t *testing.T) {
 			idx := bytes.Index(container, res)
 			require.GreaterOrEqual(t, idx, 0, "resource bytes must appear in the container")
 
-			// Prove the whole region aliases, not just its first byte: flip
-			// every byte of the resource in the container and require the
-			// returned slice to reflect all of it.
+			// Flip every byte, not just the first: proves the whole region
+			// aliases rather than one lucky offset.
 			before := append([]byte(nil), got...)
 			for i := range res {
 				container[idx+i] ^= 0xFF
@@ -215,10 +207,8 @@ func TestResource_SingleOccurrence_IsZeroCopy(t *testing.T) {
 					"byte %d must reflect the source mutation", i)
 			}
 
-			// The view must not be append-extendable into its neighbours:
-			// protowire.ConsumeBytes hands back a slice whose capacity runs to
-			// the end of the container, so an unclamped return would let a
-			// caller's append silently overwrite the sibling scope field.
+			// An unclamped capacity would let a caller's append overwrite the
+			// sibling scope field.
 			require.Equal(t, len(got), cap(got),
 				"capacity must be clamped so append reallocates instead of corrupting the container")
 			tail := append([]byte(nil), container[idx+len(res):]...)
@@ -411,17 +401,9 @@ func TestResource_UnknownAndOutOfOrderFieldsSkipped(t *testing.T) {
 }
 
 // TestResource_SplicedOccurrencesRejected pins the boundary that makes merging
-// by concatenation safe. A Resource can be split across two occurrences so
-// that neither half parses alone — the first declares a length it does not
-// carry, the second supplies the remainder — while their concatenation is a
-// perfectly valid Resource.
-//
-// pdata parses each occurrence of a repeated singular message field
-// independently and rejects such a payload. Concatenating without checking
-// would reassemble the halves and report success, so the wire fast path would
-// accept a payload its pdata fallback rejects. bindweed and sage both rely on
-// that parity: "Each occurrence must parse on its own, so a payload spliced
-// across occurrences fails exactly like it does on the pdata path."
+// by concatenation safe. Neither half of a spliced Resource parses alone, but
+// their concatenation does; pdata rejects such a payload, so merging without
+// checking would make the wire path accept what its pdata fallback refuses.
 func TestResource_SplicedOccurrencesRejected(t *testing.T) {
 	full := resourceWithStringAttr("service.name", "checkout")
 	cut := 12 // lands inside the attributes field, after its length prefix

--- a/resource_test.go
+++ b/resource_test.go
@@ -1,0 +1,473 @@
+package otlpwire
+
+// Differential and structural tests for Resource(), covering E-2941: the
+// container's single Resource is optional (absence is not an error) and
+// repeated singular Resource occurrences merge, matching pdata's object
+// model. Fixtures are built directly with protowire because pdata's public
+// API cannot emit the omitted-field, present-but-empty, or repeated-singular-
+// field shapes under test; pdata is still used as the oracle for what those
+// wire bytes mean once parsed.
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// ---------- wire-fixture builders ----------
+
+// wrapAsRequest wraps one resource container as an export request. All three
+// export request types carry the container in repeated field 1.
+func wrapAsRequest(container []byte) []byte {
+	out := protowire.AppendTag(nil, 1, protowire.BytesType)
+	out = protowire.AppendVarint(out, uint64(len(container)))
+	return append(out, container...)
+}
+
+// scopeContainerNoResource builds a ResourceSpans/ResourceLogs/ResourceMetrics
+// that omits the optional Resource field (field 1) and carries only an empty
+// scope container (field 2).
+func scopeContainerNoResource() []byte {
+	out := protowire.AppendTag(nil, 2, protowire.BytesType)
+	return protowire.AppendVarint(out, 0)
+}
+
+// containerWithResource builds a container whose Resource field holds the
+// supplied raw Resource bytes, followed by an empty scope container.
+func containerWithResource(resource []byte) []byte {
+	return containerWithResources(resource)
+}
+
+// containerWithResources builds a container carrying every supplied Resource
+// occurrence, in wire order, followed by an empty scope container.
+func containerWithResources(resources ...[]byte) []byte {
+	var out []byte
+	for _, r := range resources {
+		out = protowire.AppendTag(out, 1, protowire.BytesType)
+		out = protowire.AppendVarint(out, uint64(len(r)))
+		out = append(out, r...)
+	}
+	out = protowire.AppendTag(out, 2, protowire.BytesType)
+	return protowire.AppendVarint(out, 0)
+}
+
+// resourceWithStringAttr builds a Resource message carrying one string
+// attribute (Resource.attributes is field 1, KeyValue.key field 1,
+// KeyValue.value field 2, AnyValue.string_value field 1).
+func resourceWithStringAttr(key, value string) []byte {
+	anyValue := protowire.AppendTag(nil, 1, protowire.BytesType)
+	anyValue = protowire.AppendString(anyValue, value)
+
+	kv := protowire.AppendTag(nil, 1, protowire.BytesType)
+	kv = protowire.AppendString(kv, key)
+	kv = protowire.AppendTag(kv, 2, protowire.BytesType)
+	kv = protowire.AppendVarint(kv, uint64(len(anyValue)))
+	kv = append(kv, anyValue...)
+
+	res := protowire.AppendTag(nil, 1, protowire.BytesType)
+	res = protowire.AppendVarint(res, uint64(len(kv)))
+	return append(res, kv...)
+}
+
+// ---------- signal-generic harness ----------
+
+// resourceGetter is satisfied by ResourceLogs, ResourceMetrics, and
+// ResourceSpans, letting one test body cover all three signals.
+type resourceGetter interface {
+	Resource() (Resource, error)
+}
+
+type signalFixture struct {
+	name string
+	wrap func([]byte) resourceGetter
+	// attrs unmarshals payload (a full export request) with the matching
+	// pdata OTLP package and returns the single resource container's
+	// Resource attributes, the oracle for merge and absence behavior.
+	attrs func(t *testing.T, payload []byte) pcommon.Map
+}
+
+var signalFixtures = []signalFixture{
+	{
+		name: "metrics",
+		wrap: func(b []byte) resourceGetter { return ResourceMetrics(b) },
+		attrs: func(t *testing.T, payload []byte) pcommon.Map {
+			t.Helper()
+			req := pmetricotlp.NewExportRequest()
+			require.NoError(t, req.UnmarshalProto(payload))
+			require.Equal(t, 1, req.Metrics().ResourceMetrics().Len())
+			return req.Metrics().ResourceMetrics().At(0).Resource().Attributes()
+		},
+	},
+	{
+		name: "logs",
+		wrap: func(b []byte) resourceGetter { return ResourceLogs(b) },
+		attrs: func(t *testing.T, payload []byte) pcommon.Map {
+			t.Helper()
+			req := plogotlp.NewExportRequest()
+			require.NoError(t, req.UnmarshalProto(payload))
+			require.Equal(t, 1, req.Logs().ResourceLogs().Len())
+			return req.Logs().ResourceLogs().At(0).Resource().Attributes()
+		},
+	},
+	{
+		name: "traces",
+		wrap: func(b []byte) resourceGetter { return ResourceSpans(b) },
+		attrs: func(t *testing.T, payload []byte) pcommon.Map {
+			t.Helper()
+			req := ptraceotlp.NewExportRequest()
+			require.NoError(t, req.UnmarshalProto(payload))
+			require.Equal(t, 1, req.Traces().ResourceSpans().Len())
+			return req.Traces().ResourceSpans().At(0).Resource().Attributes()
+		},
+	},
+}
+
+// ---------- absence and empty-but-present ----------
+
+// TestResource_AbsentField proves the omitted-Resource payload is valid OTLP
+// -- pdata unmarshals it and reports zero attributes -- and that Resource()
+// now agrees: (nil, nil), not an error.
+func TestResource_AbsentField(t *testing.T) {
+	container := scopeContainerNoResource()
+	payload := wrapAsRequest(container)
+
+	for _, sf := range signalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			attrs := sf.attrs(t, payload)
+			require.Equal(t, 0, attrs.Len(), "pdata accepts the omitted field")
+
+			got, err := sf.wrap(container).Resource()
+			require.NoError(t, err)
+			require.Nil(t, got)
+		})
+	}
+}
+
+// TestResource_PresentButEmpty shows the present-but-zero-length Resource
+// case, which already worked before this change and must keep working.
+func TestResource_PresentButEmpty(t *testing.T) {
+	container := containerWithResource(nil)
+	payload := wrapAsRequest(container)
+
+	for _, sf := range signalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			attrs := sf.attrs(t, payload)
+			require.Equal(t, 0, attrs.Len())
+
+			got, err := sf.wrap(container).Resource()
+			require.NoError(t, err)
+			require.Empty(t, got)
+		})
+	}
+}
+
+// ---------- single occurrence: the hot, zero-copy path ----------
+
+// TestResource_SingleOccurrence_IsZeroCopy proves the common case -- exactly
+// one Resource occurrence, what every real producer emits -- returns a slice
+// that aliases the source buffer rather than a copy. Mutating the source
+// buffer's resource region is observed through the returned slice, which
+// only holds if they share the same backing array.
+func TestResource_SingleOccurrence_IsZeroCopy(t *testing.T) {
+	res := resourceWithStringAttr("service.name", "checkout")
+	baseContainer := containerWithResource(res)
+	payload := wrapAsRequest(baseContainer)
+
+	for _, sf := range signalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			attrs := sf.attrs(t, payload)
+			value, ok := attrs.Get("service.name")
+			require.True(t, ok)
+			require.Equal(t, "checkout", value.Str())
+
+			// Fresh copy per subtest since the aliasing check below mutates
+			// the container in place.
+			container := append([]byte(nil), baseContainer...)
+			got, err := sf.wrap(container).Resource()
+			require.NoError(t, err)
+			require.NotEmpty(t, got)
+
+			strVal, found, err := got.StringAttribute("service.name")
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, "checkout", string(strVal))
+
+			idx := bytes.Index(container, res)
+			require.GreaterOrEqual(t, idx, 0, "resource bytes must appear in the container")
+
+			// Prove the whole region aliases, not just its first byte: flip
+			// every byte of the resource in the container and require the
+			// returned slice to reflect all of it.
+			before := append([]byte(nil), got...)
+			for i := range res {
+				container[idx+i] ^= 0xFF
+			}
+			require.Equal(t, container[idx:idx+len(res)], []byte(got),
+				"returned slice must alias the whole resource region, not copy it")
+			for i := range got {
+				require.NotEqual(t, before[i], got[i],
+					"byte %d must reflect the source mutation", i)
+			}
+
+			// The view must not be append-extendable into its neighbours:
+			// protowire.ConsumeBytes hands back a slice whose capacity runs to
+			// the end of the container, so an unclamped return would let a
+			// caller's append silently overwrite the sibling scope field.
+			require.Equal(t, len(got), cap(got),
+				"capacity must be clamped so append reallocates instead of corrupting the container")
+			tail := append([]byte(nil), container[idx+len(res):]...)
+			_ = append(got, 0xEE, 0xEE) //nolint:gocritic // deliberately discarded: asserting no in-place growth
+			require.Equal(t, tail, container[idx+len(res):],
+				"appending to the returned view must not touch bytes after the resource")
+		})
+	}
+}
+
+// TestResourceSingleOccurrence_ZeroAllocations pins the hard performance gate:
+// Resource() on the common single-occurrence container allocates nothing.
+func TestResourceSingleOccurrence_ZeroAllocations(t *testing.T) {
+	container := containerWithResource(resourceWithStringAttr("service.name", "checkout"))
+	rm := ResourceMetrics(container)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, err := rm.Resource()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) == 0 {
+			t.Fatal("expected a non-empty resource")
+		}
+	})
+	require.Zero(t, allocs)
+}
+
+// ---------- merge: 2+ occurrences ----------
+
+// TestResource_Merge covers protobuf's merge behavior for repeated
+// occurrences of the singular Resource field: distinct keys, a duplicate key
+// (pdata keeps the first value), and 3+ occurrences. otlp-wire merges by
+// concatenating the encoded Resource bodies; this is verified byte-equivalent
+// to pdata's merge for these shapes.
+func TestResource_Merge(t *testing.T) {
+	first := resourceWithStringAttr("service.name", "checkout")
+	second := resourceWithStringAttr("deployment.environment", "prod")
+	dup := resourceWithStringAttr("service.name", "shadow")
+
+	tests := []struct {
+		name        string
+		occurrences [][]byte
+		wantLen     int // pdata's raw attribute count (duplicates are not deduplicated)
+	}{
+		{"two distinct keys", [][]byte{first, second}, 2},
+		{"duplicate key", [][]byte{first, dup}, 2},
+		{"three occurrences", [][]byte{first, second, dup}, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			container := containerWithResources(tt.occurrences...)
+			payload := wrapAsRequest(container)
+
+			for _, sf := range signalFixtures {
+				t.Run(sf.name, func(t *testing.T) {
+					attrs := sf.attrs(t, payload)
+					require.Equal(t, tt.wantLen, attrs.Len(), "pdata merge result")
+					pdataValue, ok := attrs.Get("service.name")
+					require.True(t, ok)
+
+					got, err := sf.wrap(container).Resource()
+					require.NoError(t, err)
+
+					count := 0
+					seq, errFn := got.Attributes()
+					for range seq {
+						count++
+					}
+					require.NoError(t, errFn())
+					require.Equal(t, tt.wantLen, count, "otlp-wire must see every merged attribute occurrence")
+
+					value, found, err := got.StringAttribute("service.name")
+					require.NoError(t, err)
+					require.True(t, found)
+					require.Equal(t, pdataValue.Str(), string(value), "first-value-wins must match pdata")
+				})
+			}
+		})
+	}
+}
+
+// TestResource_Merge_MultipleOccurrencesAllocate documents the one
+// intentional exception to the zero-copy contract: 2+ occurrences require a
+// concatenated buffer and must not alias the source.
+func TestResource_Merge_MultipleOccurrencesAllocate(t *testing.T) {
+	container := containerWithResources(
+		resourceWithStringAttr("service.name", "checkout"),
+		resourceWithStringAttr("deployment.environment", "prod"),
+	)
+	rm := ResourceMetrics(container)
+
+	got, err := rm.Resource()
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+
+	allocs := testing.AllocsPerRun(200, func() {
+		merged, err := rm.Resource()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(merged) == 0 {
+			t.Fatal("expected merged resource bytes")
+		}
+	})
+	require.Greater(t, allocs, 0.0, "2+ occurrences must allocate a new buffer, not alias the source")
+}
+
+// ---------- malformed and structural coverage ----------
+
+// TestResource_MalformedWrongWireType keeps malformed-wire coverage distinct
+// from absence: an incorrect wire type on the Resource field must stay an
+// error regardless of occurrence count.
+func TestResource_MalformedWrongWireType(t *testing.T) {
+	container := protowire.AppendTag(nil, 1, protowire.VarintType)
+	container = protowire.AppendVarint(container, 42)
+
+	for _, sf := range signalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			got, err := sf.wrap(container).Resource()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "wrong wire type")
+			require.Nil(t, got)
+		})
+	}
+}
+
+// TestResource_MalformedTruncatedLength covers a Resource field whose length
+// prefix claims more bytes than the buffer holds.
+func TestResource_MalformedTruncatedLength(t *testing.T) {
+	container := protowire.AppendTag(nil, 1, protowire.BytesType)
+	container = protowire.AppendVarint(container, 50) // claims 50 bytes; none follow
+
+	for _, sf := range signalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			got, err := sf.wrap(container).Resource()
+			require.Error(t, err)
+			require.Nil(t, got)
+		})
+	}
+}
+
+// TestResource_MalformedTrailingFieldAfterResource exercises the
+// validation-scope change: merging requires scanning the complete container
+// to find every Resource occurrence, so a malformed field located after the
+// (only) Resource occurrence is now detected, where the previous
+// first-match-and-return implementation never reached it.
+func TestResource_MalformedTrailingFieldAfterResource(t *testing.T) {
+	container := containerWithResource(resourceWithStringAttr("service.name", "checkout"))
+	// Append a malformed trailing field: a truncated tag byte with the
+	// continuation bit set and nothing after it.
+	container = append(container, 0x80)
+
+	for _, sf := range signalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			got, err := sf.wrap(container).Resource()
+			require.Error(t, err, "scanning the full container for merge now surfaces this corruption")
+			require.Nil(t, got)
+		})
+	}
+}
+
+// TestResource_UnknownAndOutOfOrderFieldsSkipped confirms unknown top-level
+// fields and an out-of-order Resource occurrence (appearing after the scope
+// container rather than before it) are both handled correctly.
+func TestResource_UnknownAndOutOfOrderFieldsSkipped(t *testing.T) {
+	res := resourceWithStringAttr("service.name", "checkout")
+
+	var container []byte
+	container = appendUnknownGroup(container, 90) // unknown field before anything else
+	container = protowire.AppendTag(container, 2, protowire.BytesType)
+	container = protowire.AppendVarint(container, 0) // empty scope container, field 2
+	container = appendUnknownGroup(container, 91)    // unknown field between scope and resource
+	container = protowire.AppendTag(container, 1, protowire.BytesType)
+	container = protowire.AppendVarint(container, uint64(len(res)))
+	container = append(container, res...) // resource arrives out of order, after the scope field
+	container = appendUnknownGroup(container, 92)
+
+	for _, sf := range signalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			got, err := sf.wrap(container).Resource()
+			require.NoError(t, err)
+			value, found, err := got.StringAttribute("service.name")
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, "checkout", string(value))
+		})
+	}
+}
+
+// TestResource_SplicedOccurrencesRejected pins the boundary that makes merging
+// by concatenation safe. A Resource can be split across two occurrences so
+// that neither half parses alone — the first declares a length it does not
+// carry, the second supplies the remainder — while their concatenation is a
+// perfectly valid Resource.
+//
+// pdata parses each occurrence of a repeated singular message field
+// independently and rejects such a payload. Concatenating without checking
+// would reassemble the halves and report success, so the wire fast path would
+// accept a payload its pdata fallback rejects. bindweed and sage both rely on
+// that parity: "Each occurrence must parse on its own, so a payload spliced
+// across occurrences fails exactly like it does on the pdata path."
+func TestResource_SplicedOccurrencesRejected(t *testing.T) {
+	full := resourceWithStringAttr("service.name", "checkout")
+	cut := 12 // lands inside the attributes field, after its length prefix
+	occ1, occ2 := full[:cut], full[cut:]
+
+	require.True(t, bytes.Equal(append(append([]byte{}, occ1...), occ2...), full),
+		"fixture must split a valid Resource into two halves")
+
+	container := containerWithResources(occ1, occ2)
+
+	// pdata rejects the payload outright.
+	req := plogotlp.NewExportRequest()
+	require.Error(t, req.UnmarshalProto(wrapAsRequest(container)),
+		"pdata must reject a spliced Resource")
+
+	// otlp-wire must reject it too, rather than silently reassembling it.
+	for _, sf := range signalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			got, err := sf.wrap(container).Resource()
+			require.Error(t, err, "spliced occurrences must not be merged into a valid Resource")
+			require.Nil(t, got)
+		})
+	}
+}
+
+// TestResource_ValidOccurrencesStillMerge guards the fix above from becoming
+// over-strict: occurrences that each stand alone must still merge.
+func TestResource_ValidOccurrencesStillMerge(t *testing.T) {
+	a := resourceWithStringAttr("service.name", "checkout")
+	b := resourceWithStringAttr("deployment.environment", "prod")
+	container := containerWithResources(a, b)
+
+	for _, sf := range signalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			got, err := sf.wrap(container).Resource()
+			require.NoError(t, err)
+
+			for key, want := range map[string]string{
+				"service.name":           "checkout",
+				"deployment.environment": "prod",
+			} {
+				value, found, err := got.StringAttribute(key)
+				require.NoError(t, err)
+				require.True(t, found, "attribute %q must survive the merge", key)
+				require.Equal(t, want, string(value))
+			}
+		})
+	}
+}

--- a/traces.go
+++ b/traces.go
@@ -21,9 +21,16 @@ func (r ResourceSpans) SpanCount() (int, error) {
 	return countInResourceSpans([]byte(r))
 }
 
-// Resource returns the raw Resource message bytes.
-func (r ResourceSpans) Resource() ([]byte, error) {
-	return extractResourceMessage([]byte(r))
+// Resource returns the Resource message for this ResourceSpans. It returns
+// (nil, nil) when the field is absent, aliases the input for the single
+// occurrence every real producer emits, and merges 2+ occurrences into a new
+// buffer. See extractResourceMessage for the full contract.
+func (r ResourceSpans) Resource() (Resource, error) {
+	raw, err := extractResourceMessage([]byte(r))
+	if err != nil {
+		return nil, err
+	}
+	return Resource(raw), nil
 }
 
 // WriteTo writes the ResourceSpans as a valid ExportTracesServiceRequest to w.

--- a/types.go
+++ b/types.go
@@ -18,10 +18,9 @@ type ResourceLogs []byte
 
 // Resource represents a Resource message (raw wire bytes).
 //
-// Resource values are normally obtained by converting the bytes returned by a
-// ResourceMetrics, ResourceLogs, or ResourceSpans Resource method. This keeps
-// those established methods source-compatible while providing attribute
-// accessors for callers that need resource context.
+// Resource values are normally obtained from a ResourceMetrics, ResourceLogs,
+// or ResourceSpans Resource method, which returns exactly one merged Resource
+// per container, matching pdata's object model.
 type Resource []byte
 
 // ScopeLogs represents a single ScopeLogs message (raw wire bytes).

--- a/wire.go
+++ b/wire.go
@@ -142,10 +142,9 @@ func forEachRepeatedField(data []byte, fieldNum protowire.Number, fn func([]byte
 	}
 }
 
-// validateMessageFraming reports whether data is a structurally well-formed
-// protobuf message: every tag parses, every value lies fully inside data, and
-// the walk lands exactly on the end. It does not interpret field numbers or
-// validate semantics, and it allocates nothing.
+// validateMessageFraming reports whether data is structurally well-formed:
+// every tag parses, every value is contained, and the walk ends exactly at the
+// end. Structure only, no semantics.
 func validateMessageFraming(data []byte) error {
 	for pos := 0; pos < len(data); {
 		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
@@ -163,47 +162,19 @@ func validateMessageFraming(data []byte) error {
 	return nil
 }
 
-// extractResourceMessage extracts and merges the Resource message (field 1)
-// from ResourceMetrics/ResourceLogs/ResourceSpans messages.
+// extractResourceMessage returns the Resource message (field 1) of a
+// ResourceMetrics/ResourceLogs/ResourceSpans, merging repeated occurrences the
+// way protobuf and pdata do.
 //
-// OTLP declares the Resource field optional: a container that omits it is
-// valid and pdata reports it as an empty Resource, so absence returns
-// (nil, nil) rather than an error, matching extractBytesField and
-// extractFixedBytesField elsewhere in this file. A malformed occurrence
-// (wrong wire type, bad length) still returns an error.
+// An absent field returns (nil, nil); malformed framing returns an error. One
+// occurrence aliases data; two or more are each validated, then concatenated
+// into a new buffer. Locating every occurrence requires scanning the whole
+// container, so a malformed field after the last occurrence is an error too,
+// and the cost grows with the container's field count instead of being
+// constant.
 //
-// Protobuf also merges repeated occurrences of a singular message field, and
-// pdata performs that merge. A single occurrence is the case every real
-// producer emits and returns a slice aliasing data with no extra allocation.
-// Two or more occurrences require a new buffer: this function concatenates
-// the encoded bodies in wire order, which has been verified to be
-// byte-equivalent to protobuf's field-by-field merge for singular message
-// fields (distinct keys, duplicate keys, and 3+ occurrences), so
-// concatenation is correct without a general recursive merge.
-//
-// Validation-scope note: finding every occurrence to merge correctly means
-// this function must scan the complete container instead of returning as
-// soon as the first Resource field is found (the previous behavior, and the
-// pattern extractBytesField/extractFixed64Field/extractFixedBytesField still
-// use for their single-value fields). Consequently a malformed field located
-// after the last Resource occurrence is now reported as an error, where a
-// shallow single-field extractor would never have reached it. This is an
-// intentional, documented expansion of validation scope for this one
-// accessor; see docs/specification.md.
-//
-// Cost note, stated plainly because it is a complexity change and not just a
-// constant: the previous implementation returned at the first Resource field,
-// which in practice is the container's first field, so it was O(1) regardless
-// of container size. This one is O(number of top-level fields). Each skipped
-// field is still cheap — protowire.ConsumeFieldValue on a length-delimited
-// field reads the length prefix and steps over the body without descending
-// into it — so the walk is over the container's tags, never its payload. But
-// the total grows with the scope count: measured at roughly 17ns for one
-// scope entry, 88ns for ten and 412ns for fifty, against a flat ~7ns before,
-// all still zero-allocation. See BenchmarkResource_ScanScaling in
-// benchmark_comparison_test.go and the table in docs/BENCHMARKS.md. Scanning
-// fully is the price of matching pdata, which also parses the whole message;
-// there is no way to prove a second occurrence is absent without looking.
+// docs/DESIGN.md covers why concatenation is a correct merge and why each
+// occurrence is validated first; docs/BENCHMARKS.md has the scan cost.
 func extractResourceMessage(data []byte) ([]byte, error) {
 	var first []byte
 	var found bool
@@ -249,23 +220,16 @@ func extractResourceMessage(data []byte) ([]byte, error) {
 		return nil, nil
 	}
 	if len(rest) == 0 {
-		// Zero-copy: aliases data. The capacity is clamped to the length so a
-		// caller that appends to the returned view reallocates instead of
-		// writing over whatever follows the Resource in the container.
-		// protowire.ConsumeBytes yields a two-index slice whose capacity runs
-		// to the end of the enclosing buffer, so without this an append would
-		// silently corrupt the sibling scope or schema_url field.
+		// Aliases data. Capacity is clamped so a caller's append reallocates:
+		// ConsumeBytes hands back a slice whose capacity runs to the end of
+		// the container, which would otherwise let append overwrite the
+		// sibling scope field.
 		return first[:len(first):len(first)], nil
 	}
 
-	// Concatenation must not manufacture validity that was not on the wire.
-	// pdata parses each occurrence of a repeated singular message field on its
-	// own, so a message spliced across two occurrences - the first declaring a
-	// length it does not carry, the second supplying the remainder - is
-	// rejected there. Concatenating first would silently reassemble it into a
-	// well-formed Resource and report success, accepting a payload the pdata
-	// fallback rejects. Require every occurrence to stand alone before joining
-	// them.
+	// Concatenation must not manufacture validity. A Resource spliced across
+	// two occurrences, neither parseable alone, would otherwise reassemble
+	// into a valid message that pdata rejects.
 	if err := validateMessageFraming(first); err != nil {
 		return nil, err
 	}

--- a/wire.go
+++ b/wire.go
@@ -142,9 +142,72 @@ func forEachRepeatedField(data []byte, fieldNum protowire.Number, fn func([]byte
 	}
 }
 
-// extractResourceMessage extracts the Resource message (field 1) from
-// ResourceMetrics/ResourceLogs/ResourceSpans messages.
+// validateMessageFraming reports whether data is a structurally well-formed
+// protobuf message: every tag parses, every value lies fully inside data, and
+// the walk lands exactly on the end. It does not interpret field numbers or
+// validate semantics, and it allocates nothing.
+func validateMessageFraming(data []byte) error {
+	for pos := 0; pos < len(data); {
+		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return errors.New("malformed protobuf tag in resource occurrence")
+		}
+		pos += tagLen
+
+		n := skipField(data[pos:], num, wireType)
+		if n < 0 {
+			return errors.New("malformed field in resource occurrence")
+		}
+		pos += n
+	}
+	return nil
+}
+
+// extractResourceMessage extracts and merges the Resource message (field 1)
+// from ResourceMetrics/ResourceLogs/ResourceSpans messages.
+//
+// OTLP declares the Resource field optional: a container that omits it is
+// valid and pdata reports it as an empty Resource, so absence returns
+// (nil, nil) rather than an error, matching extractBytesField and
+// extractFixedBytesField elsewhere in this file. A malformed occurrence
+// (wrong wire type, bad length) still returns an error.
+//
+// Protobuf also merges repeated occurrences of a singular message field, and
+// pdata performs that merge. A single occurrence is the case every real
+// producer emits and returns a slice aliasing data with no extra allocation.
+// Two or more occurrences require a new buffer: this function concatenates
+// the encoded bodies in wire order, which has been verified to be
+// byte-equivalent to protobuf's field-by-field merge for singular message
+// fields (distinct keys, duplicate keys, and 3+ occurrences), so
+// concatenation is correct without a general recursive merge.
+//
+// Validation-scope note: finding every occurrence to merge correctly means
+// this function must scan the complete container instead of returning as
+// soon as the first Resource field is found (the previous behavior, and the
+// pattern extractBytesField/extractFixed64Field/extractFixedBytesField still
+// use for their single-value fields). Consequently a malformed field located
+// after the last Resource occurrence is now reported as an error, where a
+// shallow single-field extractor would never have reached it. This is an
+// intentional, documented expansion of validation scope for this one
+// accessor; see docs/specification.md.
+//
+// Cost note, stated plainly because it is a complexity change and not just a
+// constant: the previous implementation returned at the first Resource field,
+// which in practice is the container's first field, so it was O(1) regardless
+// of container size. This one is O(number of top-level fields). Each skipped
+// field is still cheap — protowire.ConsumeFieldValue on a length-delimited
+// field reads the length prefix and steps over the body without descending
+// into it — so the walk is over the container's tags, never its payload. But
+// the total grows with the scope count: measured at roughly 17ns for one
+// scope entry, 88ns for ten and 412ns for fifty, against a flat ~7ns before,
+// all still zero-allocation. See BenchmarkResource_ScanScaling in
+// benchmark_comparison_test.go and the table in docs/BENCHMARKS.md. Scanning
+// fully is the price of matching pdata, which also parses the whole message;
+// there is no way to prove a second occurrence is absent without looking.
 func extractResourceMessage(data []byte) ([]byte, error) {
+	var first []byte
+	var found bool
+	var rest [][]byte
 	pos := 0
 
 	for pos < len(data) {
@@ -163,7 +226,15 @@ func extractResourceMessage(data []byte) ([]byte, error) {
 			if n < 0 {
 				return nil, errors.New("invalid bytes in resource field")
 			}
-			return msgBytes, nil
+			pos += n
+
+			if !found {
+				first = msgBytes
+				found = true
+			} else {
+				rest = append(rest, msgBytes)
+			}
+			continue
 		}
 
 		// Skip other fields
@@ -174,7 +245,46 @@ func extractResourceMessage(data []byte) ([]byte, error) {
 		pos += n
 	}
 
-	return nil, errors.New("resource field not found")
+	if !found {
+		return nil, nil
+	}
+	if len(rest) == 0 {
+		// Zero-copy: aliases data. The capacity is clamped to the length so a
+		// caller that appends to the returned view reallocates instead of
+		// writing over whatever follows the Resource in the container.
+		// protowire.ConsumeBytes yields a two-index slice whose capacity runs
+		// to the end of the enclosing buffer, so without this an append would
+		// silently corrupt the sibling scope or schema_url field.
+		return first[:len(first):len(first)], nil
+	}
+
+	// Concatenation must not manufacture validity that was not on the wire.
+	// pdata parses each occurrence of a repeated singular message field on its
+	// own, so a message spliced across two occurrences - the first declaring a
+	// length it does not carry, the second supplying the remainder - is
+	// rejected there. Concatenating first would silently reassemble it into a
+	// well-formed Resource and report success, accepting a payload the pdata
+	// fallback rejects. Require every occurrence to stand alone before joining
+	// them.
+	if err := validateMessageFraming(first); err != nil {
+		return nil, err
+	}
+	for _, r := range rest {
+		if err := validateMessageFraming(r); err != nil {
+			return nil, err
+		}
+	}
+
+	total := len(first)
+	for _, r := range rest {
+		total += len(r)
+	}
+	merged := make([]byte, 0, total)
+	merged = append(merged, first...)
+	for _, r := range rest {
+		merged = append(merged, r...)
+	}
+	return merged, nil
 }
 
 // extractBytesField extracts the first occurrence of a length-delimited


### PR DESCRIPTION
Closes E-2941. First change of the otlp-wire v0.1.0 API realignment (E-2940).

## Motivation

`Resource()` diverges from pdata in three ways at once, all in the same function, so they are fixed together as one coherent "Resource() now matches pdata" change.

**Absence is treated as an error.** OTLP declares the field optional — `trace.proto` on `ResourceSpans.resource`: *"If this field is not set then no resource info is known."* pdata accepts such a container and reports an empty Resource; otlp-wire returns `"resource field not found"`. Consumer impact at current default-branch heads:

| Consumer | Behavior on a legal absent-Resource payload |
| --- | --- |
| **fig** | fatal for the payload → NAK, documented in `internal/event/extract.go`. Redelivery cannot succeed differently, so it is a poison message. |
| chaff, dibber, marigold, overstory | abort the detector |
| loam | falls back to the full pdata path — safe, but loses the short-circuit |
| seedtray | records the error and skips the container |
| gaps | string-match workaround: `err.Error() != "resource field not found"` |
| bindweed, sage | bypass `Resource()` entirely with their own parser |

**Repeated occurrences are not merged.** Protobuf merges repeated occurrences of a singular message field and pdata implements this; otlp-wire returned only the first. Since a resource container has exactly one Resource, multiple wire occurrences are an *encoding* of that one resource, not a list.

**The return is untyped**, forcing `otlpwire.Resource(raw)` at every call site.

Not currently firing in production: checked 2026-08-07 in `og-ext-prod-gke`, zero absent-Resource errors across all three fig pods over their full 5d15h lifetime. fig logs actively (1200–1600 lines/pod), so that zero is meaningful. This is correctness work, not incident response.

## What changed

- `Resource()` returns the typed `Resource` on all three container types
- absent field → `(nil, nil)`; malformed framing still errors
- repeated occurrences merged by concatenating encoded bodies, verified byte-equivalent to protobuf's field-by-field merge
- single occurrence stays zero-copy and zero-allocation
- `ResourceLogs.StringAttribute()` removed — no pdata analogue, skips a level, existed only because `Resource()` could not return a merged resource

## Two hazards found in adversarial review

**Concatenation could manufacture validity that was never on the wire.** A Resource can be split across two occurrences so neither half parses alone while their concatenation does. pdata parses occurrences independently and rejects it:

```
pdata UnmarshalProto:   err=unexpected EOF        ← rejects
otlpwire Resource():    err=<nil>  len=28         ← accepted, pre-fix
merged StringAttribute: value="checkout" found=true
```

That is exactly the parity bindweed and sage hand-rolled `mergeResourceOccurrences` for — *"Each occurrence must parse on its own, so a payload spliced across occurrences fails exactly like it does on the pdata path."* `validateMessageFraming` now checks each occurrence before joining. Structural only, allocation-free, and runs solely on the multi-occurrence path. Pinned by `TestResource_SplicedOccurrencesRejected`, with `TestResource_ValidOccurrencesStillMerge` guarding against over-strictness.

**The returned view was append-unsafe.** `protowire.ConsumeBytes` yields a slice whose capacity runs to the end of the container, so appending to the returned `Resource` grew in place and overwrote the sibling `scope_logs` field:

```
len=28 cap=30
before tail: 75741200
after  tail: 7574eeee   ← sibling field corrupted
```

Pre-existing for raw `[]byte` extraction, but this PR promotes the value to a named type with a documented zero-copy contract, which invites exactly that use. Returning `first[:n:n]` makes `append` reallocate. Asserted in `TestResource_SingleOccurrence_IsZeroCopy`.

## Performance — read this one

Merging requires scanning every top-level field instead of returning at the first match. **That is a complexity change, not a constant factor.** 11th Gen i7-11800H, linux/amd64, Go 1.25.12, paired against `8c0e9b4` in a detached worktree:

| scope entries in container | before | after |
|---:|---:|---:|
| 1 | 6.8 ns | 17.4 ns |
| 10 | 6.8 ns | 88.5 ns |
| 50 | 6.8 ns | 412 ns |

Zero-allocation at every size. The old path was O(1) in container size; this is O(number of top-level fields), roughly 8 ns per scope entry. Each skipped field is cheap — `ConsumeFieldValue` steps over the body without descending — so the walk covers tags, never payload.

Scanning fully is what pdata parity costs; a second occurrence cannot be ruled out without looking. Absolute numbers stay well under a microsecond for realistic containers, but consumers calling `Resource()` per container on every message (loam, fig, chaff) should see this. Pinned by `BenchmarkResource_ScanScaling` so a future regression is visible.

Multi-occurrence merge: ~205 ns (range 160–253 across 10 runs), 144 B, 2 allocs. Range rather than a median because it allocates and genuinely varies.

## Compatibility

Source-compatible despite the signature change — `type Resource []byte` is assignable to `[]byte`. Verified by building consumers against a patched local copy: **fig, marigold, gaps, dibber, overstory, bindweed, mulch and sage all build clean with no source changes**, including fig's `yield(rm.Resource())` multi-value call form. loam, chaff, seedtray and nameplate were inconclusive — they failed on a `go mod tidy` module-graph artifact of the local `replace`, not a compile error.

The breaking part is the `StringAttribute` removal, which has exactly one caller: mulch's `isProductionWire`. Migration is in the `BREAKING CHANGE:` footer.

Behavioral changes callers should know about:
- code relying on the absent-Resource error must check for a nil `Resource` instead — gaps' string-match becomes dead code and is safe to remove in either order
- a malformed field *after* the last Resource occurrence is now an error, where first-match-and-return never reached it

## Validation

```
gofmt -l .                            (clean)
go build ./...                        ok
go vet ./...                          ok
git diff --check                      ok
go test -race -shuffle=on -count=1    ok   1.030s
go test -run Example                  ok
```

`go mod tidy -diff` deliberately not run: CONTRIBUTING.md records that `go.sum` retains checksum history so it reports unrelated baseline drift.

Docs updated per the AGENTS.md validation matrix, which this change triggers on three rows at once (Public API, Iterator/parser, Performance): `example_test.go`, `README.md`, `docs/DESIGN.md`, `docs/specification.md`, `docs/BENCHMARKS.md`.

## Risks and rollout

Main risk is the scan-cost change above; it is bounded, measured, and zero-allocation. Merge semantics are the higher-blast-radius change but are covered by pdata differential fixtures for distinct keys, duplicate keys, 3+ occurrences, splices, empty and malformed occurrences, across all three signals.

Release as **v0.1.0** — the `StringAttribute` removal sets the boundary. Per `operations.md`: tag the exact merge SHA, then canary **mulch** (already on v0.0.4, actively maintained, the only consumer needing a source change) and compare equivalent pre/post windows for output parity, errors, throughput, backlog slope, CPU, allocations and GC before broader upgrades. Roll back to the previous module version on regression. Tracked in E-2949.

Supersedes #14 — same diagnosis, but it is `CONFLICTING`, patches the deleted `otlpwire.go`, carries a stale release plan, and covers only the absence facet.

Companion issues: E-2942 (scope/schema URL), E-2943 (metric metadata), E-2944 (severity text), E-2945 (span accessors), E-2946 (WriteTo short write), E-2947 (fig `IsValid` guard).

---

*Agent involvement, per CONTRIBUTING.md: implemented and reviewed with Claude Code. A Sonnet sub-agent produced the initial implementation; the splice-validation and capacity-clamp fixes, the scaling benchmark, and the doc corrections came from adversarial review of that work. All findings were reproduced against pdata before being acted on. A human maintainer should review the complete diff and take ownership before merge.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `Resource()` now returns a typed `Resource` for metrics, logs, and traces.
  * Repeated resource fields are merged automatically.
  * Missing resource fields are handled without errors.
  * Resource attributes can be retrieved through `Resource.StringAttribute`.

* **Breaking Changes**
  * Removed direct `ResourceLogs.StringAttribute`; use `Resource()` first.

* **Bug Fixes**
  * Improved validation and error reporting for malformed resource data.

* **Documentation**
  * Updated API guidance, migration examples, behavior details, and performance notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->