### PR TITLE
feat(scope)!: expose InstrumentationScope and SchemaUrl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,11 @@ before/after results under the same conditions.
 This is one package and one module, `go.olly.garden/otlp-wire`. Production
 code is split by domain: public types in `types.go`, signal traversal in
 `metrics.go`, `logs.go`, and `traces.go`, shared attribute semantics in
-`attributes.go`, and low-level protobuf walking in `wire.go`. Functional tests
-are in `otlpwire_test.go` and `log_iteration_test.go`, usage examples in
-`example_test.go`, and comparative benchmarks in
-`benchmark_comparison_test.go`.
+`attributes.go`, signal-generic instrumentation-scope accessors in `scope.go`,
+and low-level protobuf walking in `wire.go`. Functional tests are in
+`otlpwire_test.go`, `log_iteration_test.go`, `resource_test.go`, and
+`scope_test.go`, usage examples in `example_test.go`, and comparative
+benchmarks in `benchmark_comparison_test.go`.
 
 Public wire types are byte slices or small wrappers over byte slices. They
 navigate protobuf fields directly with `protowire.ConsumeTag`,
@@ -48,24 +49,33 @@ navigate protobuf fields directly with `protowire.ConsumeTag`,
 ```text
 ExportMetricsServiceRequest
 └── ResourceMetrics
+    ├── Resource
     └── ScopeMetrics
+        ├── InstrumentationScope
         └── Metric
             └── DataPoint
                 └── KeyValue
 
 ExportLogsServiceRequest
 └── ResourceLogs
+    ├── Resource
+    └── ScopeLogs
+        ├── InstrumentationScope
+        └── LogRecord
 
 ExportTracesServiceRequest
 └── ResourceSpans
+    ├── Resource
     └── ScopeSpans
+        ├── InstrumentationScope
         └── Span
 ```
 
 Field numbers and wire types must stay aligned with the upstream OTLP protobuf
 definitions. Shared helpers such as repeated-field counting/iteration, field
-skipping, resource extraction/writing, and fixed-byte extraction are the
-building blocks for new accessors.
+skipping, merged singular-message extraction, resource writing, and
+first-match, last-value-wins and fixed-byte extraction are the building blocks
+for new accessors.
 
 ## Iterator and error contracts
 
@@ -78,6 +88,14 @@ building blocks for new accessors.
   per-element allocation cost matters.
 - `DataPoint` carries `MetricType` because OTLP metric bodies use different
   field numbers for timestamps and attributes. Preserve that association.
+- A new accessor for a *singular* field must pick its resolution deliberately:
+  singular messages (`Resource`, `InstrumentationScope`) merge repeated
+  occurrences via `extractMergedMessage`; singular scalars (`SchemaUrl`,
+  scope `Name`/`Version`, `Metric.Name`) take the last occurrence via
+  `extractLastBytesField`. Both scan the whole message, so neither can return
+  early. `extractBytesField`'s first-match behavior is reserved for the
+  documented `KeyValue.Key`/`ValueRaw` hashing views. Verify the choice
+  against pdata's generated unmarshal — merge appends, replacement assigns.
 - Malformed tags, lengths, wire types, identifiers, metric bodies, or nested
   messages must return parse errors. Never silently accept corruption to keep
   an iterator moving.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,13 +89,10 @@ for new accessors.
 - `DataPoint` carries `MetricType` because OTLP metric bodies use different
   field numbers for timestamps and attributes. Preserve that association.
 - A new accessor for a *singular* field must pick its resolution deliberately:
-  singular messages (`Resource`, `InstrumentationScope`) merge repeated
-  occurrences via `extractMergedMessage`; singular scalars (`SchemaUrl`,
-  scope `Name`/`Version`, `Metric.Name`) take the last occurrence via
-  `extractLastBytesField`. Both scan the whole message, so neither can return
-  early. `extractBytesField`'s first-match behavior is reserved for the
-  documented `KeyValue.Key`/`ValueRaw` hashing views. Verify the choice
-  against pdata's generated unmarshal — merge appends, replacement assigns.
+  merge (`extractMergedMessage`) for messages, last-value-wins
+  (`extractLastBytesField`) for scalars. Verify the choice against pdata's
+  generated unmarshal — merge appends, replacement assigns. See "Singular
+  field resolution" in [docs/DESIGN.md](docs/DESIGN.md).
 - Malformed tags, lengths, wire types, identifiers, metric bodies, or nested
   messages must return parse errors. Never silently accept corruption to keep
   an iterator moving.

--- a/README.md
+++ b/README.md
@@ -299,18 +299,11 @@ name, err := scope.Name()
 ```
 
 **Repeated fields resolve two different ways**, matching protobuf and pdata:
-
-- **Singular *messages*** — `Resource()`, `Scope()` — **merge**. pdata unmarshals
-  every occurrence into the same object, so their contents accumulate.
-- **Singular *scalars*** — `SchemaUrl()`, `InstrumentationScope.Name()` and
-  `Version()`, `Metric.Name()` — **resolve to the last occurrence**. pdata
-  assigns on each one, so a later occurrence replaces an earlier one.
-
-Honoring the scalar rule means these accessors scan the whole enclosing
-message instead of returning at the first match, so corruption after the last
-occurrence is reported as an error. `KeyValue.Key` and `KeyValue.ValueRaw`
-are deliberately exempt: they remain lightweight first-match views for hashing
-hot paths (see [docs/DESIGN.md](docs/DESIGN.md)).
+singular *messages* (`Resource()`, `Scope()`) merge, while singular *scalars*
+(`SchemaUrl()`, `InstrumentationScope.Name()` and `Version()`, `Metric.Name()`)
+resolve to the last occurrence. `KeyValue.Key` and `KeyValue.ValueRaw` are
+deliberately exempt and stay first-match for hashing hot paths.
+[docs/DESIGN.md](docs/DESIGN.md) explains why.
 
 `KeyValue.ValueRaw` remains a lightweight view of the first encoded AnyValue
 field for hashing-oriented hot paths. `KeyValue.StringValue` fully parses

--- a/README.md
+++ b/README.md
@@ -102,7 +102,11 @@ See [example_test.go](example_test.go) for complete working examples.
 ```
 ExportMetricsServiceRequest (OTLP message bytes)
   └─ ResourceMetrics[] (one per resource)
+       ├─ Resource()   (exactly one, merged)
+       ├─ SchemaUrl()
        └─ ScopeMetrics[] (one per instrumentation scope)
+            ├─ Scope()      (exactly one, merged)
+            ├─ SchemaUrl()
             └─ Metric[] (individual metrics)
                  ├─ Name()
                  └─ DataPoint[] (one per data point, any metric type)
@@ -114,17 +118,30 @@ ExportMetricsServiceRequest (OTLP message bytes)
 
 ExportLogsServiceRequest (OTLP message bytes)
   └─ ResourceLogs[] (one per resource)
+       ├─ Resource()   (exactly one, merged)
+       ├─ SchemaUrl()
        └─ ScopeLogs[] (one per instrumentation scope)
+            ├─ Scope()      (exactly one, merged)
+            ├─ SchemaUrl()
             └─ LogRecord[]
                  └─ SeverityNumber()
 
 ExportTracesServiceRequest (OTLP message bytes)
   └─ ResourceSpans[] (one per resource)
+       ├─ Resource()   (exactly one, merged)
+       ├─ SchemaUrl()
        └─ ScopeSpans[] (one per instrumentation scope)
+            ├─ Scope()      (exactly one, merged)
+            ├─ SchemaUrl()
             └─ Span[] (individual spans)
                  ├─ TraceID()
                  ├─ SpanID()
                  └─ ParentSpanID()
+
+InstrumentationScope (from any Scope())
+  ├─ Name()
+  ├─ Version()
+  └─ KeyValue[] (attributes)
 ```
 
 ### Methods
@@ -149,25 +166,39 @@ func (t ExportTracesServiceRequest) ResourceSpans() (iter.Seq[ResourceSpans], fu
 type ResourceMetrics []byte
 func (r ResourceMetrics) DataPointCount() (int, error)
 func (r ResourceMetrics) Resource() (Resource, error)
+func (r ResourceMetrics) SchemaUrl() ([]byte, error)
 func (r ResourceMetrics) WriteTo(w io.Writer) (int64, error)
 
 type ResourceLogs []byte
 func (r ResourceLogs) LogRecordCount() (int, error)
 func (r ResourceLogs) Resource() (Resource, error)
+func (r ResourceLogs) SchemaUrl() ([]byte, error)
 func (r ResourceLogs) WriteTo(w io.Writer) (int64, error)
 func (r ResourceLogs) ScopeLogs() (iter.Seq[ScopeLogs], func() error)
 
 type ResourceSpans []byte
 func (r ResourceSpans) SpanCount() (int, error)
 func (r ResourceSpans) Resource() (Resource, error)
+func (r ResourceSpans) SchemaUrl() ([]byte, error)
 func (r ResourceSpans) WriteTo(w io.Writer) (int64, error)
 func (r ResourceSpans) ScopeSpans() (iter.Seq[ScopeSpans], func() error)
+```
+
+**Instrumentation scope (all three signals):**
+```go
+type InstrumentationScope []byte
+func (s InstrumentationScope) Name() ([]byte, error)
+func (s InstrumentationScope) Version() ([]byte, error)
+func (s InstrumentationScope) Attributes() (iter.Seq[KeyValue], func() error)
+func (s InstrumentationScope) AttributesSeq(yield func(KeyValue, error) bool)
 ```
 
 **Scope-level operations (traces):**
 ```go
 type ScopeSpans []byte
 func (s ScopeSpans) SpanCount() (int, error)
+func (s ScopeSpans) Scope() (InstrumentationScope, error)
+func (s ScopeSpans) SchemaUrl() ([]byte, error)
 func (s ScopeSpans) Spans() (iter.Seq[Span], func() error)
 ```
 
@@ -182,6 +213,8 @@ func (s Span) ParentSpanID() ([8]byte, error)
 **Scope- and metric-level operations (metrics depth):**
 ```go
 type ScopeMetrics []byte
+func (s ScopeMetrics) Scope() (InstrumentationScope, error)
+func (s ScopeMetrics) SchemaUrl() ([]byte, error)
 func (s ScopeMetrics) Metrics() (iter.Seq[Metric], func() error)
 
 type Metric []byte
@@ -214,6 +247,8 @@ const (
 **Log-level operations and resource attributes:**
 ```go
 type ScopeLogs []byte
+func (s ScopeLogs) Scope() (InstrumentationScope, error)
+func (s ScopeLogs) SchemaUrl() ([]byte, error)
 func (s ScopeLogs) LogRecords() (iter.Seq[LogRecord], func() error) // ergonomic, 2 allocs per open
 func (s ScopeLogs) LogRecordsSeq(yield func(LogRecord, error) bool) // zero-alloc, range directly
 
@@ -247,6 +282,35 @@ if err != nil {
 }
 value, found, err := resource.StringAttribute("service.name")
 ```
+
+Scope containers work the same way: `ScopeMetrics`, `ScopeLogs`, and
+`ScopeSpans` each have exactly one `InstrumentationScope`, reached with
+`Scope()`. It is absence-tolerant, zero-copy for the single occurrence real
+producers emit, and merges 2+ occurrences, exactly as `Resource()` does. Note
+that scope attributes are field 3 of `InstrumentationScope`, whereas resource
+attributes are field 1 — the accessors hide that difference:
+
+```go
+scope, err := scopeLogs.Scope()
+if err != nil {
+    return err
+}
+name, err := scope.Name()
+```
+
+**Repeated fields resolve two different ways**, matching protobuf and pdata:
+
+- **Singular *messages*** — `Resource()`, `Scope()` — **merge**. pdata unmarshals
+  every occurrence into the same object, so their contents accumulate.
+- **Singular *scalars*** — `SchemaUrl()`, `InstrumentationScope.Name()` and
+  `Version()`, `Metric.Name()` — **resolve to the last occurrence**. pdata
+  assigns on each one, so a later occurrence replaces an earlier one.
+
+Honoring the scalar rule means these accessors scan the whole enclosing
+message instead of returning at the first match, so corruption after the last
+occurrence is reported as an error. `KeyValue.Key` and `KeyValue.ValueRaw`
+are deliberately exempt: they remain lightweight first-match views for hashing
+hot paths (see [docs/DESIGN.md](docs/DESIGN.md)).
 
 `KeyValue.ValueRaw` remains a lightweight view of the first encoded AnyValue
 field for hashing-oriented hot paths. `KeyValue.StringValue` fully parses

--- a/attributes.go
+++ b/attributes.go
@@ -327,7 +327,7 @@ type resourceStringAttributeState struct {
 // scanResourceStringAttribute validates a complete Resource message and
 // records the first matching attribute only. pdata's resource map keeps that
 // first duplicate key. When the caller's Resource value came from merging 2+
-// wire occurrences (see extractResourceMessage), the merged bytes already
+// wire occurrences (see extractMergedMessage), the merged bytes already
 // hold every occurrence's attributes concatenated in wire order, so this
 // single pass reproduces the merge's first-value-wins behavior without any
 // extra merge-aware logic here.

--- a/attributes.go
+++ b/attributes.go
@@ -32,6 +32,22 @@ func (kv KeyValue) StringValue() ([]byte, bool, error) {
 	return value.stringValue, true, nil
 }
 
+// keyValueSeq walks the repeated KeyValue field at fieldNum, yielding each
+// element inline. It backs every AttributesSeq method; the field number
+// differs per container (Resource 1, InstrumentationScope 3, and per
+// data-point type for DataPoint). On a parse error it yields a nil KeyValue
+// with a non-nil error and stops. Nothing escapes, so iterating allocates
+// nothing.
+func keyValueSeq(data []byte, fieldNum protowire.Number, yield func(KeyValue, error) bool) {
+	forEachRepeatedField(data, fieldNum, func(rb []byte, err error) bool {
+		if err != nil {
+			yield(nil, err)
+			return false
+		}
+		return yield(KeyValue(rb), nil)
+	})
+}
+
 // Attributes returns an iterator over the Resource's attribute KeyValues.
 // The returned function should be called after iteration to check for errors.
 func (r Resource) Attributes() (iter.Seq[KeyValue], func() error) {
@@ -43,13 +59,7 @@ func (r Resource) Attributes() (iter.Seq[KeyValue], func() error) {
 // directly. On a parse error it yields a nil KeyValue with a non-nil error and
 // stops.
 func (r Resource) AttributesSeq(yield func(KeyValue, error) bool) {
-	forEachRepeatedField([]byte(r), 1, func(rb []byte, err error) bool {
-		if err != nil {
-			yield(nil, err)
-			return false
-		}
-		return yield(KeyValue(rb), nil)
-	})
+	keyValueSeq([]byte(r), 1, yield)
 }
 
 // StringAttribute returns the string value of the first resource attribute

--- a/benchmark_comparison_test.go
+++ b/benchmark_comparison_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -1054,5 +1055,194 @@ func BenchmarkResource_ScanScaling(b *testing.B) {
 				_, _ = rm.Resource()
 			}
 		})
+	}
+}
+
+// ========== Scope and schema_url (E-2942) ==========
+
+// scopeContainerWithRecords builds a ScopeLogs carrying one scope (field 1),
+// n log records (field 2), and a schema_url (field 3). The scope and
+// schema_url accessors must scan past every record to honor merge and
+// last-value-wins semantics, so this fixture exposes that cost.
+func scopeContainerWithRecords(n int) []byte {
+	scope := scopeMessage("checkout-instr", "1.2.3")
+	out := protowire.AppendTag(nil, 1, protowire.BytesType)
+	out = protowire.AppendVarint(out, uint64(len(scope)))
+	out = append(out, scope...)
+
+	record := make([]byte, 64)
+	for i := 0; i < n; i++ {
+		out = protowire.AppendTag(out, 2, protowire.BytesType)
+		out = protowire.AppendVarint(out, uint64(len(record)))
+		out = append(out, record...)
+	}
+
+	out = protowire.AppendTag(out, 3, protowire.BytesType)
+	return protowire.AppendString(out, "https://example.test/schema/v1")
+}
+
+// BenchmarkScope_SingleOccurrence is the hot path: one scope occurrence
+// returns a slice aliasing the input, with no allocation.
+func BenchmarkScope_SingleOccurrence(b *testing.B) {
+	sm := ScopeMetrics(scopeContainer(scopeMessage("checkout-instr", "1.2.3")))
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = sm.Scope()
+	}
+}
+
+// BenchmarkScope_MultipleOccurrences is the paired benchmark for the
+// documented exception: 2+ occurrences concatenate into a new buffer.
+func BenchmarkScope_MultipleOccurrences(b *testing.B) {
+	sm := ScopeMetrics(scopeContainer(
+		scopeMessage("checkout-instr", ""),
+		scopeMessage("", "1.2.3"),
+		scopeWithStringAttr("library.language", "go"),
+	))
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = sm.Scope()
+	}
+}
+
+// minimalScopeRequest builds an ExportLogsServiceRequest carrying exactly one
+// resource, one scope container and one populated scope, so the paired
+// benchmarks below compare scope access against decoding the same bytes.
+func minimalScopeRequest() []byte {
+	sc := scopeContainer(append(
+		scopeMessage("checkout-instr", "1.2.3"),
+		scopeWithStringAttr("library.language", "go")...))
+	return wrapAsRequest(resourceContainerWithScope(sc))
+}
+
+// BenchmarkScope_NameVersion_WireFormat reads scope name and version straight
+// from the wire. Paired with BenchmarkScope_NameVersion_Unmarshal.
+func BenchmarkScope_NameVersion_WireFormat(b *testing.B) {
+	payload := minimalScopeRequest()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		resources, resErr := ExportLogsServiceRequest(payload).ResourceLogs()
+		for rl := range resources {
+			scopes, scopeErr := rl.ScopeLogs()
+			for sl := range scopes {
+				scope, err := sl.Scope()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err := scope.Name(); err != nil {
+					b.Fatal(err)
+				}
+				if _, err := scope.Version(); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := scopeErr(); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := resErr(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkScope_NameVersion_Unmarshal is the full-decode baseline for the
+// same bytes. It stands in for the consumer code this API replaces (dibber
+// unmarshals a generated InstrumentationScope per scope; sage strict-parses
+// one per occurrence); it is not those implementations verbatim, since
+// replicating them would add a production proto module as a dependency.
+func BenchmarkScope_NameVersion_Unmarshal(b *testing.B) {
+	payload := minimalScopeRequest()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		req := plogotlp.NewExportRequest()
+		if err := req.UnmarshalProto(payload); err != nil {
+			b.Fatal(err)
+		}
+		logs := req.Logs()
+		for r := 0; r < logs.ResourceLogs().Len(); r++ {
+			rl := logs.ResourceLogs().At(r)
+			for s := 0; s < rl.ScopeLogs().Len(); s++ {
+				scope := rl.ScopeLogs().At(s).Scope()
+				_, _ = scope.Name(), scope.Version()
+			}
+		}
+	}
+}
+
+// BenchmarkScope_ScanScaling pins the complexity of Scope(): merging requires
+// scanning every top-level field, so cost grows with the record count rather
+// than staying constant. This matters more than the Resource equivalent
+// because a scope container holds records, not scopes. Backs the scaling
+// table in docs/BENCHMARKS.md.
+func BenchmarkScope_ScanScaling(b *testing.B) {
+	for _, records := range []int{1, 100, 1000} {
+		b.Run(fmt.Sprintf("records=%d", records), func(b *testing.B) {
+			sl := ScopeLogs(scopeContainerWithRecords(records))
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = sl.Scope()
+			}
+		})
+	}
+}
+
+// BenchmarkSchemaUrl_ScanScaling pins the same cost for the scalar accessor,
+// which must reach the last occurrence and therefore cannot stop early.
+func BenchmarkSchemaUrl_ScanScaling(b *testing.B) {
+	for _, records := range []int{1, 100, 1000} {
+		b.Run(fmt.Sprintf("records=%d", records), func(b *testing.B) {
+			sl := ScopeLogs(scopeContainerWithRecords(records))
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = sl.SchemaUrl()
+			}
+		})
+	}
+}
+
+// BenchmarkMetric_Name covers the accessor changed from first-match to
+// last-value-wins, which turned an early return into a full scan of the
+// metric's top-level fields. Compare against the same benchmark on main.
+func BenchmarkMetric_Name(b *testing.B) {
+	metrics := createScrapeShapedMetrics()
+	marshaler := &pmetric.ProtoMarshaler{}
+	payload, err := marshaler.MarshalMetrics(metrics)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		resources, resErr := ExportMetricsServiceRequest(payload).ResourceMetrics()
+		for rm := range resources {
+			scopes, scopeErr := rm.ScopeMetrics()
+			for sm := range scopes {
+				ms, mErr := sm.Metrics()
+				for m := range ms {
+					if _, err := m.Name(); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := mErr(); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := scopeErr(); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := resErr(); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/benchmark_comparison_test.go
+++ b/benchmark_comparison_test.go
@@ -2,6 +2,7 @@ package otlpwire
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1070,7 +1071,17 @@ func scopeContainerWithRecords(n int) []byte {
 	out = protowire.AppendVarint(out, uint64(len(scope)))
 	out = append(out, scope...)
 
-	record := make([]byte, 64)
+	// A valid, decodable LogRecord body of a pinned size. The accessors under
+	// test never look inside a record — they read its tag and length and step
+	// over it — but an undecodable filler would be a trap for anyone who later
+	// makes this fixture do more. 64 bytes matches containerWithScopes above,
+	// so the two scaling benchmarks stay comparable.
+	record := protowire.AppendTag(nil, 5, protowire.BytesType) // LogRecord.body
+	body := protowire.AppendTag(nil, 1, protowire.BytesType)   // AnyValue.string_value
+	body = protowire.AppendString(body, strings.Repeat("x", 60))
+	record = protowire.AppendVarint(record, uint64(len(body)))
+	record = append(record, body...)
+
 	for i := 0; i < n; i++ {
 		out = protowire.AppendTag(out, 2, protowire.BytesType)
 		out = protowire.AppendVarint(out, uint64(len(record)))

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -237,6 +237,116 @@ machine; this machine's absolute numbers differ from the Apple M4 figures
 recorded for this benchmark above since they are different hardware, but the
 before/after comparison on identical hardware is what matters here).
 
+## Scope, schema_url and Metric.Name (E-2942)
+
+E-2942 added `Scope()` and `SchemaUrl()` across all six containers, plus
+`InstrumentationScope` accessors, and changed `Metric.Name()` from
+first-match to protobuf singular-scalar (last-value-wins) resolution. Both
+new resolutions must scan the whole enclosing message, so these benchmarks
+quantify that scan and confirm the zero-allocation gates still hold.
+
+**Environment:** 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz, linux/amd64,
+Go 1.25.12. `Metric.Name` was compared against the identical benchmark with
+only the accessor body reverted to `extractBytesField`, so the two sides run
+the same fixture and harness on the same machine in the same session.
+
+**Commands:**
+
+```bash
+go test -run '^$' -bench 'BenchmarkScope_(SingleOccurrence|MultipleOccurrences|NameVersion_WireFormat|NameVersion_Unmarshal)$' -benchmem -count=10 ./...
+go test -run '^$' -bench 'ScanScaling' -benchmem -count=5 ./...
+go test -run '^$' -bench 'BenchmarkMetric_Name$' -benchmem -count=6 ./...
+```
+
+### Scope access versus full decode
+
+**Fixture:** an `ExportLogsServiceRequest` holding one resource container, one
+scope container and one populated scope (name, version, one attribute), built
+with `protowire`. The wire side opens both closure-based iterators and reads
+name and version; the baseline unmarshals the same bytes with
+`plogotlp.ExportRequest` and reads the same two fields. Medians of 10 runs.
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---:|---:|---:|
+| `BenchmarkScope_NameVersion_WireFormat` | 221 | 72 | 4 |
+| `BenchmarkScope_NameVersion_Unmarshal` | 501 | 360 | 10 |
+| `BenchmarkScope_SingleOccurrence` (accessor alone) | 11.2 | 0 | 0 |
+| `BenchmarkScope_MultipleOccurrences` (3 occurrences, merges) | 187 | 112 | 2 |
+
+The four allocations on the wire side are the two closure-based iterators
+being opened, not `Scope()` — the accessor itself is zero-allocation, as the
+single-occurrence row shows.
+
+**What this comparison does and does not prove.** The baseline is a full pdata
+decode of the same bytes. It stands in for the consumer code this API replaces
+— dibber unmarshals a generated `InstrumentationScope` per scope, sage
+strict-parses one per occurrence — but it is not either implementation
+verbatim. Reproducing them exactly would mean adding `go.opentelemetry.io/proto/otlp`
+as a dependency of a public library purely for a benchmark, which was judged
+not worth the supply-chain surface. Treat these numbers as the order of
+magnitude, and validate the real saving in the consumer migrations, which are
+tracked separately.
+
+### Scan cost scales with the container
+
+Merging must find every occurrence and last-value-wins must reach the final
+one, so neither accessor can stop early. Cost therefore grows with the number
+of sibling fields. This matters more here than for `Resource()`: a resource
+container holds a handful of scopes, whereas a scope container holds every
+record. One scope, then *n* 64-byte log records, then a `schema_url`; medians
+of 5 runs.
+
+| records | `ScopeLogs.Scope()` | `ScopeLogs.SchemaUrl()` |
+|---:|---:|---:|
+| 1 | 34.4 ns | 30.4 ns |
+| 100 | 1106 ns | 1021 ns |
+| 1000 | 10636 ns | 9054 ns |
+
+Both remain 0 B/op, 0 allocs/op at every size.
+
+Findings:
+
+- **Roughly 10 ns per skipped record**, allocation-free. A consumer that reads
+  the scope and then iterates the records pays this as a constant factor on a
+  walk it was already doing.
+- **A consumer that reads only the scope and stops early pays the most.**
+  dibber's `scopeFromContainer` returns at the first scope occurrence with a
+  non-empty name and never touches the records; `Scope()` cannot, because
+  proving no later occurrence exists requires reaching the end. That is the
+  price of pdata parity, and it is the same trade already accepted for
+  `Resource()` in E-2941.
+- Each skipped field is still cheap: `protowire.ConsumeFieldValue` reads the
+  length prefix and steps over the body without descending. Growth is in the
+  number of tags, not their size.
+
+### `Metric.Name` — first-match to last-value-wins
+
+**Fixture:** the E-2608 scrape shape (one resource, one scope, 4800 metrics
+with one datapoint each), iterating every metric and reading its name.
+Medians of 6 runs.
+
+| Revision | ns/op | B/op | allocs/op |
+|---|---:|---:|---:|
+| first-match (previous) | 118,496 | 112 | 6 |
+| last-value-wins (this change) | 121,909 | 112 | 6 |
+
+About 3% slower across 4800 metrics — roughly 0.7 ns more per metric — with
+allocations unchanged. A `Metric`'s top-level fields are its name,
+description, unit and one oneof body, so the added scan skips a handful of
+tags and never descends into the datapoints. The correctness reason for the
+change is in [DESIGN.md](DESIGN.md); this measures what it cost.
+
+### Gates unchanged
+
+`BenchmarkResource_SingleOccurrence`, `BenchmarkResource_MultipleOccurrences`,
+`BenchmarkResource_ScanScaling` and `BenchmarkMetrics_Count_WireFormat` were
+re-run on this branch against `main` in a worktree on the same machine.
+Counting stays 0 B/op, 0 allocs/op; `Resource()` keeps its zero-allocation
+single-occurrence path and its 144 B / 2 allocs merge path. Timing
+differences were within run-to-run noise on this machine, which is why no
+before/after table is given for them — generalizing `extractResourceMessage`
+into `extractMergedMessage` added a field-number parameter and no work.
+
 ---
 
 ## Implementation Details

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -268,10 +268,10 @@ name and version; the baseline unmarshals the same bytes with
 
 | Benchmark | ns/op | B/op | allocs/op |
 |---|---:|---:|---:|
-| `BenchmarkScope_NameVersion_WireFormat` | 221 | 72 | 4 |
-| `BenchmarkScope_NameVersion_Unmarshal` | 501 | 360 | 10 |
-| `BenchmarkScope_SingleOccurrence` (accessor alone) | 11.2 | 0 | 0 |
-| `BenchmarkScope_MultipleOccurrences` (3 occurrences, merges) | 187 | 112 | 2 |
+| `BenchmarkScope_NameVersion_WireFormat` | 194 | 72 | 4 |
+| `BenchmarkScope_NameVersion_Unmarshal` | 441 | 360 | 10 |
+| `BenchmarkScope_SingleOccurrence` (accessor alone) | 9.5 | 0 | 0 |
+| `BenchmarkScope_MultipleOccurrences` (3 occurrences, merges) | 141 | 112 | 2 |
 
 The four allocations on the wire side are the two closure-based iterators
 being opened, not `Scope()` — the accessor itself is zero-allocation, as the
@@ -298,15 +298,15 @@ of 5 runs.
 
 | records | `ScopeLogs.Scope()` | `ScopeLogs.SchemaUrl()` |
 |---:|---:|---:|
-| 1 | 34.4 ns | 30.4 ns |
-| 100 | 1106 ns | 1021 ns |
-| 1000 | 10636 ns | 9054 ns |
+| 1 | 26.3 ns | 26.2 ns |
+| 100 | 847 ns | 766 ns |
+| 1000 | 8146 ns | 7545 ns |
 
 Both remain 0 B/op, 0 allocs/op at every size.
 
 Findings:
 
-- **Roughly 10 ns per skipped record**, allocation-free. A consumer that reads
+- **Roughly 8 ns per skipped record**, allocation-free. A consumer that reads
   the scope and then iterates the records pays this as a constant factor on a
   walk it was already doing.
 - **A consumer that reads only the scope and stops early pays the most.**
@@ -322,19 +322,34 @@ Findings:
 ### `Metric.Name` — first-match to last-value-wins
 
 **Fixture:** the E-2608 scrape shape (one resource, one scope, 4800 metrics
-with one datapoint each), iterating every metric and reading its name.
-Medians of 6 runs.
+with one datapoint each), iterating every metric and reading its name. The two
+revisions differ only in `Metric.Name`'s body; everything else, including the
+capacity clamp in `forEachRepeatedField`, is identical. Measured by
+alternating the two builds (two rounds, `-count=6` each) rather than running
+one after the other, because a single sequential pair on this machine drifts
+enough to understate the gap.
 
-| Revision | ns/op | B/op | allocs/op |
+| Revision | ns/op (round 1, round 2) | B/op | allocs/op |
 |---|---:|---:|---:|
-| first-match (previous) | 118,496 | 112 | 6 |
-| last-value-wins (this change) | 121,909 | 112 | 6 |
+| first-match (previous) | 116,093 / 115,150 | 112 | 6 |
+| last-value-wins (this change) | 129,147 / 130,234 | 112 | 6 |
 
-About 3% slower across 4800 metrics — roughly 0.7 ns more per metric — with
-allocations unchanged. A `Metric`'s top-level fields are its name,
-description, unit and one oneof body, so the added scan skips a handful of
-tags and never descends into the datapoints. The correctness reason for the
-change is in [DESIGN.md](DESIGN.md); this measures what it cost.
+About **12% slower** across 4800 metrics — roughly 2.9 ns more per metric —
+with allocations unchanged. The observed ranges do not overlap, so the gap is
+real rather than noise.
+
+The cost is bounded and does not scale with payload size: a `Metric`'s
+top-level fields are its name, description, unit, one oneof body and optional
+metadata, and `protowire.ConsumeFieldValue` on the length-delimited body reads
+its length prefix and steps over it without descending into the datapoints.
+What the scan buys is pdata parity on a repeated `name`; what it costs is the
+early return. A consumer reading names across millions of metrics per scrape
+should weigh that 12% deliberately — it is the largest single regression in
+this change. The correctness reason is in [DESIGN.md](DESIGN.md).
+
+An earlier revision of this section reported ~3% from a non-interleaved
+measurement taken while the machine was under other load. The figures above
+supersede it.
 
 ### Gates unchanged
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -239,8 +239,9 @@ before/after comparison on identical hardware is what matters here).
 
 ## Scope, schema_url and Metric.Name (E-2942)
 
-E-2942 added `Scope()` and `SchemaUrl()` across all six containers, plus
-`InstrumentationScope` accessors, and changed `Metric.Name()` from
+E-2942 added `Scope()` to `ScopeMetrics`, `ScopeLogs` and `ScopeSpans`,
+`SchemaUrl()` to all six containers, and the `InstrumentationScope`
+accessors. It also changed `Metric.Name()` from
 first-match to protobuf singular-scalar (last-value-wins) resolution. Both
 new resolutions must scan the whole enclosing message, so these benchmarks
 quantify that scan and confirm the zero-allocation gates still hold.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -32,6 +32,7 @@ ExportMetricsServiceRequest
 └── ResourceMetrics
     ├── Resource
     └── ScopeMetrics
+        ├── InstrumentationScope
         └── Metric
             └── DataPoint
                 └── KeyValue
@@ -40,17 +41,19 @@ ExportLogsServiceRequest
 └── ResourceLogs
     ├── Resource
     └── ScopeLogs
+        ├── InstrumentationScope
         └── LogRecord
 
 ExportTracesServiceRequest
 └── ResourceSpans
     ├── Resource
     └── ScopeSpans
+        ├── InstrumentationScope
         └── Span
 ```
 
-Request, resource, scope, record, span, metric, Resource and KeyValue types are
-named byte slices. They are cheap to construct and make zero-copy ownership
+Request, resource, scope, record, span, metric, Resource, InstrumentationScope
+and KeyValue types are named byte slices. They are cheap to construct and make zero-copy ownership
 visible. `DataPoint` is a small struct because it must retain the metric body
 type that identifies the body and determines its attribute layout.
 
@@ -61,8 +64,9 @@ Parsing composes a small set of helpers around
 
 - repeated-field counting;
 - repeated-field iteration;
-- length-delimited, fixed-width and scalar extraction;
-- resource extraction and re-wrapping;
+- length-delimited, fixed-width and scalar extraction, in first-match and
+  last-value-wins forms;
+- merged singular-message extraction and resource re-wrapping;
 - field skipping with matching-group validation;
 - bounded semantic parsing for KeyValue, AnyValue, Resource and LogRecord.
 
@@ -143,31 +147,49 @@ count spans, and extract the three fixed-width identifiers used by partial
 trace detectors. Identifier accessors return arrays to make the required width
 part of the Go type and reject incorrectly sized wire values.
 
-## Resource extraction and `WriteTo`
+## Singular field resolution
 
-Resource containers share the same outer protobuf shape across metrics, logs
-and traces: Resource is field 1, the repeated scope container is field 2, and
-the export request repeats resource containers in field 1.
+All six containers share one outer protobuf shape. In a resource container
+(`ResourceMetrics`/`ResourceLogs`/`ResourceSpans`) field 1 is the Resource;
+in a scope container (`ScopeMetrics`/`ScopeLogs`/`ScopeSpans`) field 1 is the
+InstrumentationScope. In both, field 2 repeats the children and field 3 is
+`schema_url`.
 
-The three `Resource()` methods therefore share one extractor,
-`extractResourceMessage`. Its contract, decided for E-2941:
+Protobuf resolves a repeated occurrence of a *singular* field two different
+ways, and pdata implements both, so otlp-wire must distinguish them:
 
-- **Absence is not an error.** OTLP declares the Resource field optional, and
-  pdata accepts a container without it, reporting an empty Resource. The
+- a singular **message** merges — pdata unmarshals every occurrence into the
+  same object, so contents accumulate;
+- a singular **scalar** is replaced — pdata assigns
+  (`orig.SchemaUrl = string(...)`), so the last occurrence wins.
+
+Getting this wrong is invisible on well-formed input from a normal producer
+and wrong on everything else, which is exactly the class of divergence E-2940
+exists to close.
+
+### Singular messages: merged (`Resource`, `InstrumentationScope`)
+
+The three `Resource()` and three `Scope()` methods share one extractor,
+`extractMergedMessage`. Its contract, decided for E-2941 and generalized to
+scope in E-2942:
+
+- **Absence is not an error.** OTLP declares both fields optional, and pdata
+  accepts a container without them, reporting an empty message. The
   extractor returns `(nil, nil)` for absence, matching the convention already
   used by `extractBytesField`, `extractFixed64Field`, and
   `extractFixedBytesField` elsewhere in `wire.go`. A malformed occurrence
   (wrong wire type, bad length) is still an error.
-- **Exactly one Resource, merged.** `ResourceMetrics`/`ResourceLogs`/
-  `ResourceSpans` have exactly one pdata-visible Resource, matching pdata's
-  object model. Protobuf merges repeated occurrences of a singular message
-  field, and pdata performs that merge, so `Resource()` does too instead of
-  returning only the first occurrence (the pre-E-2941 behavior).
-- **Zero-copy for the case that matters.** A single Resource occurrence is
-  what every real producer emits. That case returns a slice aliasing the
+- **Exactly one, merged.** Each container has exactly one pdata-visible
+  Resource or scope, matching pdata's object model. Protobuf merges repeated
+  occurrences of a singular message field, and pdata performs that merge, so
+  the accessors do too instead of returning only the first occurrence (the
+  pre-E-2941 behavior).
+- **Zero-copy for the case that matters.** A single occurrence is what every
+  real producer emits. That case returns a slice aliasing the
   input, with no allocation — this is a hard performance gate, verified by
-  `testing.AllocsPerRun` in `resource_test.go` and by
-  `BenchmarkResource_SingleOccurrence`. Two or more occurrences are merged by
+  `testing.AllocsPerRun` in `resource_test.go` and `scope_test.go` and by
+  `BenchmarkResource_SingleOccurrence` and `BenchmarkScope_SingleOccurrence`.
+  Two or more occurrences are merged by
   concatenating their encoded bodies into one new buffer. Concatenation was
   verified byte-equivalent to protobuf's field-by-field merge for singular
   message fields (distinct keys, duplicate keys, 3+ occurrences), so it
@@ -185,25 +207,53 @@ The three `Resource()` methods therefore share one extractor,
   the pdata fallback refuses. `validateMessageFraming` therefore walks each
   occurrence first. It is structural only and allocation-free, and it runs
   exclusively on the multi-occurrence path, so the single-occurrence hot path
-  keeps its measured cost. `TestResource_SplicedOccurrencesRejected` pins the
-  behavior against pdata; `TestResource_ValidOccurrencesStillMerge` guards
-  against it becoming over-strict.
+  keeps its measured cost. `TestResource_SplicedOccurrencesRejected` and
+  `TestScope_SplicedOccurrencesRejected` pin the behavior against pdata;
+  the `ValidOccurrencesStillMerge` tests guard against it becoming
+  over-strict.
 
-**Validation-scope change.** Finding every occurrence to merge correctly
-requires scanning the complete container, so `extractResourceMessage` can no
-longer return as soon as it finds the first Resource field the way the
-pre-E-2941 version did (and the way the other single-field extractors in
-`wire.go` still do for fields that do not merge). One consequence: a
-malformed field located *after* the last Resource occurrence in the container
-is now reported as an error, where the shallow, first-match extractor never
-reached it. This is an intentional, narrow expansion of validation scope for
-this one accessor — see the "Resources and attributes" section of
+### Singular scalars: last occurrence wins
+
+`SchemaUrl`, `InstrumentationScope.Name`, `InstrumentationScope.Version` and
+`Metric.Name` share `extractLastBytesField`. Because a later occurrence
+replaces an earlier one, the extractor cannot stop at the first match; it
+records the most recent occurrence and returns after the walk completes.
+
+`Metric.Name` returned the first occurrence before E-2942. That was a
+divergence from pdata of the same kind E-2941 fixed for `Resource()`, so it
+was corrected here rather than left to differ from the new accessors beside
+it.
+
+`KeyValue.Key` and `KeyValue.ValueRaw` deliberately keep first-match
+semantics via `extractBytesField`. They are the lightweight views described
+under "Error and compatibility strategy": per-attribute hot paths that hash
+encoded bytes and never needed pdata-equivalent scalar resolution. Their
+divergence is intentional and documented rather than latent.
+
+**Validation-scope change.** Both resolutions need the complete message:
+merging must find every occurrence, and last-value-wins must reach the final
+one. Neither `extractMergedMessage` nor `extractLastBytesField` can return
+early the way `extractBytesField` still does. One consequence: a malformed
+field located *after* the last relevant occurrence is now reported as an
+error, where a shallow first-match extractor never reached it. This is an
+intentional, narrow expansion of validation scope for these accessors — see
+the "Resources and attributes" section of
 [specification.md](specification.md) — not a general change to the "iterators
-validate operation-scoped" contract. The added scan is cheap:
+validate operation-scoped" contract. Each skipped tag is cheap:
 `protowire.ConsumeFieldValue` on a length-delimited field only reads the
-length prefix and skips the body, so scanning the remaining top-level tags is
-O(1) per tag regardless of payload size, confirmed by
-`BenchmarkResource_SingleOccurrence` (see [BENCHMARKS.md](BENCHMARKS.md)).
+length prefix and jumps the body, so the per-tag cost is O(1) regardless of
+payload size. The *total* is O(sibling fields), which matters more for scope
+containers than for resource containers: a resource container holds a handful
+of scopes, whereas a scope container holds every record. Measured at roughly
+10 ns per skipped record, so `ScopeLogs.Scope()` on a 1000-record container
+costs about 10 µs and stays allocation-free. A consumer that reads the scope
+and then iterates the records pays this as a constant factor on a walk it was
+already doing; one that reads *only* the scope name and stops early — dibber's
+shape — trades its former early exit for pdata parity. `BenchmarkScope_ScanScaling`
+and `BenchmarkSchemaUrl_ScanScaling` pin the curve (see
+[BENCHMARKS.md](BENCHMARKS.md)).
+
+### `WriteTo`
 
 The three `WriteTo` methods share one writer that prefixes the unchanged
 resource container with an export-request field tag and length. Direct
@@ -233,10 +283,10 @@ they do not need while giving routing and detector paths a parity-oriented API.
 ## Performance design
 
 Counting uses direct tag walks and remains allocation-free. Returned byte
-slices alias the input, with one documented exception: `Resource()` allocates
-a concatenated buffer when a container carries 2+ Resource occurrences (see
-"Resource extraction and WriteTo" above); the single-occurrence case every
-real producer emits stays zero-copy. Ordinary iterator cost is explicit and
+slices alias the input, with one documented exception: `Resource()` and
+`Scope()` allocate a concatenated buffer when a container carries 2+
+occurrences of that field (see "Singular field resolution" above); the
+single-occurrence case every real producer emits stays zero-copy. Ordinary iterator cost is explicit and
 amortized at outer levels; zero-allocation yield variants cover repeated
 inner levels.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -224,11 +224,24 @@ divergence from pdata of the same kind E-2941 fixed for `Resource()`, so it
 was corrected here rather than left to differ from the new accessors beside
 it.
 
-`KeyValue.Key` and `KeyValue.ValueRaw` deliberately keep first-match
-semantics via `extractBytesField`. They are the lightweight views described
-under "Error and compatibility strategy": per-attribute hot paths that hash
-encoded bytes and never needed pdata-equivalent scalar resolution. Their
-divergence is intentional and documented rather than latent.
+`KeyValue.Key` and `KeyValue.ValueRaw` keep first-match semantics via
+`extractBytesField`, and this is a known divergence rather than an
+application of the rule above. Both fields would resolve differently under
+it: pdata takes the last `KeyValue.key` (a scalar) and *merges* repeated
+`KeyValue.value` occurrences (a message, `orig.Value.UnmarshalProto` into the
+same AnyValue). So a KeyValue carrying two `value` occurrences resolves in
+pdata to the merged oneof result, while `ValueRaw` returns the first
+occurrence's bytes; and `Key` returns the first key where this package's own
+`parseKeyValue` — behind `StringValue` and `Resource.StringAttribute` —
+returns the last.
+
+They were left on first-match here because they are the per-attribute
+hashing views described under "Error and compatibility strategy", the
+library's hottest path, and changing them is a behavioral change to existing
+accessors that this change did not measure. Repeated occurrences of either
+field require a producer no consumer has been observed to run. The
+divergence is tracked for the specification-drift work rather than left
+implicit.
 
 **Validation-scope change.** Both resolutions need the complete message:
 merging must find every occurrence, and last-value-wins must reach the final

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -241,17 +241,12 @@ the "Resources and attributes" section of
 [specification.md](specification.md) — not a general change to the "iterators
 validate operation-scoped" contract. Each skipped tag is cheap:
 `protowire.ConsumeFieldValue` on a length-delimited field only reads the
-length prefix and jumps the body, so the per-tag cost is O(1) regardless of
-payload size. The *total* is O(sibling fields), which matters more for scope
-containers than for resource containers: a resource container holds a handful
-of scopes, whereas a scope container holds every record. Measured at roughly
-10 ns per skipped record, so `ScopeLogs.Scope()` on a 1000-record container
-costs about 10 µs and stays allocation-free. A consumer that reads the scope
-and then iterates the records pays this as a constant factor on a walk it was
-already doing; one that reads *only* the scope name and stops early — dibber's
-shape — trades its former early exit for pdata parity. `BenchmarkScope_ScanScaling`
-and `BenchmarkSchemaUrl_ScanScaling` pin the curve (see
-[BENCHMARKS.md](BENCHMARKS.md)).
+length prefix and jumps the body, so cost scales with the enclosing message's
+field count, not its payload size, and stays allocation-free. That matters
+more for scope containers than resource containers, because a scope container
+holds every record where a resource container holds a handful of scopes.
+[BENCHMARKS.md](BENCHMARKS.md) has the measured curve and what it costs a
+consumer that reads only the scope and stops early.
 
 ### `WriteTo`
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -322,6 +322,22 @@ accessors scan the whole enclosing message, so a malformed field located
 *after* the last occurrence is reported as an error; and cost grows with the
 enclosing message's field count while staying allocation-free.
 
+**Where the widened scan is stricter than pdata.** Skipping a field applies
+this library's group validation, which requires a start-group wire type to
+have its matching end-group marker. pdata's unknown-field skip does not: it
+returns as soon as it consumes a non-group wire type, even inside an unclosed
+group. A payload carrying an unclosed group in an unknown field *after* the
+last occurrence of a scanned field is therefore an error here and accepted by
+pdata. This is the one direction in which the wire path and the pdata
+fallback disagree, it is the safe direction, and it is deliberate: `AGENTS.md`
+requires that corruption never be silently accepted to keep a walk moving.
+Groups are a proto2 construct that OTLP never emits, so the shapes affected
+are malformed or adversarial rather than anything a conformant producer
+emits. `Metric.Name` is newly subject to this because it now scans; before
+E-2942 it returned at the first `name` field and never reached such a field.
+`TestMetricName_UnclosedGroupIsStricterThanPdata` pins the divergence so it
+stays a decision rather than an accident.
+
 **`Metric.Name` behavior change (unreleased, E-2942, v0.1.0).** It previously
 returned the first occurrence. That diverged from pdata in exactly the way
 `Resource()` did before E-2941, so it was corrected rather than left

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -90,6 +90,7 @@ ExportMetricsServiceRequest
 └── ResourceMetrics
     ├── Resource
     └── ScopeMetrics
+        ├── InstrumentationScope
         └── Metric
             └── DataPoint
                 └── KeyValue
@@ -98,14 +99,24 @@ ExportLogsServiceRequest
 └── ResourceLogs
     ├── Resource
     └── ScopeLogs
+        ├── InstrumentationScope
         └── LogRecord
 
 ExportTracesServiceRequest
 └── ResourceSpans
     ├── Resource
     └── ScopeSpans
+        ├── InstrumentationScope
         └── Span
 ```
+
+This hierarchy mirrors pdata's object model deliberately: a container holds
+exactly one Resource and exactly one InstrumentationScope, and each level's
+accessor is named after pdata's. The mirror cannot be exact in one respect —
+otlp-wire parses lazily, so every accessor returns `(T, error)` and cannot
+chain the way pdata's validated-at-unmarshal accessors do. A flattened
+convenience that collapses two error checks is admitted only when a measured
+hot path justifies it.
 
 The exported methods are listed in [README.md](../README.md) and verified by
 [example_test.go](../example_test.go). The contracts below apply across that
@@ -279,6 +290,54 @@ encoded field. `KeyValue.StringValue` is the semantic string accessor: it
 validates the complete KeyValue and AnyValue structure and applies protobuf
 oneof ordering. These two classes of accessor are deliberately different.
 
+### Instrumentation scope and schema URL
+
+**Added in E-2942 (unreleased, v0.1.0).** `ScopeMetrics`, `ScopeLogs`, and
+`ScopeSpans` each expose `Scope() (InstrumentationScope, error)`, and all six
+containers expose `SchemaUrl() ([]byte, error)`.
+
+`Scope()` carries the identical contract to `Resource()` above — exactly one
+per container, absence returns `(nil, nil)`, a single occurrence aliases the
+input with no allocation, 2+ occurrences are validated individually and then
+merged by concatenation, and the merge requires scanning the whole container.
+Every clause in the "Resources and attributes" section applies unchanged,
+because pdata treats both fields the same way: it unmarshals each occurrence
+into the same object.
+
+`InstrumentationScope.Name`, `Version`, `Attributes`, and `AttributesSeq` read
+that message. **Scope attributes are field 3**, where Resource attributes are
+field 1; the accessors absorb the difference, but anyone writing new wire code
+against this hierarchy must not assume they match.
+
+**Singular scalars resolve to the last occurrence (E-2942).** `SchemaUrl`,
+`InstrumentationScope.Name`, `InstrumentationScope.Version`, and `Metric.Name`
+return the *last* occurrence when a field is repeated. Protobuf specifies
+replacement for repeated singular scalars, and pdata implements it with a
+plain assignment. This is the counterpart to the merge rule for singular
+messages, and the distinction is a behavioral contract, not an implementation
+detail: a consumer relying on first-match resolution would diverge from its
+pdata fallback on the same bytes.
+
+Two consequences follow, both mirroring the `Resource()` change:
+
+- These accessors scan the whole enclosing message rather than returning at
+  the first match, so a malformed field located *after* the last occurrence is
+  now reported as an error.
+- Cost grows with the number of sibling fields. For a scope container that
+  means the record count, which is larger than the scope count a resource
+  container holds. The walk stays allocation-free and skips record bodies
+  without descending; see [BENCHMARKS.md](BENCHMARKS.md) for the measured
+  curve.
+
+**`Metric.Name` behavior change (unreleased, E-2942, v0.1.0).** It previously
+returned the first occurrence. That diverged from pdata in exactly the way
+`Resource()` did before E-2941, so it was corrected rather than left
+inconsistent with the accessors added beside it. The signature is unchanged
+and no consumer surveyed depends on the old resolution; a producer emitting a
+repeated `Metric.name` was already outside what its pdata fallback would agree
+with. `KeyValue.Key` and `ValueRaw` keep first-match semantics deliberately,
+as documented above — they are hashing-oriented views, not parity accessors.
+
 ### Metrics depth
 
 Metrics traversal supports gauge, sum, histogram, exponential histogram, and
@@ -332,16 +391,21 @@ is part of this library's purpose and compatibility surface.
 
 - Counting valid requests is zero-allocation.
 - Ordinary iterator opens have the documented small closure cost.
-- `DataPointsSeq`, `AttributesSeq`, and `LogRecordsSeq` remain zero-allocation
-  on their per-element paths.
+- `DataPointsSeq`, `AttributesSeq` (on both `Resource` and
+  `InstrumentationScope`), and `LogRecordsSeq` remain zero-allocation on their
+  per-element paths.
 - Accessors return aliased slices rather than copying payload data, with one
-  documented exception: `Resource()` aliases the input when a container holds
-  a single Resource occurrence (the case every real producer emits) and
-  allocates a concatenated buffer only when merging 2+ occurrences
-  (unreleased, E-2941, v0.1.0). See "Resources and attributes" above and
-  `BenchmarkResource_SingleOccurrence` /
-  `BenchmarkResource_MultipleOccurrences` in
+  documented exception: `Resource()` and `Scope()` alias the input when a
+  container holds a single occurrence of that field (the case every real
+  producer emits) and allocate a concatenated buffer only when merging 2+
+  occurrences (unreleased, E-2941 and E-2942, v0.1.0). See "Resources and
+  attributes" and "Instrumentation scope and schema URL" above, and the
+  `SingleOccurrence` / `MultipleOccurrences` benchmarks in
   [BENCHMARKS.md](BENCHMARKS.md).
+- Accessors that must scan a whole message to resolve a singular field
+  (`Resource()`, `Scope()`, and the last-value-wins scalars) cost time
+  proportional to the enclosing message's field count, not its payload size,
+  and remain allocation-free.
 - Production code must not introduce pdata or generated-message unmarshaling.
 
 Exact timings are environment-specific, not API guarantees. Any performance

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -311,23 +311,16 @@ against this hierarchy must not assume they match.
 
 **Singular scalars resolve to the last occurrence (E-2942).** `SchemaUrl`,
 `InstrumentationScope.Name`, `InstrumentationScope.Version`, and `Metric.Name`
-return the *last* occurrence when a field is repeated. Protobuf specifies
-replacement for repeated singular scalars, and pdata implements it with a
-plain assignment. This is the counterpart to the merge rule for singular
-messages, and the distinction is a behavioral contract, not an implementation
-detail: a consumer relying on first-match resolution would diverge from its
-pdata fallback on the same bytes.
+return the *last* occurrence when a field is repeated, which is what protobuf
+and pdata do. The distinction from the merge rule for singular messages is a
+behavioral contract, not an implementation detail: a consumer relying on
+first-match resolution would diverge from its pdata fallback on the same
+bytes. [DESIGN.md](DESIGN.md) records why.
 
-Two consequences follow, both mirroring the `Resource()` change:
-
-- These accessors scan the whole enclosing message rather than returning at
-  the first match, so a malformed field located *after* the last occurrence is
-  now reported as an error.
-- Cost grows with the number of sibling fields. For a scope container that
-  means the record count, which is larger than the scope count a resource
-  container holds. The walk stays allocation-free and skips record bodies
-  without descending; see [BENCHMARKS.md](BENCHMARKS.md) for the measured
-  curve.
+Two consequences follow, both mirroring the `Resource()` change: these
+accessors scan the whole enclosing message, so a malformed field located
+*after* the last occurrence is reported as an error; and cost grows with the
+enclosing message's field count while staying allocation-free.
 
 **`Metric.Name` behavior change (unreleased, E-2942, v0.1.0).** It previously
 returned the first occurrence. That diverged from pdata in exactly the way

--- a/example_test.go
+++ b/example_test.go
@@ -199,6 +199,64 @@ func ExampleResourceLogs_Resource() {
 	// Output: checkout severity=13
 }
 
+// ExampleScopeLogs_Scope reads instrumentation scope identity and schema URL
+// without unmarshaling the request. Each scope container has exactly one
+// InstrumentationScope, mirroring pdata's object model.
+func ExampleScopeLogs_Scope() {
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	resourceLogs.SetSchemaUrl("https://opentelemetry.io/schemas/1.29.0")
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	scopeLogs.Scope().SetName("checkout-instrumentation")
+	scopeLogs.Scope().SetVersion("1.2.3")
+	scopeLogs.LogRecords().AppendEmpty()
+
+	data, err := (&plog.ProtoMarshaler{}).MarshalLogs(logs)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	request := otlpwire.ExportLogsServiceRequest(data)
+	resources, resourceErr := request.ResourceLogs()
+	for resource := range resources {
+		schemaURL, err := resource.SchemaUrl()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		scopes, scopeErr := resource.ScopeLogs()
+		for scopeLogs := range scopes {
+			scope, err := scopeLogs.Scope()
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			name, err := scope.Name()
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			version, err := scope.Version()
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Printf("%s@%s schema=%s\n", name, version, schemaURL)
+		}
+		if err := scopeErr(); err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+	if err := resourceErr(); err != nil {
+		fmt.Println(err)
+	}
+
+	// Output: checkout-instrumentation@1.2.3 schema=https://opentelemetry.io/schemas/1.29.0
+}
+
 // Helper functions
 
 func createSampleMetrics(dataPoints int) pmetric.Metrics {

--- a/example_test.go
+++ b/example_test.go
@@ -160,16 +160,16 @@ func ExampleResourceLogs_Resource() {
 		resource, err := resourceLogs.Resource()
 		if err != nil {
 			fmt.Println(err)
-			return
+			break
 		}
 		service, found, err := resource.StringAttribute("service.name")
 		if err != nil {
 			fmt.Println(err)
-			return
+			break
 		}
 		if !found {
 			fmt.Println("service.name missing")
-			return
+			break
 		}
 
 		scopes, scopeErr := resourceLogs.ScopeLogs()
@@ -177,19 +177,19 @@ func ExampleResourceLogs_Resource() {
 			for record, err := range scope.LogRecordsSeq {
 				if err != nil {
 					fmt.Println(err)
-					return
+					break
 				}
 				severity, err := record.SeverityNumber()
 				if err != nil {
 					fmt.Println(err)
-					return
+					break
 				}
 				fmt.Printf("%s severity=%d\n", service, severity)
 			}
 		}
 		if err := scopeErr(); err != nil {
 			fmt.Println(err)
-			return
+			break
 		}
 	}
 	if err := resourceErr(); err != nil {
@@ -217,37 +217,29 @@ func ExampleScopeLogs_Scope() {
 		return
 	}
 
+	// Each iterator's error closure must run even when the loop exits early,
+	// so accessor errors break out rather than returning past the check.
 	request := otlpwire.ExportLogsServiceRequest(data)
 	resources, resourceErr := request.ResourceLogs()
 	for resource := range resources {
 		schemaURL, err := resource.SchemaUrl()
 		if err != nil {
 			fmt.Println(err)
-			return
+			break
 		}
 
 		scopes, scopeErr := resource.ScopeLogs()
 		for scopeLogs := range scopes {
-			scope, err := scopeLogs.Scope()
+			name, version, err := scopeIdentity(scopeLogs)
 			if err != nil {
 				fmt.Println(err)
-				return
-			}
-			name, err := scope.Name()
-			if err != nil {
-				fmt.Println(err)
-				return
-			}
-			version, err := scope.Version()
-			if err != nil {
-				fmt.Println(err)
-				return
+				break
 			}
 			fmt.Printf("%s@%s schema=%s\n", name, version, schemaURL)
 		}
 		if err := scopeErr(); err != nil {
 			fmt.Println(err)
-			return
+			break
 		}
 	}
 	if err := resourceErr(); err != nil {
@@ -255,6 +247,20 @@ func ExampleScopeLogs_Scope() {
 	}
 
 	// Output: checkout-instrumentation@1.2.3 schema=https://opentelemetry.io/schemas/1.29.0
+}
+
+// scopeIdentity reads a scope's name and version, keeping the example's loop
+// body free of the three error checks the lazy accessors require.
+func scopeIdentity(scopeLogs otlpwire.ScopeLogs) (name, version []byte, err error) {
+	scope, err := scopeLogs.Scope()
+	if err != nil {
+		return nil, nil, err
+	}
+	if name, err = scope.Name(); err != nil {
+		return nil, nil, err
+	}
+	version, err = scope.Version()
+	return name, version, err
 }
 
 // Helper functions

--- a/log_iteration_test.go
+++ b/log_iteration_test.go
@@ -347,7 +347,7 @@ func TestResourceStringAttribute_EntityRefPdataParity(t *testing.T) {
 // TestResourceLogsResource_MergedResourcesPdataParity covers the migration
 // path documented for the removed ResourceLogs.StringAttribute:
 // rl.Resource() then res.StringAttribute(key). ResourceLogs.Resource() merges
-// repeated singular Resource occurrences (see extractResourceMessage), and
+// repeated singular Resource occurrences (see extractMergedMessage), and
 // Resource.StringAttribute retains pdata's first-duplicate-key-wins behavior
 // over the merged bytes.
 func TestResourceLogsResource_MergedResourcesPdataParity(t *testing.T) {

--- a/logs.go
+++ b/logs.go
@@ -27,13 +27,20 @@ func (r ResourceLogs) LogRecordCount() (int, error) {
 // Resource returns the Resource message for this ResourceLogs. It returns
 // (nil, nil) when the field is absent, aliases the input for the single
 // occurrence every real producer emits, and merges 2+ occurrences into a new
-// buffer. See extractResourceMessage for the full contract.
+// buffer. See extractMergedMessage for the full contract.
 func (r ResourceLogs) Resource() (Resource, error) {
-	raw, err := extractResourceMessage([]byte(r))
+	raw, err := extractMergedMessage([]byte(r), 1)
 	if err != nil {
 		return nil, err
 	}
 	return Resource(raw), nil
+}
+
+// SchemaUrl returns the ResourceLogs schema_url (field 3) as a view into the
+// underlying buffer. Returns nil if the field is not present. Repeated
+// occurrences resolve to the last one.
+func (r ResourceLogs) SchemaUrl() ([]byte, error) {
+	return extractLastBytesField([]byte(r), 3)
 }
 
 // WriteTo writes the ResourceLogs as a valid ExportLogsServiceRequest to w.
@@ -47,6 +54,25 @@ func (r ResourceLogs) WriteTo(w io.Writer) (int64, error) {
 // The returned function should be called after iteration to check for errors.
 func (r ResourceLogs) ScopeLogs() (iter.Seq[ScopeLogs], func() error) {
 	return repeatedFieldSeq[ScopeLogs]([]byte(r), 2)
+}
+
+// Scope returns the InstrumentationScope for this ScopeLogs. It returns
+// (nil, nil) when the field is absent, aliases the input for the single
+// occurrence every real producer emits, and merges 2+ occurrences into a new
+// buffer. See extractMergedMessage for the full contract.
+func (s ScopeLogs) Scope() (InstrumentationScope, error) {
+	raw, err := extractMergedMessage([]byte(s), 1)
+	if err != nil {
+		return nil, err
+	}
+	return InstrumentationScope(raw), nil
+}
+
+// SchemaUrl returns the ScopeLogs schema_url (field 3) as a view into the
+// underlying buffer. Returns nil if the field is not present. Repeated
+// occurrences resolve to the last one.
+func (s ScopeLogs) SchemaUrl() ([]byte, error) {
+	return extractLastBytesField([]byte(s), 3)
 }
 
 // LogRecords returns an iterator over LogRecords in this ScopeLogs.

--- a/metrics.go
+++ b/metrics.go
@@ -77,13 +77,20 @@ func (r ResourceMetrics) DataPointCount() (int, error) {
 // Resource returns the Resource message for this ResourceMetrics. It returns
 // (nil, nil) when the field is absent, aliases the input for the single
 // occurrence every real producer emits, and merges 2+ occurrences into a new
-// buffer. See extractResourceMessage for the full contract.
+// buffer. See extractMergedMessage for the full contract.
 func (r ResourceMetrics) Resource() (Resource, error) {
-	raw, err := extractResourceMessage([]byte(r))
+	raw, err := extractMergedMessage([]byte(r), 1)
 	if err != nil {
 		return nil, err
 	}
 	return Resource(raw), nil
+}
+
+// SchemaUrl returns the ResourceMetrics schema_url (field 3) as a view into
+// the underlying buffer. Returns nil if the field is not present. Repeated
+// occurrences resolve to the last one.
+func (r ResourceMetrics) SchemaUrl() ([]byte, error) {
+	return extractLastBytesField([]byte(r), 3)
 }
 
 // WriteTo writes the ResourceMetrics as a valid ExportMetricsServiceRequest to w.
@@ -99,6 +106,25 @@ func (r ResourceMetrics) ScopeMetrics() (iter.Seq[ScopeMetrics], func() error) {
 	return repeatedFieldSeq[ScopeMetrics]([]byte(r), 2)
 }
 
+// Scope returns the InstrumentationScope for this ScopeMetrics. It returns
+// (nil, nil) when the field is absent, aliases the input for the single
+// occurrence every real producer emits, and merges 2+ occurrences into a new
+// buffer. See extractMergedMessage for the full contract.
+func (s ScopeMetrics) Scope() (InstrumentationScope, error) {
+	raw, err := extractMergedMessage([]byte(s), 1)
+	if err != nil {
+		return nil, err
+	}
+	return InstrumentationScope(raw), nil
+}
+
+// SchemaUrl returns the ScopeMetrics schema_url (field 3) as a view into the
+// underlying buffer. Returns nil if the field is not present. Repeated
+// occurrences resolve to the last one.
+func (s ScopeMetrics) SchemaUrl() ([]byte, error) {
+	return extractLastBytesField([]byte(s), 3)
+}
+
 // Metrics returns an iterator over Metrics in this ScopeMetrics.
 // Field 2 in the ScopeMetrics protobuf message.
 // The returned function should be called after iteration to check for errors.
@@ -107,9 +133,11 @@ func (s ScopeMetrics) Metrics() (iter.Seq[Metric], func() error) {
 }
 
 // Name returns the metric name (field 1) as a view into the underlying
-// buffer. Returns nil if the field is not present.
+// buffer. Returns nil if the field is not present. Repeated occurrences
+// resolve to the last one, matching protobuf singular scalar semantics and
+// pdata's unmarshal.
 func (m Metric) Name() ([]byte, error) {
-	return extractBytesField([]byte(m), 1)
+	return extractLastBytesField([]byte(m), 1)
 }
 
 // DataPoints returns an iterator over datapoints in this Metric, descending

--- a/metrics.go
+++ b/metrics.go
@@ -49,13 +49,7 @@ func (d DataPoint) Attributes() (iter.Seq[KeyValue], func() error) {
 //
 // On a parse error it yields a nil KeyValue with a non-nil error and stops.
 func (d DataPoint) AttributesSeq(yield func(KeyValue, error) bool) {
-	forEachRepeatedField(d.raw, d.attributesFieldNum(), func(rb []byte, err error) bool {
-		if err != nil {
-			yield(nil, err)
-			return false
-		}
-		return yield(KeyValue(rb), nil)
-	})
+	keyValueSeq(d.raw, d.attributesFieldNum(), yield)
 }
 
 // DataPointCount returns the total number of metric data points in the batch.
@@ -134,8 +128,7 @@ func (s ScopeMetrics) Metrics() (iter.Seq[Metric], func() error) {
 
 // Name returns the metric name (field 1) as a view into the underlying
 // buffer. Returns nil if the field is not present. Repeated occurrences
-// resolve to the last one, matching protobuf singular scalar semantics and
-// pdata's unmarshal.
+// resolve to the last one; see extractLastBytesField.
 func (m Metric) Name() ([]byte, error) {
 	return extractLastBytesField([]byte(m), 1)
 }

--- a/operations.md
+++ b/operations.md
@@ -35,6 +35,7 @@ parity; all are pre-release, so no rollback of a shipped tag is involved.
 | `Resource()` merges repeated occurrences instead of returning the first | E-2941 | Consumers reading resource attributes from multi-occurrence payloads |
 | `Resource()`, `Scope()` and the singular-scalar accessors report corruption located after the last relevant occurrence | E-2941, E-2942 | Consumers that previously parsed such payloads without error |
 | `Metric.Name()` returns the last occurrence of a repeated `name` instead of the first | E-2942 | Consumers reading names from payloads with a repeated `Metric.name` |
+| Scanning accessors reject an unclosed group in an unknown trailing field, which pdata accepts | E-2942 | Consumers pairing the wire path with a pdata fallback; only reachable on malformed or adversarial input, never on conformant OTLP |
 
 The canary decision and its measured pre/post comparison are recorded at
 release time, per "Release and production analysis" below. Confirm the canary

--- a/operations.md
+++ b/operations.md
@@ -40,7 +40,7 @@ parity; all are pre-release, so no rollback of a shipped tag is involved.
 The canary decision and its measured pre/post comparison are recorded at
 release time, per "Release and production analysis" below. Confirm the canary
 consumer's telemetry is version-attributed first: see the uncovered-scenario
-note above.
+note under "Telemetry inventory" below.
 
 ## Telemetry inventory
 

--- a/operations.md
+++ b/operations.md
@@ -20,7 +20,26 @@ this before releasing the module or changing a consumer rollout boundary.
 | --- | --- | --- | --- | --- |
 | Wire-contract regression | observed in tests | Consumer rejects valid OTLP or accepts malformed selected fields | Field number, wire type, merge, or oneof behavior changed | pdata differential and malformed-wire tests |
 | Allocation regression | hypothesized | Higher GC/CPU in high-volume consumers | Extra copies, escaping closures, or full decode added to a hot path | Allocation tests and paired `-benchmem` benchmarks |
-| Consumer contract regression | hypothesized | Compile failure or changed routing/detector result after upgrade | Exported API, aliasing, iterator timing, or `WriteTo` bytes changed | Consumer-focused tests and canary comparison |
+| Consumer contract regression | observed in tests | Compile failure or changed routing/detector result after upgrade | Exported API, aliasing, iterator timing, or `WriteTo` bytes changed | Consumer-focused tests and canary comparison; the v0.1.0 transitions below |
+
+### Known consumer-visible transitions in v0.1.0 (unreleased)
+
+The v0.1.0 API realignment (E-2940) changes behavior consumers can observe,
+not only signatures. Each is intentional and moves the wire path toward pdata
+parity; all are pre-release, so no rollback of a shipped tag is involved.
+
+| Change | Issue | Who is affected |
+| --- | --- | --- |
+| `ResourceLogs.StringAttribute` removed | E-2941 | mulch (only consumer with source to change) |
+| `Resource()` returns `(nil, nil)` for an absent Resource instead of an error | E-2941 | Any consumer treating that error as a signal; not firing in production as of 2026-08-07 |
+| `Resource()` merges repeated occurrences instead of returning the first | E-2941 | Consumers reading resource attributes from multi-occurrence payloads |
+| `Resource()`, `Scope()` and the singular-scalar accessors report corruption located after the last relevant occurrence | E-2941, E-2942 | Consumers that previously parsed such payloads without error |
+| `Metric.Name()` returns the last occurrence of a repeated `name` instead of the first | E-2942 | Consumers reading names from payloads with a repeated `Metric.name` |
+
+The canary decision and its measured pre/post comparison are recorded at
+release time, per "Release and production analysis" below. Confirm the canary
+consumer's telemetry is version-attributed first: see the uncovered-scenario
+note above.
 
 ## Telemetry inventory
 

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -1488,6 +1488,49 @@ func TestMetricName_Absent(t *testing.T) {
 	require.Nil(t, name)
 }
 
+// TestMetricName_LastValueWins covers the E-2942 change from first-match to
+// protobuf singular-scalar semantics. pdata assigns on each occurrence, so the
+// last one wins; the previous first-match behavior diverged.
+func TestMetricName_LastValueWins(t *testing.T) {
+	var m Metric
+	m = protowire.AppendTag(m, 1, protowire.BytesType)
+	m = protowire.AppendString(m, "first")
+	m = protowire.AppendTag(m, 3, protowire.BytesType)
+	m = protowire.AppendString(m, "1")
+	m = protowire.AppendTag(m, 1, protowire.BytesType)
+	m = protowire.AppendString(m, "second")
+
+	name, err := m.Name()
+	require.NoError(t, err)
+	require.Equal(t, "second", string(name))
+
+	// pdata is the oracle: wrap the metric into a full request and compare.
+	sm := protowire.AppendTag(nil, 2, protowire.BytesType)
+	sm = protowire.AppendVarint(sm, uint64(len(m)))
+	sm = append(sm, m...)
+	rm := protowire.AppendTag(nil, 2, protowire.BytesType)
+	rm = protowire.AppendVarint(rm, uint64(len(sm)))
+	rm = append(rm, sm...)
+
+	req := pmetricotlp.NewExportRequest()
+	require.NoError(t, req.UnmarshalProto(wrapAsRequest(rm)))
+	require.Equal(t, "second",
+		req.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+}
+
+// TestMetricName_MalformedTrailingField pins the validation-scope consequence
+// of the full scan: corruption after the last name occurrence is now reported.
+func TestMetricName_MalformedTrailingField(t *testing.T) {
+	var m Metric
+	m = protowire.AppendTag(m, 1, protowire.BytesType)
+	m = protowire.AppendString(m, "requests")
+	m = protowire.AppendTag(m, 3, protowire.BytesType)
+	m = protowire.AppendVarint(m, 64) // declares more than it carries
+
+	_, err := m.Name()
+	require.Error(t, err)
+}
+
 // buildAllTypesMetrics builds one metric of each of the five types, each
 // with two datapoints carrying attributes {"method":"GET","status":"200"}
 // and timestamp 1000000000.

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -1518,6 +1518,42 @@ func TestMetricName_LastValueWins(t *testing.T) {
 		req.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
 }
 
+// TestMetricName_UnclosedGroupIsStricterThanPdata pins the one direction in
+// which the widened scan disagrees with pdata. protowire's field skip requires
+// a start-group to have its matching end-group; pdata's unknown-field skip
+// returns as soon as it consumes a non-group wire type, even inside an
+// unclosed group. So this payload is an error here and accepted there.
+//
+// The divergence is deliberate and in the safe direction (see the
+// "Instrumentation scope and schema URL" section of docs/specification.md).
+// Groups are proto2-only and OTLP never emits them. This test exists so the
+// behavior cannot change silently.
+func TestMetricName_UnclosedGroupIsStricterThanPdata(t *testing.T) {
+	var m Metric
+	m = protowire.AppendTag(m, 1, protowire.BytesType)
+	m = protowire.AppendString(m, "requests")
+	// Unknown field 8 as a start-group holding a fixed32, with no end-group.
+	m = protowire.AppendTag(m, 8, protowire.StartGroupType)
+	m = protowire.AppendTag(m, 6, protowire.Fixed32Type)
+	m = protowire.AppendFixed32(m, 0)
+
+	sm := protowire.AppendTag(nil, 2, protowire.BytesType)
+	sm = protowire.AppendVarint(sm, uint64(len(m)))
+	sm = append(sm, m...)
+	rm := protowire.AppendTag(nil, 2, protowire.BytesType)
+	rm = protowire.AppendVarint(rm, uint64(len(sm)))
+	rm = append(rm, sm...)
+
+	req := pmetricotlp.NewExportRequest()
+	require.NoError(t, req.UnmarshalProto(wrapAsRequest(rm)),
+		"pdata tolerates the unclosed group")
+	require.Equal(t, "requests",
+		req.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+
+	_, err := m.Name()
+	require.Error(t, err, "otlp-wire rejects it: group validation is strict")
+}
+
 // TestMetricName_MalformedTrailingField pins the validation-scope consequence
 // of the full scan: corruption after the last name occurrence is now reported.
 func TestMetricName_MalformedTrailingField(t *testing.T) {

--- a/resource_test.go
+++ b/resource_test.go
@@ -54,10 +54,9 @@ func containerWithResources(resources ...[]byte) []byte {
 	return protowire.AppendVarint(out, 0)
 }
 
-// resourceWithStringAttr builds a Resource message carrying one string
-// attribute (Resource.attributes is field 1, KeyValue.key field 1,
-// KeyValue.value field 2, AnyValue.string_value field 1).
-func resourceWithStringAttr(key, value string) []byte {
+// stringKeyValue builds a KeyValue message with a string value (KeyValue.key
+// is field 1, KeyValue.value field 2, AnyValue.string_value field 1).
+func stringKeyValue(key, value string) []byte {
 	anyValue := protowire.AppendTag(nil, 1, protowire.BytesType)
 	anyValue = protowire.AppendString(anyValue, value)
 
@@ -65,8 +64,13 @@ func resourceWithStringAttr(key, value string) []byte {
 	kv = protowire.AppendString(kv, key)
 	kv = protowire.AppendTag(kv, 2, protowire.BytesType)
 	kv = protowire.AppendVarint(kv, uint64(len(anyValue)))
-	kv = append(kv, anyValue...)
+	return append(kv, anyValue...)
+}
 
+// resourceWithStringAttr builds a Resource message carrying one string
+// attribute. Resource.attributes is field 1.
+func resourceWithStringAttr(key, value string) []byte {
+	kv := stringKeyValue(key, value)
 	res := protowire.AppendTag(nil, 1, protowire.BytesType)
 	res = protowire.AppendVarint(res, uint64(len(kv)))
 	return append(res, kv...)

--- a/resource_test.go
+++ b/resource_test.go
@@ -521,3 +521,91 @@ func TestResourceSchemaUrl(t *testing.T) {
 		})
 	}
 }
+
+// ---------- Resource.AttributesSeq ----------
+
+// TestResource_AttributesSeq covers the zero-allocation attribute path, which
+// scope_test.go cites as the gate its own AttributesSeq must match. It reads
+// Resource attributes from field 1; a wrong field number here would silently
+// yield nothing to every caller on the hot path.
+func TestResource_AttributesSeq(t *testing.T) {
+	res := append(resourceWithStringAttr("service.name", "checkout"),
+		resourceWithStringAttr("host.name", "host-1")...)
+	resource := Resource(res)
+
+	var got [][2]string
+	resource.AttributesSeq(func(kv KeyValue, err error) bool {
+		require.NoError(t, err)
+		key, err := kv.Key()
+		require.NoError(t, err)
+		value, found, err := kv.StringValue()
+		require.NoError(t, err)
+		require.True(t, found)
+		got = append(got, [2]string{string(key), string(value)})
+		return true
+	})
+	require.Equal(t, [][2]string{
+		{"service.name", "checkout"},
+		{"host.name", "host-1"},
+	}, got)
+
+	// Same elements as the closure-based iterator.
+	var viaIter [][2]string
+	seq, errFn := resource.Attributes()
+	for kv := range seq {
+		key, err := kv.Key()
+		require.NoError(t, err)
+		value, _, err := kv.StringValue()
+		require.NoError(t, err)
+		viaIter = append(viaIter, [2]string{string(key), string(value)})
+	}
+	require.NoError(t, errFn())
+	require.Equal(t, got, viaIter)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		count := 0
+		resource.AttributesSeq(func(_ KeyValue, err error) bool {
+			if err != nil {
+				t.Fatal(err)
+			}
+			count++
+			return true
+		})
+		if count != 2 {
+			t.Fatalf("expected 2 attributes, got %d", count)
+		}
+	})
+	require.Zero(t, allocs)
+}
+
+// TestIteratedViewsAreCapacityClamped pins the guarantee that a yielded view
+// cannot be appended into its neighbours. protowire hands back slices whose
+// capacity runs to the end of the enclosing message, so without the clamp in
+// forEachRepeatedField a caller's append would corrupt the OTLP buffer it
+// does not own.
+func TestIteratedViewsAreCapacityClamped(t *testing.T) {
+	res := append(resourceWithStringAttr("service.name", "checkout"),
+		resourceWithStringAttr("host.name", "host-1")...)
+	scope := append(scopeWithStringAttr("library.language", "go"),
+		scopeWithStringAttr("library.name", "otel")...)
+
+	for _, tc := range []struct {
+		name string
+		seq  func(func(KeyValue, error) bool)
+	}{
+		{"resource", Resource(res).AttributesSeq},
+		{"scope", InstrumentationScope(scope).AttributesSeq},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			visited := 0
+			tc.seq(func(kv KeyValue, err error) bool {
+				require.NoError(t, err)
+				visited++
+				require.Equal(t, len(kv), cap(kv),
+					"yielded KeyValue must be capacity-clamped")
+				return true
+			})
+			require.Equal(t, 2, visited)
+		})
+	}
+}

--- a/resource_test.go
+++ b/resource_test.go
@@ -82,6 +82,7 @@ func resourceWithStringAttr(key, value string) []byte {
 // ResourceSpans, letting one test body cover all three signals.
 type resourceGetter interface {
 	Resource() (Resource, error)
+	SchemaUrl() ([]byte, error)
 }
 
 type signalFixture struct {
@@ -90,6 +91,9 @@ type signalFixture struct {
 	// attrs returns the container's Resource attributes via pdata, the oracle
 	// for merge and absence behavior.
 	attrs func(t *testing.T, payload []byte) pcommon.Map
+	// schemaURL returns the container's schema_url via pdata, the oracle for
+	// singular-scalar resolution.
+	schemaURL func(t *testing.T, payload []byte) string
 }
 
 var signalFixtures = []signalFixture{
@@ -103,6 +107,12 @@ var signalFixtures = []signalFixture{
 			require.Equal(t, 1, req.Metrics().ResourceMetrics().Len())
 			return req.Metrics().ResourceMetrics().At(0).Resource().Attributes()
 		},
+		schemaURL: func(t *testing.T, payload []byte) string {
+			t.Helper()
+			req := pmetricotlp.NewExportRequest()
+			require.NoError(t, req.UnmarshalProto(payload))
+			return req.Metrics().ResourceMetrics().At(0).SchemaUrl()
+		},
 	},
 	{
 		name: "logs",
@@ -114,6 +124,12 @@ var signalFixtures = []signalFixture{
 			require.Equal(t, 1, req.Logs().ResourceLogs().Len())
 			return req.Logs().ResourceLogs().At(0).Resource().Attributes()
 		},
+		schemaURL: func(t *testing.T, payload []byte) string {
+			t.Helper()
+			req := plogotlp.NewExportRequest()
+			require.NoError(t, req.UnmarshalProto(payload))
+			return req.Logs().ResourceLogs().At(0).SchemaUrl()
+		},
 	},
 	{
 		name: "traces",
@@ -124,6 +140,12 @@ var signalFixtures = []signalFixture{
 			require.NoError(t, req.UnmarshalProto(payload))
 			require.Equal(t, 1, req.Traces().ResourceSpans().Len())
 			return req.Traces().ResourceSpans().At(0).Resource().Attributes()
+		},
+		schemaURL: func(t *testing.T, payload []byte) string {
+			t.Helper()
+			req := ptraceotlp.NewExportRequest()
+			require.NoError(t, req.UnmarshalProto(payload))
+			return req.Traces().ResourceSpans().At(0).SchemaUrl()
 		},
 	},
 }
@@ -453,6 +475,48 @@ func TestResource_ValidOccurrencesStillMerge(t *testing.T) {
 				require.NoError(t, err)
 				require.True(t, found, "attribute %q must survive the merge", key)
 				require.Equal(t, want, string(value))
+			}
+		})
+	}
+}
+
+// ---------- schema_url: a singular scalar, not a merged message ----------
+
+// TestResourceSchemaUrl covers the container-level schema_url (field 3).
+// Unlike Resource, it is a singular *scalar*: protobuf and pdata resolve a
+// repeated occurrence to the last one rather than merging.
+func TestResourceSchemaUrl(t *testing.T) {
+	tests := []struct {
+		name string
+		urls []string
+		want string
+	}{
+		{"absent", nil, ""},
+		{"single", []string{"https://example.test/v1"}, "https://example.test/v1"},
+		{"repeated", []string{"https://example.test/v1", "https://example.test/v2"}, "https://example.test/v2"},
+		{"last is empty", []string{"https://example.test/v1", ""}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			container := containerWithResource(resourceWithStringAttr("service.name", "checkout"))
+			for _, u := range tt.urls {
+				container = protowire.AppendTag(container, 3, protowire.BytesType)
+				container = protowire.AppendString(container, u)
+			}
+			payload := wrapAsRequest(container)
+
+			for _, sf := range signalFixtures {
+				t.Run(sf.name, func(t *testing.T) {
+					require.Equal(t, tt.want, sf.schemaURL(t, payload), "pdata schema_url")
+
+					got, err := sf.wrap(container).SchemaUrl()
+					require.NoError(t, err)
+					require.Equal(t, tt.want, string(got))
+					if tt.urls == nil {
+						require.Nil(t, got, "an absent schema_url is (nil, nil)")
+					}
+				})
 			}
 		})
 	}

--- a/scope.go
+++ b/scope.go
@@ -5,13 +5,12 @@ import (
 )
 
 // Name returns the scope name (field 1) as a view into the underlying buffer.
-// Returns nil if the field is not present.
+// Returns nil if the field is not present. Repeated occurrences resolve to
+// the last one; see extractLastBytesField.
 //
-// Repeated occurrences resolve to the last one, matching protobuf singular
-// scalar semantics and pdata's unmarshal. Validation is structural and
-// operation-scoped: the whole scope message is walked, so trailing corruption
-// is reported, but nested attribute values are only parsed when Attributes is
-// iterated.
+// Validation is structural and operation-scoped: the whole scope message is
+// walked, so trailing corruption is reported, but nested attribute values are
+// only parsed when Attributes is iterated.
 func (s InstrumentationScope) Name() ([]byte, error) {
 	return extractLastBytesField([]byte(s), 1)
 }
@@ -36,11 +35,5 @@ func (s InstrumentationScope) Attributes() (iter.Seq[KeyValue], func() error) {
 // directly. On a parse error it yields a nil KeyValue with a non-nil error and
 // stops.
 func (s InstrumentationScope) AttributesSeq(yield func(KeyValue, error) bool) {
-	forEachRepeatedField([]byte(s), 3, func(rb []byte, err error) bool {
-		if err != nil {
-			yield(nil, err)
-			return false
-		}
-		return yield(KeyValue(rb), nil)
-	})
+	keyValueSeq([]byte(s), 3, yield)
 }

--- a/scope.go
+++ b/scope.go
@@ -1,0 +1,46 @@
+package otlpwire
+
+import (
+	"iter"
+)
+
+// Name returns the scope name (field 1) as a view into the underlying buffer.
+// Returns nil if the field is not present.
+//
+// Repeated occurrences resolve to the last one, matching protobuf singular
+// scalar semantics and pdata's unmarshal. Validation is structural and
+// operation-scoped: the whole scope message is walked, so trailing corruption
+// is reported, but nested attribute values are only parsed when Attributes is
+// iterated.
+func (s InstrumentationScope) Name() ([]byte, error) {
+	return extractLastBytesField([]byte(s), 1)
+}
+
+// Version returns the scope version (field 2) as a view into the underlying
+// buffer. Returns nil if the field is not present. Repeated occurrences
+// resolve to the last one, as for Name.
+func (s InstrumentationScope) Version() ([]byte, error) {
+	return extractLastBytesField([]byte(s), 2)
+}
+
+// Attributes returns an iterator over the scope's attribute KeyValues.
+// The returned function should be called after iteration to check for errors.
+//
+// Scope attributes are field 3, unlike Resource attributes, which are field 1.
+func (s InstrumentationScope) Attributes() (iter.Seq[KeyValue], func() error) {
+	return repeatedFieldSeq[KeyValue]([]byte(s), 3)
+}
+
+// AttributesSeq is a zero-allocation alternative to Attributes. It has the
+// shape of an iter.Seq2[KeyValue, error] and is meant to be ranged over
+// directly. On a parse error it yields a nil KeyValue with a non-nil error and
+// stops.
+func (s InstrumentationScope) AttributesSeq(yield func(KeyValue, error) bool) {
+	forEachRepeatedField([]byte(s), 3, func(rb []byte, err error) bool {
+		if err != nil {
+			yield(nil, err)
+			return false
+		}
+		return yield(KeyValue(rb), nil)
+	})
+}

--- a/scope_test.go
+++ b/scope_test.go
@@ -39,15 +39,7 @@ func scopeMessage(name, version string) []byte {
 // scopeWithStringAttr builds an InstrumentationScope carrying one string
 // attribute. Scope attributes are field 3; Resource attributes are field 1.
 func scopeWithStringAttr(key, value string) []byte {
-	anyValue := protowire.AppendTag(nil, 1, protowire.BytesType)
-	anyValue = protowire.AppendString(anyValue, value)
-
-	kv := protowire.AppendTag(nil, 1, protowire.BytesType)
-	kv = protowire.AppendString(kv, key)
-	kv = protowire.AppendTag(kv, 2, protowire.BytesType)
-	kv = protowire.AppendVarint(kv, uint64(len(anyValue)))
-	kv = append(kv, anyValue...)
-
+	kv := stringKeyValue(key, value)
 	out := protowire.AppendTag(nil, 3, protowire.BytesType)
 	out = protowire.AppendVarint(out, uint64(len(kv)))
 	return append(out, kv...)

--- a/scope_test.go
+++ b/scope_test.go
@@ -1,0 +1,743 @@
+package otlpwire
+
+// Tests for Scope() and SchemaUrl(). The scope container's InstrumentationScope
+// is optional and repeated singular occurrences merge, exactly as for Resource.
+// schema_url is a singular *scalar*, so repeated occurrences resolve to the
+// last one instead of merging. Fixtures are built with protowire because
+// pdata's API cannot emit the omitted, empty, or repeated-singular shapes under
+// test; pdata remains the oracle for meaning.
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// ---------- wire-fixture builders ----------
+
+// scopeMessage builds an InstrumentationScope carrying name (field 1) and
+// version (field 2). Empty strings are omitted rather than encoded.
+func scopeMessage(name, version string) []byte {
+	var out []byte
+	if name != "" {
+		out = protowire.AppendTag(out, 1, protowire.BytesType)
+		out = protowire.AppendString(out, name)
+	}
+	if version != "" {
+		out = protowire.AppendTag(out, 2, protowire.BytesType)
+		out = protowire.AppendString(out, version)
+	}
+	return out
+}
+
+// scopeWithStringAttr builds an InstrumentationScope carrying one string
+// attribute. Scope attributes are field 3; Resource attributes are field 1.
+func scopeWithStringAttr(key, value string) []byte {
+	anyValue := protowire.AppendTag(nil, 1, protowire.BytesType)
+	anyValue = protowire.AppendString(anyValue, value)
+
+	kv := protowire.AppendTag(nil, 1, protowire.BytesType)
+	kv = protowire.AppendString(kv, key)
+	kv = protowire.AppendTag(kv, 2, protowire.BytesType)
+	kv = protowire.AppendVarint(kv, uint64(len(anyValue)))
+	kv = append(kv, anyValue...)
+
+	out := protowire.AppendTag(nil, 3, protowire.BytesType)
+	out = protowire.AppendVarint(out, uint64(len(kv)))
+	return append(out, kv...)
+}
+
+// scopeContainer builds a ScopeLogs/ScopeSpans/ScopeMetrics carrying every
+// supplied InstrumentationScope occurrence in field 1, in wire order.
+func scopeContainer(scopes ...[]byte) []byte {
+	var out []byte
+	for _, s := range scopes {
+		out = protowire.AppendTag(out, 1, protowire.BytesType)
+		out = protowire.AppendVarint(out, uint64(len(s)))
+		out = append(out, s...)
+	}
+	return out
+}
+
+// scopeContainerWithSchemaURLs appends schema_url occurrences (field 3) after
+// the supplied scope occurrences.
+func scopeContainerWithSchemaURLs(scopes [][]byte, schemaURLs ...string) []byte {
+	out := scopeContainer(scopes...)
+	for _, u := range schemaURLs {
+		out = protowire.AppendTag(out, 3, protowire.BytesType)
+		out = protowire.AppendString(out, u)
+	}
+	return out
+}
+
+// resourceContainerWithScope wraps a scope container as field 2 of a
+// ResourceLogs/ResourceMetrics/ResourceSpans, omitting the optional Resource.
+func resourceContainerWithScope(sc []byte) []byte {
+	out := protowire.AppendTag(nil, 2, protowire.BytesType)
+	out = protowire.AppendVarint(out, uint64(len(sc)))
+	return append(out, sc...)
+}
+
+// resourceContainerWithSchemaURLs wraps a scope container and appends
+// schema_url occurrences (field 3) at the resource-container level.
+func resourceContainerWithSchemaURLs(sc []byte, schemaURLs ...string) []byte {
+	out := resourceContainerWithScope(sc)
+	for _, u := range schemaURLs {
+		out = protowire.AppendTag(out, 3, protowire.BytesType)
+		out = protowire.AppendString(out, u)
+	}
+	return out
+}
+
+// ---------- signal-generic harness ----------
+
+// scopeGetter is satisfied by ScopeLogs, ScopeMetrics, and ScopeSpans.
+type scopeGetter interface {
+	Scope() (InstrumentationScope, error)
+	SchemaUrl() ([]byte, error)
+}
+
+// schemaURLGetter is satisfied by every resource and scope container.
+type schemaURLGetter interface {
+	SchemaUrl() ([]byte, error)
+}
+
+// pdataScopeView is what the oracle reports for a single-resource,
+// single-scope payload.
+type pdataScopeView struct {
+	scope             pcommon.InstrumentationScope
+	scopeSchemaURL    string
+	resourceSchemaURL string
+}
+
+type scopeSignalFixture struct {
+	name      string
+	scopes    func([]byte) scopeGetter
+	resources func([]byte) schemaURLGetter
+	pdata     func(t *testing.T, payload []byte) pdataScopeView
+}
+
+var scopeSignalFixtures = []scopeSignalFixture{
+	{
+		name:      "metrics",
+		scopes:    func(b []byte) scopeGetter { return ScopeMetrics(b) },
+		resources: func(b []byte) schemaURLGetter { return ResourceMetrics(b) },
+		pdata: func(t *testing.T, payload []byte) pdataScopeView {
+			t.Helper()
+			req := pmetricotlp.NewExportRequest()
+			require.NoError(t, req.UnmarshalProto(payload))
+			require.Equal(t, 1, req.Metrics().ResourceMetrics().Len())
+			rm := req.Metrics().ResourceMetrics().At(0)
+			require.Equal(t, 1, rm.ScopeMetrics().Len())
+			sm := rm.ScopeMetrics().At(0)
+			return pdataScopeView{sm.Scope(), sm.SchemaUrl(), rm.SchemaUrl()}
+		},
+	},
+	{
+		name:      "logs",
+		scopes:    func(b []byte) scopeGetter { return ScopeLogs(b) },
+		resources: func(b []byte) schemaURLGetter { return ResourceLogs(b) },
+		pdata: func(t *testing.T, payload []byte) pdataScopeView {
+			t.Helper()
+			req := plogotlp.NewExportRequest()
+			require.NoError(t, req.UnmarshalProto(payload))
+			require.Equal(t, 1, req.Logs().ResourceLogs().Len())
+			rl := req.Logs().ResourceLogs().At(0)
+			require.Equal(t, 1, rl.ScopeLogs().Len())
+			sl := rl.ScopeLogs().At(0)
+			return pdataScopeView{sl.Scope(), sl.SchemaUrl(), rl.SchemaUrl()}
+		},
+	},
+	{
+		name:      "traces",
+		scopes:    func(b []byte) scopeGetter { return ScopeSpans(b) },
+		resources: func(b []byte) schemaURLGetter { return ResourceSpans(b) },
+		pdata: func(t *testing.T, payload []byte) pdataScopeView {
+			t.Helper()
+			req := ptraceotlp.NewExportRequest()
+			require.NoError(t, req.UnmarshalProto(payload))
+			require.Equal(t, 1, req.Traces().ResourceSpans().Len())
+			rs := req.Traces().ResourceSpans().At(0)
+			require.Equal(t, 1, rs.ScopeSpans().Len())
+			ss := rs.ScopeSpans().At(0)
+			return pdataScopeView{ss.Scope(), ss.SchemaUrl(), rs.SchemaUrl()}
+		},
+	},
+}
+
+// ---------- absence and empty-but-present ----------
+
+// TestScope_AbsentField proves an omitted scope is valid OTLP and that Scope()
+// reports (nil, nil) rather than an error, matching pdata's empty scope.
+func TestScope_AbsentField(t *testing.T) {
+	sc := scopeContainer()
+	payload := wrapAsRequest(resourceContainerWithScope(sc))
+
+	for _, sf := range scopeSignalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			view := sf.pdata(t, payload)
+			require.Empty(t, view.scope.Name())
+			require.Empty(t, view.scope.Version())
+			require.Equal(t, 0, view.scope.Attributes().Len())
+
+			got, err := sf.scopes(sc).Scope()
+			require.NoError(t, err)
+			require.Nil(t, got)
+		})
+	}
+}
+
+// TestScope_PresentButEmpty covers a zero-length scope message: present on the
+// wire, empty in pdata.
+func TestScope_PresentButEmpty(t *testing.T) {
+	sc := scopeContainer(nil)
+	payload := wrapAsRequest(resourceContainerWithScope(sc))
+
+	for _, sf := range scopeSignalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			view := sf.pdata(t, payload)
+			require.Empty(t, view.scope.Name())
+
+			got, err := sf.scopes(sc).Scope()
+			require.NoError(t, err)
+			require.Empty(t, got)
+
+			name, err := got.Name()
+			require.NoError(t, err)
+			require.Nil(t, name)
+		})
+	}
+}
+
+// ---------- populated: name, version, attributes ----------
+
+// TestScope_Populated checks the accessors against pdata for a fully populated
+// scope, and pins that scope attributes come from field 3.
+func TestScope_Populated(t *testing.T) {
+	scope := append(scopeMessage("checkout-instr", "1.2.3"),
+		scopeWithStringAttr("library.language", "go")...)
+	sc := scopeContainer(scope)
+	payload := wrapAsRequest(resourceContainerWithScope(sc))
+
+	for _, sf := range scopeSignalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			view := sf.pdata(t, payload)
+			require.Equal(t, "checkout-instr", view.scope.Name())
+			require.Equal(t, "1.2.3", view.scope.Version())
+
+			got, err := sf.scopes(sc).Scope()
+			require.NoError(t, err)
+
+			name, err := got.Name()
+			require.NoError(t, err)
+			require.Equal(t, view.scope.Name(), string(name))
+
+			version, err := got.Version()
+			require.NoError(t, err)
+			require.Equal(t, view.scope.Version(), string(version))
+
+			pdataValue, ok := view.scope.Attributes().Get("library.language")
+			require.True(t, ok)
+			require.Equal(t, "go", pdataValue.Str())
+
+			count := 0
+			seq, errFn := got.Attributes()
+			for kv := range seq {
+				count++
+				key, err := kv.Key()
+				require.NoError(t, err)
+				require.Equal(t, "library.language", string(key))
+				value, found, err := kv.StringValue()
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, "go", string(value))
+			}
+			require.NoError(t, errFn())
+			require.Equal(t, view.scope.Attributes().Len(), count)
+		})
+	}
+}
+
+// TestScope_AttributesSeqMatchesAttributes proves the zero-allocation variant
+// yields the same elements as the closure-based iterator.
+func TestScope_AttributesSeqMatchesAttributes(t *testing.T) {
+	scope := append(scopeWithStringAttr("a", "1"), scopeWithStringAttr("b", "2")...)
+	got := InstrumentationScope(scope)
+
+	var viaSeq []string
+	got.AttributesSeq(func(kv KeyValue, err error) bool {
+		require.NoError(t, err)
+		key, keyErr := kv.Key()
+		require.NoError(t, keyErr)
+		viaSeq = append(viaSeq, string(key))
+		return true
+	})
+
+	var viaIter []string
+	seq, errFn := got.Attributes()
+	for kv := range seq {
+		key, err := kv.Key()
+		require.NoError(t, err)
+		viaIter = append(viaIter, string(key))
+	}
+	require.NoError(t, errFn())
+
+	require.Equal(t, []string{"a", "b"}, viaSeq)
+	require.Equal(t, viaSeq, viaIter)
+}
+
+// TestScope_AttributesSeq_EarlyStop proves an early return leaves the rest
+// unvisited, matching the documented lazy-iteration contract.
+func TestScope_AttributesSeq_EarlyStop(t *testing.T) {
+	scope := append(scopeWithStringAttr("a", "1"), scopeWithStringAttr("b", "2")...)
+
+	visited := 0
+	InstrumentationScope(scope).AttributesSeq(func(_ KeyValue, err error) bool {
+		require.NoError(t, err)
+		visited++
+		return false
+	})
+	require.Equal(t, 1, visited)
+}
+
+// TestScope_AttributesSeq_ZeroAllocations pins the hot-path gate that matches
+// the existing Resource.AttributesSeq guarantee.
+func TestScope_AttributesSeq_ZeroAllocations(t *testing.T) {
+	scope := InstrumentationScope(append(
+		scopeWithStringAttr("service.name", "checkout"),
+		scopeWithStringAttr("library.language", "go")...))
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		count := 0
+		scope.AttributesSeq(func(_ KeyValue, err error) bool {
+			if err != nil {
+				t.Fatal(err)
+			}
+			count++
+			return true
+		})
+		if count != 2 {
+			t.Fatalf("expected 2 attributes, got %d", count)
+		}
+	})
+	require.Zero(t, allocs)
+}
+
+// ---------- single occurrence: the hot, zero-copy path ----------
+
+// TestScope_SingleOccurrence_IsZeroCopy proves the common case returns a slice
+// aliasing the source buffer rather than a copy, and that the returned view
+// cannot be appended into its neighbours.
+func TestScope_SingleOccurrence_IsZeroCopy(t *testing.T) {
+	scope := scopeMessage("checkout-instr", "1.2.3")
+	baseContainer := scopeContainerWithSchemaURLs([][]byte{scope}, "https://example.test/schema")
+
+	for _, sf := range scopeSignalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			// Fresh copy per subtest since the aliasing check mutates in place.
+			sc := append([]byte(nil), baseContainer...)
+			got, err := sf.scopes(sc).Scope()
+			require.NoError(t, err)
+			require.NotEmpty(t, got)
+
+			idx := bytes.Index(sc, scope)
+			require.GreaterOrEqual(t, idx, 0, "scope bytes must appear in the container")
+
+			before := append([]byte(nil), got...)
+			for i := range scope {
+				sc[idx+i] ^= 0xFF
+			}
+			require.Equal(t, sc[idx:idx+len(scope)], []byte(got),
+				"returned slice must alias the whole scope region, not copy it")
+			for i := range got {
+				require.NotEqual(t, before[i], got[i],
+					"byte %d must reflect the source mutation", i)
+			}
+
+			// An unclamped capacity would let a caller's append overwrite the
+			// sibling schema_url field.
+			require.Equal(t, len(got), cap(got),
+				"capacity must be clamped so append reallocates instead of corrupting the container")
+			tail := append([]byte(nil), sc[idx+len(scope):]...)
+			_ = append(got, 0xEE, 0xEE) //nolint:gocritic // deliberately discarded: asserting no in-place growth
+			require.Equal(t, tail, sc[idx+len(scope):],
+				"appending to the returned view must not touch bytes after the scope")
+		})
+	}
+}
+
+// TestScopeSingleOccurrence_ZeroAllocations pins the performance gate: Scope()
+// on the common single-occurrence container allocates nothing.
+func TestScopeSingleOccurrence_ZeroAllocations(t *testing.T) {
+	sm := ScopeMetrics(scopeContainer(scopeMessage("checkout-instr", "1.2.3")))
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, err := sm.Scope()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) == 0 {
+			t.Fatal("expected a non-empty scope")
+		}
+	})
+	require.Zero(t, allocs)
+}
+
+// ---------- merge: 2+ scope occurrences ----------
+
+// TestScope_Merge covers protobuf merge behavior for repeated occurrences of
+// the singular scope field. Attributes accumulate, while name and version are
+// scalars, so the later occurrence wins — pdata is the oracle for both.
+func TestScope_Merge(t *testing.T) {
+	tests := []struct {
+		name        string
+		occurrences [][]byte
+	}{
+		{
+			"attributes accumulate",
+			[][]byte{scopeWithStringAttr("a", "1"), scopeWithStringAttr("b", "2")},
+		},
+		{
+			"later name and version win",
+			[][]byte{scopeMessage("first", "1.0.0"), scopeMessage("second", "2.0.0")},
+		},
+		{
+			"later occurrence fills omitted version",
+			[][]byte{scopeMessage("first", ""), scopeMessage("", "2.0.0")},
+		},
+		{
+			"three occurrences",
+			[][]byte{
+				scopeMessage("first", "1.0.0"),
+				scopeWithStringAttr("a", "1"),
+				scopeMessage("third", "3.0.0"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := scopeContainer(tt.occurrences...)
+			payload := wrapAsRequest(resourceContainerWithScope(sc))
+
+			for _, sf := range scopeSignalFixtures {
+				t.Run(sf.name, func(t *testing.T) {
+					view := sf.pdata(t, payload)
+
+					got, err := sf.scopes(sc).Scope()
+					require.NoError(t, err)
+
+					name, err := got.Name()
+					require.NoError(t, err)
+					require.Equal(t, view.scope.Name(), string(name))
+
+					version, err := got.Version()
+					require.NoError(t, err)
+					require.Equal(t, view.scope.Version(), string(version))
+
+					count := 0
+					seq, errFn := got.Attributes()
+					for range seq {
+						count++
+					}
+					require.NoError(t, errFn())
+					require.Equal(t, view.scope.Attributes().Len(), count)
+				})
+			}
+		})
+	}
+}
+
+// TestScope_MergeMultipleOccurrencesAllocates documents the one accepted
+// allocation: merging 2+ occurrences concatenates into a new buffer.
+func TestScope_MergeMultipleOccurrencesAllocates(t *testing.T) {
+	sm := ScopeMetrics(scopeContainer(scopeMessage("first", ""), scopeMessage("", "2.0.0")))
+
+	allocs := testing.AllocsPerRun(100, func() {
+		got, err := sm.Scope()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) == 0 {
+			t.Fatal("expected a non-empty scope")
+		}
+	})
+	require.Positive(t, allocs, "merging 2+ occurrences is documented to allocate")
+}
+
+// TestScope_SplicedOccurrencesRejected proves concatenation cannot manufacture
+// validity: two occurrences that each fail to parse alone must not reassemble
+// into a scope pdata would reject.
+func TestScope_SplicedOccurrencesRejected(t *testing.T) {
+	// A name field declaring 8 bytes but carrying only 3, with the remaining
+	// 5 in the next occurrence.
+	whole := protowire.AppendTag(nil, 1, protowire.BytesType)
+	whole = protowire.AppendString(whole, "checkout")
+	split := len(whole) - 5
+
+	sc := scopeContainer(whole[:split], whole[split:])
+	payload := wrapAsRequest(resourceContainerWithScope(sc))
+
+	// The three signals share these field numbers, so one oracle covers them.
+	req := pmetricotlp.NewExportRequest()
+	require.Error(t, req.UnmarshalProto(payload), "pdata must reject the spliced payload")
+
+	for _, sf := range scopeSignalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			_, err := sf.scopes(sc).Scope()
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestScope_ValidOccurrencesStillMerge guards against the splice check
+// becoming over-strict.
+func TestScope_ValidOccurrencesStillMerge(t *testing.T) {
+	sc := scopeContainer(scopeMessage("first", ""), scopeMessage("", "2.0.0"))
+
+	for _, sf := range scopeSignalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			got, err := sf.scopes(sc).Scope()
+			require.NoError(t, err)
+
+			name, err := got.Name()
+			require.NoError(t, err)
+			require.Equal(t, "first", string(name))
+
+			version, err := got.Version()
+			require.NoError(t, err)
+			require.Equal(t, "2.0.0", string(version))
+		})
+	}
+}
+
+// ---------- malformed input ----------
+
+func TestScope_Malformed(t *testing.T) {
+	tests := []struct {
+		name string
+		sc   []byte
+	}{
+		{
+			"wrong wire type for scope field",
+			func() []byte {
+				out := protowire.AppendTag(nil, 1, protowire.VarintType)
+				return protowire.AppendVarint(out, 42)
+			}(),
+		},
+		{
+			"truncated scope length",
+			func() []byte {
+				out := protowire.AppendTag(nil, 1, protowire.BytesType)
+				out = protowire.AppendVarint(out, 32)
+				return append(out, 0x01, 0x02)
+			}(),
+		},
+		{
+			"malformed field after the last scope occurrence",
+			func() []byte {
+				out := scopeContainer(scopeMessage("checkout-instr", ""))
+				out = protowire.AppendTag(out, 9, protowire.BytesType)
+				return protowire.AppendVarint(out, 64)
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, sf := range scopeSignalFixtures {
+				t.Run(sf.name, func(t *testing.T) {
+					_, err := sf.scopes(tt.sc).Scope()
+					require.Error(t, err)
+				})
+			}
+		})
+	}
+}
+
+// TestScope_MalformedAttributeSurfacesOnIteration pins the operation-scoped
+// validation level: Name() walks the scope structurally and succeeds, while
+// iterating the corrupt attribute reports the error.
+func TestScope_MalformedAttributeSurfacesOnIteration(t *testing.T) {
+	badKV := protowire.AppendTag(nil, 1, protowire.BytesType)
+	badKV = protowire.AppendVarint(badKV, 64) // declares more than it carries
+
+	scope := protowire.AppendTag(nil, 3, protowire.BytesType)
+	scope = protowire.AppendVarint(scope, uint64(len(badKV)))
+	scope = append(scope, badKV...)
+	scope = append(scopeMessage("checkout-instr", ""), scope...)
+
+	got := InstrumentationScope(scope)
+
+	name, err := got.Name()
+	require.NoError(t, err)
+	require.Equal(t, "checkout-instr", string(name))
+
+	seq, errFn := got.Attributes()
+	for kv := range seq {
+		_, _, err := kv.StringValue()
+		require.Error(t, err)
+	}
+	require.NoError(t, errFn())
+}
+
+// TestScope_UnknownAndOutOfOrderFieldsSkipped proves forward compatibility:
+// unknown fields and a scope field emitted after the records field still work.
+func TestScope_UnknownAndOutOfOrderFieldsSkipped(t *testing.T) {
+	sc := protowire.AppendTag(nil, 7, protowire.VarintType)
+	sc = protowire.AppendVarint(sc, 99)
+	sc = protowire.AppendTag(sc, 2, protowire.BytesType)
+	sc = protowire.AppendVarint(sc, 0)
+	scope := scopeMessage("checkout-instr", "1.2.3")
+	sc = protowire.AppendTag(sc, 1, protowire.BytesType)
+	sc = protowire.AppendVarint(sc, uint64(len(scope)))
+	sc = append(sc, scope...)
+
+	for _, sf := range scopeSignalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			got, err := sf.scopes(sc).Scope()
+			require.NoError(t, err)
+
+			name, err := got.Name()
+			require.NoError(t, err)
+			require.Equal(t, "checkout-instr", string(name))
+		})
+	}
+}
+
+// ---------- schema_url ----------
+
+// TestSchemaUrl_Absent proves an omitted schema_url is (nil, nil), matching
+// pdata's empty string.
+func TestSchemaUrl_Absent(t *testing.T) {
+	sc := scopeContainer(scopeMessage("checkout-instr", ""))
+	container := resourceContainerWithScope(sc)
+	payload := wrapAsRequest(container)
+
+	for _, sf := range scopeSignalFixtures {
+		t.Run(sf.name, func(t *testing.T) {
+			view := sf.pdata(t, payload)
+			require.Empty(t, view.scopeSchemaURL)
+			require.Empty(t, view.resourceSchemaURL)
+
+			got, err := sf.scopes(sc).SchemaUrl()
+			require.NoError(t, err)
+			require.Nil(t, got)
+
+			got, err = sf.resources(container).SchemaUrl()
+			require.NoError(t, err)
+			require.Nil(t, got)
+		})
+	}
+}
+
+// TestSchemaUrl_LastValueWins is the core differential for the scalar
+// contract: protobuf and pdata resolve a repeated singular string to the last
+// occurrence, so a first-match extractor would diverge.
+func TestSchemaUrl_LastValueWins(t *testing.T) {
+	tests := []struct {
+		name string
+		urls []string
+		want string
+	}{
+		{"single", []string{"https://example.test/v1"}, "https://example.test/v1"},
+		{"repeated", []string{"https://example.test/v1", "https://example.test/v2"}, "https://example.test/v2"},
+		{"three", []string{"a", "b", "c"}, "c"},
+		{"last is empty", []string{"https://example.test/v1", ""}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := scopeContainerWithSchemaURLs([][]byte{scopeMessage("s", "")}, tt.urls...)
+			container := resourceContainerWithSchemaURLs(sc, tt.urls...)
+			payload := wrapAsRequest(container)
+
+			for _, sf := range scopeSignalFixtures {
+				t.Run(sf.name, func(t *testing.T) {
+					view := sf.pdata(t, payload)
+					require.Equal(t, tt.want, view.scopeSchemaURL, "pdata scope schema_url")
+					require.Equal(t, tt.want, view.resourceSchemaURL, "pdata resource schema_url")
+
+					got, err := sf.scopes(sc).SchemaUrl()
+					require.NoError(t, err)
+					require.Equal(t, tt.want, string(got))
+
+					got, err = sf.resources(container).SchemaUrl()
+					require.NoError(t, err)
+					require.Equal(t, tt.want, string(got))
+				})
+			}
+		})
+	}
+}
+
+// TestSchemaUrl_Malformed covers the wrong-wire-type and trailing-corruption
+// cases the full scan is responsible for reporting.
+func TestSchemaUrl_Malformed(t *testing.T) {
+	tests := []struct {
+		name string
+		sc   []byte
+	}{
+		{
+			"wrong wire type",
+			func() []byte {
+				out := protowire.AppendTag(nil, 3, protowire.VarintType)
+				return protowire.AppendVarint(out, 42)
+			}(),
+		},
+		{
+			"truncated length",
+			func() []byte {
+				out := protowire.AppendTag(nil, 3, protowire.BytesType)
+				out = protowire.AppendVarint(out, 32)
+				return append(out, 0x01)
+			}(),
+		},
+		{
+			"malformed field after schema_url",
+			func() []byte {
+				out := protowire.AppendTag(nil, 3, protowire.BytesType)
+				out = protowire.AppendString(out, "https://example.test/v1")
+				out = protowire.AppendTag(out, 9, protowire.BytesType)
+				return protowire.AppendVarint(out, 64)
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, sf := range scopeSignalFixtures {
+				t.Run(sf.name, func(t *testing.T) {
+					_, err := sf.scopes(tt.sc).SchemaUrl()
+					require.Error(t, err)
+
+					_, err = sf.resources(resourceContainerWithScope(nil)).SchemaUrl()
+					require.NoError(t, err, "control: a clean container must still parse")
+				})
+			}
+		})
+	}
+}
+
+// TestSchemaUrl_ZeroAllocations keeps the accessor off the allocating path.
+func TestSchemaUrl_ZeroAllocations(t *testing.T) {
+	sm := ScopeMetrics(scopeContainerWithSchemaURLs(
+		[][]byte{scopeMessage("checkout-instr", "")}, "https://example.test/v1"))
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, err := sm.SchemaUrl()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) == 0 {
+			t.Fatal("expected a schema URL")
+		}
+	})
+	require.Zero(t, allocs)
+}

--- a/scope_test.go
+++ b/scope_test.go
@@ -76,17 +76,6 @@ func resourceContainerWithScope(sc []byte) []byte {
 	return append(out, sc...)
 }
 
-// resourceContainerWithSchemaURLs wraps a scope container and appends
-// schema_url occurrences (field 3) at the resource-container level.
-func resourceContainerWithSchemaURLs(sc []byte, schemaURLs ...string) []byte {
-	out := resourceContainerWithScope(sc)
-	for _, u := range schemaURLs {
-		out = protowire.AppendTag(out, 3, protowire.BytesType)
-		out = protowire.AppendString(out, u)
-	}
-	return out
-}
-
 // ---------- signal-generic harness ----------
 
 // scopeGetter is satisfied by ScopeLogs, ScopeMetrics, and ScopeSpans.
@@ -95,31 +84,24 @@ type scopeGetter interface {
 	SchemaUrl() ([]byte, error)
 }
 
-// schemaURLGetter is satisfied by every resource and scope container.
-type schemaURLGetter interface {
-	SchemaUrl() ([]byte, error)
-}
-
 // pdataScopeView is what the oracle reports for a single-resource,
-// single-scope payload.
+// single-scope payload. Resource-level schema_url is covered in
+// resource_test.go, next to the other resource-container accessors.
 type pdataScopeView struct {
-	scope             pcommon.InstrumentationScope
-	scopeSchemaURL    string
-	resourceSchemaURL string
+	scope          pcommon.InstrumentationScope
+	scopeSchemaURL string
 }
 
 type scopeSignalFixture struct {
-	name      string
-	scopes    func([]byte) scopeGetter
-	resources func([]byte) schemaURLGetter
-	pdata     func(t *testing.T, payload []byte) pdataScopeView
+	name   string
+	scopes func([]byte) scopeGetter
+	pdata  func(t *testing.T, payload []byte) pdataScopeView
 }
 
 var scopeSignalFixtures = []scopeSignalFixture{
 	{
-		name:      "metrics",
-		scopes:    func(b []byte) scopeGetter { return ScopeMetrics(b) },
-		resources: func(b []byte) schemaURLGetter { return ResourceMetrics(b) },
+		name:   "metrics",
+		scopes: func(b []byte) scopeGetter { return ScopeMetrics(b) },
 		pdata: func(t *testing.T, payload []byte) pdataScopeView {
 			t.Helper()
 			req := pmetricotlp.NewExportRequest()
@@ -128,13 +110,12 @@ var scopeSignalFixtures = []scopeSignalFixture{
 			rm := req.Metrics().ResourceMetrics().At(0)
 			require.Equal(t, 1, rm.ScopeMetrics().Len())
 			sm := rm.ScopeMetrics().At(0)
-			return pdataScopeView{sm.Scope(), sm.SchemaUrl(), rm.SchemaUrl()}
+			return pdataScopeView{sm.Scope(), sm.SchemaUrl()}
 		},
 	},
 	{
-		name:      "logs",
-		scopes:    func(b []byte) scopeGetter { return ScopeLogs(b) },
-		resources: func(b []byte) schemaURLGetter { return ResourceLogs(b) },
+		name:   "logs",
+		scopes: func(b []byte) scopeGetter { return ScopeLogs(b) },
 		pdata: func(t *testing.T, payload []byte) pdataScopeView {
 			t.Helper()
 			req := plogotlp.NewExportRequest()
@@ -143,13 +124,12 @@ var scopeSignalFixtures = []scopeSignalFixture{
 			rl := req.Logs().ResourceLogs().At(0)
 			require.Equal(t, 1, rl.ScopeLogs().Len())
 			sl := rl.ScopeLogs().At(0)
-			return pdataScopeView{sl.Scope(), sl.SchemaUrl(), rl.SchemaUrl()}
+			return pdataScopeView{sl.Scope(), sl.SchemaUrl()}
 		},
 	},
 	{
-		name:      "traces",
-		scopes:    func(b []byte) scopeGetter { return ScopeSpans(b) },
-		resources: func(b []byte) schemaURLGetter { return ResourceSpans(b) },
+		name:   "traces",
+		scopes: func(b []byte) scopeGetter { return ScopeSpans(b) },
 		pdata: func(t *testing.T, payload []byte) pdataScopeView {
 			t.Helper()
 			req := ptraceotlp.NewExportRequest()
@@ -158,7 +138,7 @@ var scopeSignalFixtures = []scopeSignalFixture{
 			rs := req.Traces().ResourceSpans().At(0)
 			require.Equal(t, 1, rs.ScopeSpans().Len())
 			ss := rs.ScopeSpans().At(0)
-			return pdataScopeView{ss.Scope(), ss.SchemaUrl(), rs.SchemaUrl()}
+			return pdataScopeView{ss.Scope(), ss.SchemaUrl()}
 		},
 	},
 }
@@ -609,20 +589,13 @@ func TestScope_UnknownAndOutOfOrderFieldsSkipped(t *testing.T) {
 // pdata's empty string.
 func TestSchemaUrl_Absent(t *testing.T) {
 	sc := scopeContainer(scopeMessage("checkout-instr", ""))
-	container := resourceContainerWithScope(sc)
-	payload := wrapAsRequest(container)
+	payload := wrapAsRequest(resourceContainerWithScope(sc))
 
 	for _, sf := range scopeSignalFixtures {
 		t.Run(sf.name, func(t *testing.T) {
-			view := sf.pdata(t, payload)
-			require.Empty(t, view.scopeSchemaURL)
-			require.Empty(t, view.resourceSchemaURL)
+			require.Empty(t, sf.pdata(t, payload).scopeSchemaURL)
 
 			got, err := sf.scopes(sc).SchemaUrl()
-			require.NoError(t, err)
-			require.Nil(t, got)
-
-			got, err = sf.resources(container).SchemaUrl()
 			require.NoError(t, err)
 			require.Nil(t, got)
 		})
@@ -647,20 +620,14 @@ func TestSchemaUrl_LastValueWins(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sc := scopeContainerWithSchemaURLs([][]byte{scopeMessage("s", "")}, tt.urls...)
-			container := resourceContainerWithSchemaURLs(sc, tt.urls...)
-			payload := wrapAsRequest(container)
+			payload := wrapAsRequest(resourceContainerWithScope(sc))
 
 			for _, sf := range scopeSignalFixtures {
 				t.Run(sf.name, func(t *testing.T) {
-					view := sf.pdata(t, payload)
-					require.Equal(t, tt.want, view.scopeSchemaURL, "pdata scope schema_url")
-					require.Equal(t, tt.want, view.resourceSchemaURL, "pdata resource schema_url")
+					require.Equal(t, tt.want, sf.pdata(t, payload).scopeSchemaURL,
+						"pdata scope schema_url")
 
 					got, err := sf.scopes(sc).SchemaUrl()
-					require.NoError(t, err)
-					require.Equal(t, tt.want, string(got))
-
-					got, err = sf.resources(container).SchemaUrl()
 					require.NoError(t, err)
 					require.Equal(t, tt.want, string(got))
 				})
@@ -708,9 +675,6 @@ func TestSchemaUrl_Malformed(t *testing.T) {
 				t.Run(sf.name, func(t *testing.T) {
 					_, err := sf.scopes(tt.sc).SchemaUrl()
 					require.Error(t, err)
-
-					_, err = sf.resources(resourceContainerWithScope(nil)).SchemaUrl()
-					require.NoError(t, err, "control: a clean container must still parse")
 				})
 			}
 		})

--- a/scope_test.go
+++ b/scope_test.go
@@ -178,7 +178,10 @@ func TestScope_PresentButEmpty(t *testing.T) {
 
 			got, err := sf.scopes(sc).Scope()
 			require.NoError(t, err)
-			require.Empty(t, got)
+			// NotNil separates this from TestScope_AbsentField: a
+			// present-but-empty scope must not collapse into an absent one.
+			require.NotNil(t, got, "a zero-length scope is present, not absent")
+			require.Len(t, got, 0)
 
 			name, err := got.Name()
 			require.NoError(t, err)
@@ -551,12 +554,17 @@ func TestScope_MalformedAttributeSurfacesOnIteration(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "checkout-instr", string(name))
 
+	// The visited counter matters: without it, pointing Attributes at the
+	// wrong field number would yield nothing and this test would still pass.
+	visited := 0
 	seq, errFn := got.Attributes()
 	for kv := range seq {
+		visited++
 		_, _, err := kv.StringValue()
 		require.Error(t, err)
 	}
 	require.NoError(t, errFn())
+	require.Equal(t, 1, visited, "the corrupt attribute must actually be yielded")
 }
 
 // TestScope_UnknownAndOutOfOrderFieldsSkipped proves forward compatibility:

--- a/traces.go
+++ b/traces.go
@@ -24,13 +24,20 @@ func (r ResourceSpans) SpanCount() (int, error) {
 // Resource returns the Resource message for this ResourceSpans. It returns
 // (nil, nil) when the field is absent, aliases the input for the single
 // occurrence every real producer emits, and merges 2+ occurrences into a new
-// buffer. See extractResourceMessage for the full contract.
+// buffer. See extractMergedMessage for the full contract.
 func (r ResourceSpans) Resource() (Resource, error) {
-	raw, err := extractResourceMessage([]byte(r))
+	raw, err := extractMergedMessage([]byte(r), 1)
 	if err != nil {
 		return nil, err
 	}
 	return Resource(raw), nil
+}
+
+// SchemaUrl returns the ResourceSpans schema_url (field 3) as a view into the
+// underlying buffer. Returns nil if the field is not present. Repeated
+// occurrences resolve to the last one.
+func (r ResourceSpans) SchemaUrl() ([]byte, error) {
+	return extractLastBytesField([]byte(r), 3)
 }
 
 // WriteTo writes the ResourceSpans as a valid ExportTracesServiceRequest to w.
@@ -49,6 +56,25 @@ func (r ResourceSpans) ScopeSpans() (iter.Seq[ScopeSpans], func() error) {
 // SpanCount returns the number of spans in this ScopeSpans.
 func (s ScopeSpans) SpanCount() (int, error) {
 	return countOccurrences([]byte(s), 2)
+}
+
+// Scope returns the InstrumentationScope for this ScopeSpans. It returns
+// (nil, nil) when the field is absent, aliases the input for the single
+// occurrence every real producer emits, and merges 2+ occurrences into a new
+// buffer. See extractMergedMessage for the full contract.
+func (s ScopeSpans) Scope() (InstrumentationScope, error) {
+	raw, err := extractMergedMessage([]byte(s), 1)
+	if err != nil {
+		return nil, err
+	}
+	return InstrumentationScope(raw), nil
+}
+
+// SchemaUrl returns the ScopeSpans schema_url (field 3) as a view into the
+// underlying buffer. Returns nil if the field is not present. Repeated
+// occurrences resolve to the last one.
+func (s ScopeSpans) SchemaUrl() ([]byte, error) {
+	return extractLastBytesField([]byte(s), 3)
 }
 
 // Spans returns an iterator over Spans in this ScopeSpans.

--- a/types.go
+++ b/types.go
@@ -23,6 +23,14 @@ type ResourceLogs []byte
 // per container, matching pdata's object model.
 type Resource []byte
 
+// InstrumentationScope represents an InstrumentationScope message (raw wire
+// bytes).
+//
+// InstrumentationScope values are normally obtained from a ScopeMetrics,
+// ScopeLogs, or ScopeSpans Scope method, which returns exactly one merged
+// scope per container, matching pdata's object model.
+type InstrumentationScope []byte
+
 // ScopeLogs represents a single ScopeLogs message (raw wire bytes).
 type ScopeLogs []byte
 

--- a/wire.go
+++ b/wire.go
@@ -288,18 +288,14 @@ func extractBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
 }
 
 // extractLastBytesField extracts a singular length-delimited scalar field,
-// resolving repeated occurrences by last-value-wins. Returns nil (not an
-// error) if absent. The returned slice aliases data; no copy is made.
+// resolving repeated occurrences by last-value-wins the way protobuf and
+// pdata do. Returns nil (not an error) if absent; the returned slice aliases
+// data.
 //
-// Protobuf specifies that a repeated occurrence of a singular scalar replaces
-// the earlier one, and pdata implements exactly that with a plain assignment
-// (`orig.SchemaUrl = string(...)`), unlike the embedded messages it merges via
-// extractMergedMessage. Honoring that requires scanning the whole message
-// rather than returning at the first match the way extractBytesField does, so
-// a malformed field after the last occurrence is an error here too.
-//
-// docs/DESIGN.md records why singular scalars resolve differently from
-// singular messages.
+// Reaching the last occurrence means walking the whole message, so unlike
+// extractBytesField this reports a malformed field after that occurrence.
+// docs/DESIGN.md records why scalars resolve differently from the messages
+// extractMergedMessage merges.
 func extractLastBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
 	var last []byte
 	var walkErr error

--- a/wire.go
+++ b/wire.go
@@ -149,22 +149,25 @@ func validateMessageFraming(data []byte) error {
 	for pos := 0; pos < len(data); {
 		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
 		if tagLen < 0 {
-			return errors.New("malformed protobuf tag in resource occurrence")
+			return errors.New("malformed protobuf tag in message occurrence")
 		}
 		pos += tagLen
 
 		n := skipField(data[pos:], num, wireType)
 		if n < 0 {
-			return errors.New("malformed field in resource occurrence")
+			return errors.New("malformed field in message occurrence")
 		}
 		pos += n
 	}
 	return nil
 }
 
-// extractResourceMessage returns the Resource message (field 1) of a
-// ResourceMetrics/ResourceLogs/ResourceSpans, merging repeated occurrences the
-// way protobuf and pdata do.
+// extractMergedMessage returns the singular embedded message at fieldNum,
+// merging repeated occurrences the way protobuf and pdata do. It backs both
+// the Resource field (field 1) of a ResourceMetrics/ResourceLogs/ResourceSpans
+// and the InstrumentationScope field (field 1) of a
+// ScopeMetrics/ScopeLogs/ScopeSpans: pdata unmarshals every occurrence of each
+// into the same struct, so both accumulate rather than replace.
 //
 // An absent field returns (nil, nil); malformed framing returns an error. One
 // occurrence aliases data; two or more are each validated, then concatenated
@@ -175,27 +178,26 @@ func validateMessageFraming(data []byte) error {
 //
 // docs/DESIGN.md covers why concatenation is a correct merge and why each
 // occurrence is validated first; docs/BENCHMARKS.md has the scan cost.
-func extractResourceMessage(data []byte) ([]byte, error) {
+func extractMergedMessage(data []byte, fieldNum protowire.Number) ([]byte, error) {
 	var first []byte
 	var found bool
 	var rest [][]byte
 	pos := 0
 
 	for pos < len(data) {
-		fieldNum, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
 		if tagLen < 0 {
 			return nil, errors.New("malformed protobuf tag")
 		}
 		pos += tagLen
 
-		// Field 1 = Resource (message)
-		if fieldNum == 1 {
+		if num == fieldNum {
 			if wireType != protowire.BytesType {
-				return nil, errors.New("resource field has wrong wire type")
+				return nil, errors.New("embedded message field has wrong wire type")
 			}
 			msgBytes, n := protowire.ConsumeBytes(data[pos:])
 			if n < 0 {
-				return nil, errors.New("invalid bytes in resource field")
+				return nil, errors.New("invalid bytes in embedded message field")
 			}
 			pos += n
 
@@ -209,7 +211,7 @@ func extractResourceMessage(data []byte) ([]byte, error) {
 		}
 
 		// Skip other fields
-		n := skipField(data[pos:], fieldNum, wireType)
+		n := skipField(data[pos:], num, wireType)
 		if n < 0 {
 			return nil, errors.New("failed to skip field")
 		}
@@ -227,7 +229,7 @@ func extractResourceMessage(data []byte) ([]byte, error) {
 		return first[:len(first):len(first)], nil
 	}
 
-	// Concatenation must not manufacture validity. A Resource spliced across
+	// Concatenation must not manufacture validity. A message spliced across
 	// two occurrences, neither parseable alone, would otherwise reassemble
 	// into a valid message that pdata rejects.
 	if err := validateMessageFraming(first); err != nil {
@@ -283,6 +285,54 @@ func extractBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
 	}
 
 	return nil, nil
+}
+
+// extractLastBytesField extracts a singular length-delimited scalar field,
+// resolving repeated occurrences by last-value-wins. Returns nil (not an
+// error) if absent. The returned slice aliases data; no copy is made.
+//
+// Protobuf specifies that a repeated occurrence of a singular scalar replaces
+// the earlier one, and pdata implements exactly that with a plain assignment
+// (`orig.SchemaUrl = string(...)`), unlike the embedded messages it merges via
+// extractMergedMessage. Honoring that requires scanning the whole message
+// rather than returning at the first match the way extractBytesField does, so
+// a malformed field after the last occurrence is an error here too.
+//
+// docs/DESIGN.md records why singular scalars resolve differently from
+// singular messages.
+func extractLastBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
+	var last []byte
+	pos := 0
+
+	for pos < len(data) {
+		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return nil, errors.New("malformed protobuf tag")
+		}
+		pos += tagLen
+
+		if num == fieldNum {
+			if wireType != protowire.BytesType {
+				return nil, errors.New("wrong wire type for field")
+			}
+			msgBytes, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return nil, errors.New("invalid bytes in field")
+			}
+			// Clamped so a caller's append cannot overwrite sibling fields.
+			last = msgBytes[:len(msgBytes):len(msgBytes)]
+			pos += n
+			continue
+		}
+
+		n := skipField(data[pos:], num, wireType)
+		if n < 0 {
+			return nil, errors.New("failed to skip field")
+		}
+		pos += n
+	}
+
+	return last, nil
 }
 
 // extractFixed64Field extracts the first occurrence of a fixed64 field from

--- a/wire.go
+++ b/wire.go
@@ -302,36 +302,20 @@ func extractBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
 // singular messages.
 func extractLastBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
 	var last []byte
-	pos := 0
+	var walkErr error
 
-	for pos < len(data) {
-		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
-		if tagLen < 0 {
-			return nil, errors.New("malformed protobuf tag")
+	forEachRepeatedField(data, fieldNum, func(item []byte, err error) bool {
+		if err != nil {
+			walkErr = err
+			return false
 		}
-		pos += tagLen
-
-		if num == fieldNum {
-			if wireType != protowire.BytesType {
-				return nil, errors.New("wrong wire type for field")
-			}
-			msgBytes, n := protowire.ConsumeBytes(data[pos:])
-			if n < 0 {
-				return nil, errors.New("invalid bytes in field")
-			}
-			// Clamped so a caller's append cannot overwrite sibling fields.
-			last = msgBytes[:len(msgBytes):len(msgBytes)]
-			pos += n
-			continue
-		}
-
-		n := skipField(data[pos:], num, wireType)
-		if n < 0 {
-			return nil, errors.New("failed to skip field")
-		}
-		pos += n
+		// Clamped so a caller's append cannot overwrite sibling fields.
+		last = item[:len(item):len(item)]
+		return true
+	})
+	if walkErr != nil {
+		return nil, walkErr
 	}
-
 	return last, nil
 }
 

--- a/wire.go
+++ b/wire.go
@@ -105,6 +105,12 @@ func countOccurrences(data []byte, fieldNum protowire.Number) (int, error) {
 
 // forEachRepeatedField iterates over a repeated field, calling fn for each occurrence.
 // The callback receives field bytes or an error. Return false to stop iteration.
+//
+// Yielded slices have their capacity clamped to their length. ConsumeBytes
+// hands back a slice whose capacity runs to the end of the enclosing message,
+// so an unclamped view would let a caller's append overwrite the sibling
+// fields that follow it in a buffer the library does not own. Every accessor
+// built on this helper inherits the guarantee.
 func forEachRepeatedField(data []byte, fieldNum protowire.Number, fn func([]byte, error) bool) {
 	pos := 0
 
@@ -128,7 +134,7 @@ func forEachRepeatedField(data []byte, fieldNum protowire.Number, fn func([]byte
 			}
 			pos += n
 
-			if !fn(msgBytes, nil) {
+			if !fn(msgBytes[:len(msgBytes):len(msgBytes)], nil) {
 				return
 			}
 		} else {
@@ -305,8 +311,7 @@ func extractLastBytesField(data []byte, fieldNum protowire.Number) ([]byte, erro
 			walkErr = err
 			return false
 		}
-		// Clamped so a caller's append cannot overwrite sibling fields.
-		last = item[:len(item):len(item)]
+		last = item
 		return true
 	})
 	if walkErr != nil {


### PR DESCRIPTION
Closes E-2942, the second sub-issue of E-2940 (v0.1.0 pdata realignment).

## Motivation

`ScopeMetrics`/`ScopeLogs`/`ScopeSpans` exposed only their record iterators. There was no way to reach the `InstrumentationScope` or `schema_url`, so dibber and sage each hand-rolled protobuf parsing to get them. This closes that hole the way E-2941 closed the `Resource()` one.

## Wire/API approach

All six containers share one shape: field 1 is the singular message (Resource or InstrumentationScope), field 2 repeats the children, field 3 is `schema_url`. Verified against pdata v1.64.0's generated `UnmarshalProto`, not from memory.

That verification surfaced the design point this PR turns on. **Protobuf resolves repeated occurrences of a singular field two different ways, and pdata implements both:**

- singular **messages** merge — pdata unmarshals every occurrence into the same object, so `extractResourceMessage` generalizes to `extractMergedMessage(data, fieldNum)` and now backs `Resource()` and `Scope()` alike;
- singular **scalars** are replaced — pdata assigns (`orig.SchemaUrl = string(...)`), so the last occurrence wins. New `extractLastBytesField` backs `SchemaUrl`, `InstrumentationScope.Name`/`Version`.

Two things follow that the issue did not anticipate:

1. **`schema_url` is last-value-wins, not first-match.** Reusing the existing `extractBytesField` would have silently diverged from pdata in exactly the way `Resource()` did before E-2941.
2. **Scope attributes are field 3**, where Resource attributes are field 1. Easy to get wrong by copying the Resource accessor; pinned by a test that fails if the field number moves.

`Metric.Name()` was the one remaining accessor still on first-match. Shipping a new rule with a known adjacent violation seemed worse than fixing it, so it moved onto the same helper. `KeyValue.Key`/`ValueRaw` deliberately did **not** — see risks.

## API added

```go
func (s ScopeMetrics) Scope() (InstrumentationScope, error)   // and ScopeLogs, ScopeSpans
func (s ScopeMetrics) SchemaUrl() ([]byte, error)             // and all six containers

type InstrumentationScope []byte
func (s InstrumentationScope) Name() ([]byte, error)
func (s InstrumentationScope) Version() ([]byte, error)
func (s InstrumentationScope) Attributes() (iter.Seq[KeyValue], func() error)
func (s InstrumentationScope) AttributesSeq(yield func(KeyValue, error) bool)
```

`Scope()` carries `Resource()`'s contract exactly: `(nil, nil)` when absent, zero-copy for the single occurrence real producers emit, 2+ occurrences validated individually then merged.

## Validation

```bash
go test -v -race ./...   # 293 subtests pass
go vet ./...
git diff --check && git diff --check "${BASE_SHA}...HEAD"
```

Differential fixtures against pdata across all three signals for absent, empty, populated, repeated, merged, spliced and malformed scopes; wrong-wire-type, truncated-length and trailing-corruption cases; iterator early-stop and deferred error checks.

Key behaviours were **mutation-tested**, not just asserted: reverting last-value-wins, pointing scope attributes at field 1 or 4, un-clamping yielded views, and changing `Resource.AttributesSeq`'s field number each fail the suite.

## Benchmarks

11th Gen i7-11800H, linux/amd64, Go 1.25.12. Full methodology in `docs/BENCHMARKS.md`.

| Benchmark | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| `BenchmarkScope_SingleOccurrence` | 9.5 | 0 | 0 |
| `BenchmarkScope_MultipleOccurrences` (merges) | 141 | 112 | 2 |
| `BenchmarkScope_NameVersion_WireFormat` | 194 | 72 | 4 |
| `BenchmarkScope_NameVersion_Unmarshal` (full decode) | 441 | 360 | 10 |

Counting stays 0 allocs; `Resource()` keeps its zero-allocation single-occurrence path; deep iteration is unchanged at 184 B / 7 allocs.

**The full-decode baseline is pdata, not dibber's or sage's code verbatim.** Reproducing those exactly would mean adding `go.opentelemetry.io/proto/otlp` as a dependency of a public library purely for a benchmark. Treat it as an order of magnitude and validate the real saving in the consumer migrations.

## Risks

- **`Metric.Name()` is ~12% slower** (115.6µs → 129.7µs across 4800 metrics, ~2.9ns per metric, allocations unchanged). Measured by alternating builds over two rounds with non-overlapping ranges; an earlier sequential measurement said ~3% and was wrong. This is the largest regression here and is called out as such in `docs/BENCHMARKS.md`. The scan is bounded and never descends into datapoint bodies.
- **Behavioral break:** `Metric.Name()` returns the last occurrence of a repeated `name`, not the first. Signature unchanged; no surveyed consumer depends on the old resolution.
- **Stricter than pdata in one direction.** Skipping a field applies group validation; pdata's unknown-field skip returns as soon as it consumes a non-group wire type, even inside an unclosed group. So an unclosed group in an unknown trailing field errors here and is accepted by pdata. Deliberate, in the safe direction, unreachable on conformant OTLP (groups are proto2-only), and pinned by `TestMetricName_UnclosedGroupIsStricterThanPdata`.
- **Cost tracks container shape.** `Scope()`/`SchemaUrl()` must scan the whole container, ~8ns per skipped record, allocation-free. A consumer reading only the scope and stopping early — dibber's shape — trades its former early exit for parity.
- **`KeyValue.Key`/`ValueRaw` keep first-match and still diverge from pdata**, which takes the last `key` and *merges* repeated `value` occurrences. Left alone deliberately: it is the library's hottest path and changing it is an unmeasured behavioral change to existing accessors. Now documented accurately in `docs/DESIGN.md` rather than mischaracterized, and worth logging on E-2946.
- Allocation profile, `WriteTo` bytes and the iterator/error contract are otherwise unchanged.

## Docs

`README.md`, `docs/DESIGN.md`, `docs/specification.md`, `docs/BENCHMARKS.md`, `AGENTS.md` and `operations.md` updated, including the consumer-visible transition table E-2940 asks for. The canary decision and its pre/post comparison belong to release time and are **not** recorded yet.

## Agent involvement

Per `CONTRIBUTING.md`: this change was produced with Claude Code — implementation, tests, benchmarks and documentation. It then went through a four-angle cleanup review and an adversarial correctness review, both agent-run. The adversarial pass found six real defects that are fixed in `fb18bc4`, and prompted the benchmark correction in `43d227f`. Field numbers and merge semantics were verified against pdata's generated source rather than asserted. A human maintainer must still review and take ownership before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added instrumentation scope access across metrics, logs, and traces, including name, version, and attributes.
  * Added resource and scope schema URL accessors.
  * Added support for merged repeated resource and scope data.
  * Added efficient attribute iteration with error reporting.

* **Bug Fixes**
  * Repeated scalar fields now consistently use the last value, including metric names and schema URLs.
  * Improved handling and reporting of malformed wire data.

* **Documentation**
  * Expanded API, behavior, compatibility, and performance documentation with examples and benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->