### PR TITLE
feat(logs): add LogRecord.SeverityText accessor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,13 @@ for new accessors.
   generated unmarshal — merge appends, replacement assigns. Check the `.proto`
   declaration first: neither helper applies to a `repeated` field. See
   "Singular field resolution" in [docs/DESIGN.md](docs/DESIGN.md).
+- Before reaching for either helper, check whether an existing schema-aware
+  walk already covers that message — `parseLogRecordSeverity` for `LogRecord`,
+  for example. If one does, read the field out of that walk and apply the
+  resolution there instead of adding a second, shallower parser. Two parsers
+  over one message diverge on malformed input, so the accessors disagree about
+  whether the same bytes are valid; `LogRecord.SeverityText` exists in its
+  current shape for this reason.
 - Malformed tags, lengths, wire types, identifiers, metric bodies, or nested
   messages must return parse errors. Never silently accept corruption to keep
   an iterator moving.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ ExportLogsServiceRequest (OTLP message bytes)
             ├─ Scope()      (exactly one, merged)
             ├─ SchemaUrl()
             └─ LogRecord[]
-                 └─ SeverityNumber()
+                 ├─ SeverityNumber()
+                 └─ SeverityText()
 
 ExportTracesServiceRequest (OTLP message bytes)
   └─ ResourceSpans[] (one per resource)
@@ -256,12 +257,19 @@ func (s ScopeLogs) LogRecordsSeq(yield func(LogRecord, error) bool) // zero-allo
 
 type LogRecord []byte
 func (r LogRecord) SeverityNumber() (int32, error)
+func (r LogRecord) SeverityText() ([]byte, error)
 
 type Resource []byte
 func (r Resource) Attributes() (iter.Seq[KeyValue], func() error)
 func (r Resource) AttributesSeq(yield func(KeyValue, error) bool)
 func (r Resource) StringAttribute(key string) ([]byte, bool, error)
 ```
+
+`LogRecord.SeverityText` returns raw bytes aliasing the request buffer, and
+`nil` when `severity_text` is absent, which distinguishes an absent field from
+a present empty one. It shares `SeverityNumber`'s schema-aware walk of the
+whole LogRecord, so reading both fields costs two walks; see
+[docs/DESIGN.md](docs/DESIGN.md) for why they share one parser.
 
 `Resource.StringAttribute` is zero-copy and returns a separate `found` value,
 so a missing resource attribute can be distinguished from a present empty

--- a/README.md
+++ b/README.md
@@ -267,7 +267,8 @@ func (r Resource) StringAttribute(key string) ([]byte, bool, error)
 
 `LogRecord.SeverityText` returns raw bytes aliasing the request buffer, and
 `nil` when `severity_text` is absent, which distinguishes an absent field from
-a present empty one. It shares `SeverityNumber`'s schema-aware walk of the
+a present empty one. Repeated occurrences resolve to the last, the protobuf
+singular-scalar rule. It shares `SeverityNumber`'s schema-aware walk of the
 whole LogRecord, so reading both fields costs two walks; see
 [docs/DESIGN.md](docs/DESIGN.md) for why they share one parser.
 

--- a/benchmark_comparison_test.go
+++ b/benchmark_comparison_test.go
@@ -1404,3 +1404,113 @@ func BenchmarkMetric_Metadata_Seq(b *testing.B) {
 		})
 	}
 }
+
+// ========== LogRecord.SeverityText ==========
+
+// benchSeverityTextSink prevents the severity-text arms from being optimized
+// away.
+var benchSeverityTextSink int
+
+// logRecordSeverityTextHandRolled is the field-3 walk sage hand-rolls in
+// internal/event/wire.go, copied verbatim as the "before" arm so the
+// comparison reproduces from this repository alone. It is deliberately not
+// equivalent work: it stops at field 3 and materializes a string, where
+// LogRecord.SeverityText validates every known LogRecord field and returns a
+// view. Drop this arm and its docs/BENCHMARKS.md section once sage moves to
+// LogRecord.SeverityText.
+func logRecordSeverityTextHandRolled(data []byte) (string, error) {
+	var text []byte
+	for len(data) > 0 {
+		num, typ, n := protowire.ConsumeTag(data)
+		if n < 0 {
+			return "", errors.New("malformed protobuf tag in log record")
+		}
+		data = data[n:]
+		if num == 3 {
+			if typ != protowire.BytesType {
+				return "", errors.New("wrong wire type for severity_text")
+			}
+			value, m := protowire.ConsumeBytes(data)
+			if m < 0 {
+				return "", errors.New("malformed severity_text field")
+			}
+			text = value
+			data = data[m:]
+			continue
+		}
+		n = protowire.ConsumeFieldValue(num, typ, data)
+		if n < 0 {
+			return "", errors.New("malformed field in log record")
+		}
+		data = data[n:]
+	}
+	return string(text), nil
+}
+
+func benchSeverityTextPayload(b *testing.B) []byte {
+	b.Helper()
+	payload, err := (&plog.ProtoMarshaler{}).MarshalLogs(createBenchLogs())
+	require.NoError(b, err)
+	return payload
+}
+
+// forEachBenchLogRecord walks down to every LogRecord so the arms differ only
+// in how they read severity_text. Keep the arms as separate functions:
+// dispatching through a func value defeats inlining and changes what is
+// measured.
+func forEachBenchLogRecord(b *testing.B, payload []byte, fn func(LogRecord)) {
+	resources, resErr := ExportLogsServiceRequest(payload).ResourceLogs()
+	for rl := range resources {
+		scopes, scopeErr := rl.ScopeLogs()
+		for sl := range scopes {
+			for record, err := range sl.LogRecordsSeq {
+				if err != nil {
+					b.Fatal(err)
+				}
+				fn(record)
+			}
+		}
+		if err := scopeErr(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := resErr(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkLogRecord_SeverityText_HandRolled(b *testing.B) {
+	payload := benchSeverityTextPayload(b)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		total := 0
+		forEachBenchLogRecord(b, payload, func(record LogRecord) {
+			text, err := logRecordSeverityTextHandRolled([]byte(record))
+			if err != nil {
+				b.Fatal(err)
+			}
+			total += len(text)
+		})
+		benchSeverityTextSink = total
+	}
+}
+
+func BenchmarkLogRecord_SeverityText(b *testing.B) {
+	payload := benchSeverityTextPayload(b)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		total := 0
+		forEachBenchLogRecord(b, payload, func(record LogRecord) {
+			text, err := record.SeverityText()
+			if err != nil {
+				b.Fatal(err)
+			}
+			total += len(text)
+		})
+		benchSeverityTextSink = total
+	}
+}

--- a/benchmark_comparison_test.go
+++ b/benchmark_comparison_test.go
@@ -1281,8 +1281,6 @@ func BenchmarkMetric_Name(b *testing.B) {
 
 // ========== Metric.Metadata ==========
 
-// benchMetadataAttribute mirrors what a cardinality consumer keeps per
-// attribute: aliased key and encoded-AnyValue views.
 type benchMetadataAttribute struct{ key, value []byte }
 
 // forEachBytesFieldHandRolled is the field-12 walk marigold hand-rolls in
@@ -1327,9 +1325,8 @@ func benchMetadataPayload(b *testing.B) []byte {
 	return payload
 }
 
-// forEachBenchMetric walks down to every Metric so the arms differ only in how
-// they read metadata. Keep the arms as separate functions: dispatching through
-// a func value defeats inlining and changes what is measured.
+// Keep the arms as separate functions: dispatching through a func value
+// defeats inlining and changes what is measured.
 func forEachBenchMetric(b *testing.B, payload []byte, fn func(Metric)) {
 	resources, resErr := ExportMetricsServiceRequest(payload).ResourceMetrics()
 	for rm := range resources {

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -597,10 +597,16 @@ does not interleave arms.
 records, no `severity_text` set, so this measures only the walk's added
 branching and return, not reading the new field.
 
+The "before" arm must be built from a checkout of the merge base, not from a
+stash — `git stash` on a clean worktree is a no-op and would build the same
+binary twice, measuring 0%:
+
 ```bash
-go test -c -o /tmp/after.test .          # this branch
-git -C <clean-worktree> stash && go test -c -o /tmp/before.test .   # merge base
-for round in $(seq 1 9); do
+go test -c -o /tmp/after.test .                    # this branch
+mkdir /tmp/base && git archive <merge-base> | tar -x -C /tmp/base
+(cd /tmp/base && go test -c -o /tmp/before.test .) # merge base
+
+for round in $(seq 1 15); do
   for arm in before after; do
     /tmp/$arm.test -test.run '^$' -test.benchtime 500ms \
       -test.bench '^BenchmarkLogs_SeverityClassification_WireFormat$'
@@ -608,15 +614,19 @@ for round in $(seq 1 9); do
 done
 ```
 
-| Revision | ns/op (median of 9) | B/op | allocs/op |
+| Revision | ns/op (median of 15) | B/op | allocs/op |
 |---|---:|---:|---:|
-| merge base | 78,874 | 488 | 15 |
-| this change | 80,233 | 488 | 15 |
+| merge base | 78,744 | 488 | 15 |
+| this change | 80,749 | 488 | 15 |
 
-**Median paired delta +1.29%, slower in 8 of 9 rounds**, allocations
-unchanged. The ranges overlap, so the sign consistency is the evidence, not
-the absolute numbers. One round measured +11.86% under transient machine load;
-it is included in the median rather than discarded.
+**Median paired delta +2.67%, slower in 14 of 15 rounds**, allocations
+unchanged. A second independent 15-round session on the same machine measured
++2.00%, slower in 12 of 15. Take the cost as roughly **+2 to +3%** rather than
+either figure exactly: single rounds range from −8.7% to +5.8% under desktop
+load, so the sign consistency across rounds is the evidence and the magnitude
+is only stable to about a percentage point. Nine rounds is not enough for a
+delta this size on this machine — it understated the median by roughly a
+percentage point against both 15-round sessions. Use 15 or more.
 
 This is the price of one walk instead of two implementations, and it is
 deliberate: see [DESIGN.md](DESIGN.md) for why drift between the two severity

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -576,3 +576,97 @@ paired median (between +3% and +6.5% across runs) and the sign, which held in
 12 of 12 rounds above. The cost is `forEachRepeatedField`'s capacity clamp plus
 one indirect call per element; the clamp is the guarantee a caller's `append`
 cannot reach the neighbouring entry, which the hand-rolled walk lacks.
+
+## `LogRecord.SeverityText` (E-2944)
+
+`SeverityText` reads `severity_text` out of the same schema-aware walk
+`SeverityNumber` already used, rather than getting its own extractor. Two
+measurements matter: what that shared walk costs the existing `SeverityNumber`
+hot path, and how the new accessor compares to the shallow walk sage
+hand-rolls today.
+
+**Environment:** 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz, linux/amd64,
+Go 1.25.12, developer desktop. Both comparisons alternate single-arm
+invocations of prebuilt binaries and report the median of the paired per-round
+deltas; `go test -count=N` runs a benchmark's iterations consecutively and
+does not interleave arms.
+
+### Cost to the existing `SeverityNumber` path
+
+**Fixture:** `createSeverityClassificationBenchLogs` — 5 resources × 120
+records, no `severity_text` set, so this measures only the walk's added
+branching and return, not reading the new field.
+
+```bash
+go test -c -o /tmp/after.test .          # this branch
+git -C <clean-worktree> stash && go test -c -o /tmp/before.test .   # merge base
+for round in $(seq 1 9); do
+  for arm in before after; do
+    /tmp/$arm.test -test.run '^$' -test.benchtime 500ms \
+      -test.bench '^BenchmarkLogs_SeverityClassification_WireFormat$'
+  done
+done
+```
+
+| Revision | ns/op (median of 9) | B/op | allocs/op |
+|---|---:|---:|---:|
+| merge base | 78,874 | 488 | 15 |
+| this change | 80,233 | 488 | 15 |
+
+**Median paired delta +1.29%, slower in 8 of 9 rounds**, allocations
+unchanged. The ranges overlap, so the sign consistency is the evidence, not
+the absolute numbers. One round measured +11.86% under transient machine load;
+it is included in the median rather than discarded.
+
+This is the price of one walk instead of two implementations, and it is
+deliberate: see [DESIGN.md](DESIGN.md) for why drift between the two severity
+accessors is the failure being bought out.
+
+### Against sage's hand-rolled walk
+
+**Fixture:** `createBenchLogs` — 5 resources × 100 records, each with a body,
+a timestamp, two attributes, a severity number and `severity_text`.
+
+`logRecordSeverityTextHandRolled` is sage's `internal/event/wire.go` walk
+copied verbatim so the comparison reproduces from this repository alone. The
+arms are **not** equivalent work: sage's stops at field 3 and steps over the
+body and attributes without descending, then materializes a `string`;
+`SeverityText` validates every known LogRecord field — including parsing the
+body's `AnyValue` and every attribute `KeyValue` — and returns a view.
+
+```bash
+go test -c -o /tmp/otlpwire.test .
+for round in $(seq 1 9); do
+  for arm in _HandRolled ''; do
+    /tmp/otlpwire.test -test.run '^$' -test.benchmem -test.benchtime=3000x \
+      -test.bench "^BenchmarkLogRecord_SeverityText${arm}\$"
+  done
+done
+```
+
+| Benchmark | ns/op (median of 9) | B/op | allocs/op |
+|---|---:|---:|---:|
+| `BenchmarkLogRecord_SeverityText_HandRolled` | 40,215 | 2,368 | 514 |
+| `BenchmarkLogRecord_SeverityText` | 69,185 | 368 | 14 |
+
+**About 72% slower and 500 allocations cheaper per batch**, slower in 9 of 9
+rounds. Both directions are real and neither is noise:
+
+- The CPU cost is the schema-aware validation. It is what makes `SeverityText`
+  and `SeverityNumber` accept and reject identical bytes; the hand-rolled walk
+  cannot make that promise, because it never looks at the body or attributes.
+- The allocation saving is the returned view. sage's walk allocates one string
+  per record — 500 in this fixture — where the accessor aliases the request
+  buffer with a clamped capacity.
+
+A consumer on a GC-sensitive ingest path is trading CPU for allocations here,
+not simply losing. A consumer that wants the cheap shallow read and does not
+need `SeverityNumber` parity is better served by its own walk, and should say
+so on the migration issue rather than adopting this accessor by default.
+
+Reading both severity fields runs the walk twice. No combined accessor exists;
+the trigger for adding one is sage adopting `SeverityText` and reading both
+fields per record.
+
+Drop the hand-rolled arm and this subsection once sage moves to
+`LogRecord.SeverityText`.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -145,7 +145,7 @@ malformed body or attribute that `SeverityNumber` rejects on the same bytes,
 so a consumer reading both would see one succeed and one fail. Sharing the walk
 makes that impossible by construction.
 
-Threading the value out of the walk costs a measured ~1.3% on the
+Threading the value out of the walk costs a measured 2–3% on the
 severity-classification path with allocations unchanged
 ([BENCHMARKS.md](BENCHMARKS.md)), and a consumer reading both severity fields
 pays two walks, because each accessor runs the walk once. No combined accessor

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -138,6 +138,26 @@ the whole known LogRecord structure so an early severity field cannot hide
 trailing corruption, and it implements protobuf last-value-wins scalar
 semantics.
 
+`SeverityText` (field 3) reads out of that same walk rather than getting its
+own extractor. Two independent parsers over one message is how the accessors
+drift: the shallow field-3 walk a consumer would otherwise hand-roll accepts a
+malformed body or attribute that `SeverityNumber` rejects on the same bytes,
+so a consumer reading both would see one succeed and one fail. Sharing the walk
+makes that impossible by construction.
+
+Threading the value out of the walk costs a measured ~1.3% on the
+severity-classification path with allocations unchanged
+([BENCHMARKS.md](BENCHMARKS.md)), and a consumer reading both severity fields
+pays two walks, because each accessor runs the walk once. No combined accessor
+exists. The walk already produces both values, so exposing the pair would need
+no new machinery — but per the flattened-convenience rule in E-2940 a
+convenience needs a measured hot path, and the concrete trigger is sage
+adopting `SeverityText` and reading both fields per record.
+
+Severity *classification* stays out of the library. Bands and number/text
+precedence are consumer policy, and nothing in the consumer audit argues
+otherwise.
+
 Resource context comes from `ResourceLogs.Resource()`, which merges every
 Resource occurrence for this container (see "Resource extraction" below) so
 callers get pdata-compatible resource attributes without a bespoke
@@ -176,6 +196,18 @@ ways, and pdata implements both, so otlp-wire must distinguish them:
 Getting this wrong is invisible on well-formed input from a normal producer
 and wrong on everything else, which is exactly the class of divergence E-2940
 exists to close.
+
+**Which resolution, and which parser, are separate decisions.** The rule above
+picks the *resolution*. It does not follow that a scalar gets its own call to
+`extractLastBytesField`: when the field already falls inside an existing
+schema-aware walk of the same message, the accessor reads out of that walk
+instead, applying the same last-value-wins resolution there. Adding a second,
+shallower parser over a message the library already walks is how two accessors
+come to disagree about whether the same bytes are valid — the divergence risk
+recorded in [operations.md](../operations.md). `LogRecord.SeverityText` is the
+worked example: field 3 is a singular scalar, but `parseLogRecordSeverity`
+already validates the whole LogRecord for `SeverityNumber`, so `SeverityText`
+reads from there rather than scanning independently.
 
 ### Singular messages: merged (`Resource`, `InstrumentationScope`)
 
@@ -291,9 +323,10 @@ There are two intentional semantic levels:
 
 - lightweight field views such as `KeyValue.Key` and `ValueRaw`, which return
   the first matching encoded field;
-- semantic accessors such as `StringValue`, `Resource.StringAttribute` and
-  `SeverityNumber`, which scan enough of the complete message to reproduce the
-  documented protobuf/pdata behavior and expose trailing corruption.
+- semantic accessors such as `StringValue`, `Resource.StringAttribute`,
+  `SeverityNumber` and `SeverityText`, which scan enough of the complete
+  message to reproduce the documented protobuf/pdata behavior and expose
+  trailing corruption.
 
 Keeping those levels separate prevents hashing paths from paying for semantics
 they do not need while giving routing and detector paths a parity-oriented API.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -48,7 +48,7 @@ The library supports the following operation families:
 | Extract raw Resource bytes | yes | yes | yes |
 | Re-wrap one resource container as an export request | yes | yes | yes |
 | Iterate below the resource container | scopes, metrics, data points, attributes | scopes, log records | scopes, spans |
-| Selected field access | metric name, data-point type/timestamp/attributes, KeyValue fields | severity number, resource string attributes | trace, span and parent-span IDs |
+| Selected field access | metric name, data-point type/timestamp/attributes, KeyValue fields | severity number and text, resource string attributes | trace, span and parent-span IDs |
 
 ### Non-goals
 
@@ -367,6 +367,18 @@ the enum as `int32`, and applies protobuf last-scalar-value behavior. It scans
 and validates the complete LogRecord fields known to the pinned pdata schema,
 including nested body and attributes, while skipping well-formed unknown
 fields.
+
+`LogRecord.SeverityText` returns `severity_text` (field 3) as raw bytes
+aliasing the request buffer, with the capacity clamped so a caller's `append`
+cannot overwrite adjacent record fields. It returns `nil` when the field is
+absent and a non-nil zero-length slice when it is present but empty, a
+distinction pdata cannot represent; both compare equal to `""`. Repeated
+occurrences resolve to the last one, as protobuf and pdata do for a singular
+scalar.
+
+Both severity accessors read from one schema-aware walk of the whole
+LogRecord, so they accept and reject exactly the same bytes. Each call runs
+that walk once, so a consumer reading both fields pays for two.
 
 The library does not classify severity bands or combine severity number with
 severity text. That remains consumer policy.

--- a/example_test.go
+++ b/example_test.go
@@ -138,9 +138,7 @@ func ExampleMetric_DataPoints() {
 }
 
 // ExampleMetric_Metadata reads the metadata a receiver attaches to a metric.
-// It is a repeated field, so occurrences are yielded in wire order, duplicate
-// keys included. MetadataSeq is the zero-allocation variant to reach for when
-// a hot path combines metadata with every data point's attributes.
+// MetadataSeq is the zero-allocation variant for hot paths.
 func ExampleMetric_Metadata() {
 	metrics := pmetric.NewMetrics()
 	sm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
@@ -165,9 +163,6 @@ func ExampleMetric_Metadata() {
 	// http.server.duration prometheus.unit=seconds
 }
 
-// printMetricMetadata prints every metric's metadata, keeping the example body
-// free of the error checks the lazy accessors require: each can fail, and
-// every iterator's error closure must be checked after its range.
 func printMetricMetadata(data []byte) error {
 	resources, resourcesErr := otlpwire.ExportMetricsServiceRequest(data).ResourceMetrics()
 	for rm := range resources {

--- a/example_test.go
+++ b/example_test.go
@@ -292,33 +292,57 @@ func ExampleLogRecord_SeverityText() {
 
 func printLogSeverities(data []byte) error {
 	resources, resourcesErr := otlpwire.ExportLogsServiceRequest(data).ResourceLogs()
+	var failure error
 	for resourceLogs := range resources {
-		scopes, scopesErr := resourceLogs.ScopeLogs()
-		for scope := range scopes {
-			for record, err := range scope.LogRecordsSeq {
-				if err != nil {
-					return err
-				}
-				number, err := record.SeverityNumber()
-				if err != nil {
-					return err
-				}
-				text, err := record.SeverityText()
-				if err != nil {
-					return err
-				}
-				if text == nil {
-					fmt.Printf("severity=%d text=<unset>\n", number)
-					continue
-				}
-				fmt.Printf("severity=%d text=%s\n", number, text)
-			}
-		}
-		if err := scopesErr(); err != nil {
-			return err
+		if failure = printResourceLogSeverities(resourceLogs); failure != nil {
+			break
 		}
 	}
-	return resourcesErr()
+	// The error closure must be checked even when the loop exited early,
+	// so the split into one function per level is the point of this shape,
+	// not incidental.
+	if err := resourcesErr(); err != nil {
+		return err
+	}
+	return failure
+}
+
+func printResourceLogSeverities(resourceLogs otlpwire.ResourceLogs) error {
+	scopes, scopesErr := resourceLogs.ScopeLogs()
+	var failure error
+	for scope := range scopes {
+		if failure = printScopeLogSeverities(scope); failure != nil {
+			break
+		}
+	}
+	if err := scopesErr(); err != nil {
+		return err
+	}
+	return failure
+}
+
+// printScopeLogSeverities needs no closure check: LogRecordsSeq yields its
+// errors inline rather than deferring them.
+func printScopeLogSeverities(scope otlpwire.ScopeLogs) error {
+	for record, err := range scope.LogRecordsSeq {
+		if err != nil {
+			return err
+		}
+		number, err := record.SeverityNumber()
+		if err != nil {
+			return err
+		}
+		text, err := record.SeverityText()
+		if err != nil {
+			return err
+		}
+		if text == nil {
+			fmt.Printf("severity=%d text=<unset>\n", number)
+			continue
+		}
+		fmt.Printf("severity=%d text=%s\n", number, text)
+	}
+	return nil
 }
 
 // ExampleScopeLogs_Scope reads instrumentation scope identity and schema URL

--- a/example_test.go
+++ b/example_test.go
@@ -263,6 +263,64 @@ func ExampleResourceLogs_Resource() {
 	// Output: checkout severity=13
 }
 
+// ExampleLogRecord_SeverityText reads both severity fields together, which is
+// what a severity gate needs: the number orders records, the text carries the
+// producer's own label. SeverityText returns a view into the request buffer,
+// and nil distinguishes an absent severity_text from a present empty one.
+func ExampleLogRecord_SeverityText() {
+	logs := plog.NewLogs()
+	records := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords()
+	labelled := records.AppendEmpty()
+	labelled.SetSeverityNumber(plog.SeverityNumberError)
+	labelled.SetSeverityText("ERR")
+	records.AppendEmpty().SetSeverityNumber(plog.SeverityNumberInfo)
+
+	data, err := (&plog.ProtoMarshaler{}).MarshalLogs(logs)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	if err := printLogSeverities(data); err != nil {
+		fmt.Println(err)
+	}
+
+	// Output:
+	// severity=17 text=ERR
+	// severity=9 text=<unset>
+}
+
+func printLogSeverities(data []byte) error {
+	resources, resourcesErr := otlpwire.ExportLogsServiceRequest(data).ResourceLogs()
+	for resourceLogs := range resources {
+		scopes, scopesErr := resourceLogs.ScopeLogs()
+		for scope := range scopes {
+			for record, err := range scope.LogRecordsSeq {
+				if err != nil {
+					return err
+				}
+				number, err := record.SeverityNumber()
+				if err != nil {
+					return err
+				}
+				text, err := record.SeverityText()
+				if err != nil {
+					return err
+				}
+				if text == nil {
+					fmt.Printf("severity=%d text=<unset>\n", number)
+					continue
+				}
+				fmt.Printf("severity=%d text=%s\n", number, text)
+			}
+		}
+		if err := scopesErr(); err != nil {
+			return err
+		}
+	}
+	return resourcesErr()
+}
+
 // ExampleScopeLogs_Scope reads instrumentation scope identity and schema URL
 // without unmarshaling the request. Each scope container has exactly one
 // InstrumentationScope, mirroring pdata's object model.

--- a/log_iteration_test.go
+++ b/log_iteration_test.go
@@ -123,6 +123,19 @@ func TestLogRecordSeverityText_MatchesPdata(t *testing.T) {
 			expected: []byte("SECOND"),
 		},
 		{
+			// The case that separates last-value-wins from
+			// last-non-empty-wins: an implementation guarding the
+			// assignment on len(value) > 0 would return FIRST here.
+			name:     "repeated resolving to an empty last occurrence",
+			record:   append(severityText("FIRST"), severityText("")...),
+			expected: []byte{},
+		},
+		{
+			name:     "repeated resolving from an empty first occurrence",
+			record:   append(severityText(""), severityText("LAST")...),
+			expected: []byte("LAST"),
+		},
+		{
 			name:     "unknown fields around it are skipped",
 			record:   slices.Concat(unknownScalarFields(), severityText("WARN"), severityNumberField(plog.SeverityNumberWarn), unknownScalarFields()),
 			expected: []byte("WARN"),

--- a/log_iteration_test.go
+++ b/log_iteration_test.go
@@ -178,6 +178,72 @@ func TestLogRecordSeverityText_CompleteMessageSemantics(t *testing.T) {
 	require.Error(t, err, "every severity_text occurrence must use the bytes wire type")
 }
 
+// TestLogRecordSeverity_PdataDivergence pins the inputs where the shared
+// LogRecord walk and pdata disagree about validity. They are the exception to
+// the parity the rest of the suite asserts, they are all reachable only on
+// malformed or adversarial input, and operations.md documents them for
+// consumers that pair the wire path with a pdata fallback. The point is to
+// notice when one of them changes, in either direction.
+func TestLogRecordSeverity_PdataDivergence(t *testing.T) {
+	tests := []struct {
+		name        string
+		record      LogRecord
+		wireRejects bool
+	}{
+		{
+			name:        "well-formed group in an unknown field",
+			record:      appendUnknownGroup(severityNumberField(plog.SeverityNumberInfo), 90),
+			wireRejects: false,
+		},
+		{
+			// AnyValue body carrying a well-formed group in field 40.
+			name:        "well-formed group inside the body AnyValue",
+			record:      LogRecord{0x2a, 0x07, 0xc3, 0x02, 0xc8, 0x02, 0x01, 0xc4, 0x02},
+			wireRejects: false,
+		},
+		{
+			// 10-byte varint whose final byte is >= 2: protowire requires
+			// canonical encoding, pdata's generated loop does not.
+			name:        "non-canonical varint in severity_number",
+			record:      LogRecord{0x10, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02},
+			wireRejects: true,
+		},
+		{
+			name:        "non-canonical varint as the severity_text length",
+			record:      LogRecord{0x1a, 0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02, 'X'},
+			wireRejects: true,
+		},
+		{
+			// Field number 206695283200 truncates to a positive int32, so
+			// pdata skips it where protowire rejects the tag outright.
+			name:        "field number above MaxInt32 truncating positive",
+			record:      LogRecord{0x90, 0x90, 0x90, 0x90, 0x90, 0x30, 0x30},
+			wireRejects: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, textErr := tt.record.SeverityText()
+			_, numberErr := tt.record.SeverityNumber()
+			_, pdataErr := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithRecord(tt.record))
+
+			// The divergence is wire-versus-pdata. The two accessors still
+			// agree with each other, which is the property that matters.
+			require.Equal(t, textErr == nil, numberErr == nil,
+				"severity accessors must agree even where pdata disagrees with both")
+
+			if tt.wireRejects {
+				require.Error(t, textErr, "wire path must reject")
+				require.NoError(t, pdataErr, "pdata is documented as accepting this")
+				return
+			}
+			require.NoError(t, textErr, "wire path must accept")
+			require.Error(t, pdataErr, "pdata is documented as rejecting this")
+		})
+	}
+}
+
 // TestLogRecordSeverity_MalformedParity keeps the two severity accessors from
 // drifting apart: every malformed record fails both, and pdata rejects the
 // same bytes. It is the guard for the accessor-divergence risk in

--- a/log_iteration_test.go
+++ b/log_iteration_test.go
@@ -1,6 +1,8 @@
 package otlpwire
 
 import (
+	"bytes"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -71,7 +73,104 @@ func TestLogRecordSeverityNumber_CompleteMessageSemantics(t *testing.T) {
 	require.Error(t, err, "every severity occurrence must use the enum varint wire type")
 }
 
-func TestLogRecordSeverityNumber_PdataMalformedParity(t *testing.T) {
+func TestLogRecordSeverityText(t *testing.T) {
+	tests := []struct {
+		name     string
+		set      bool
+		text     string
+		expected []byte
+	}{
+		{name: "unset", expected: nil},
+		{name: "populated", set: true, text: "INFO", expected: []byte("INFO")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := plog.NewLogs()
+			record := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+			if tt.set {
+				record.SetSeverityText(tt.text)
+			}
+
+			wireRecord := onlyLogRecord(t, marshalLogs(t, logs))
+			got, err := wireRecord.SeverityText()
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestLogRecordSeverityText_MatchesPdata uses hand-built records for the shapes
+// pdata's setter cannot emit: proto3 drops an empty severity_text on marshal,
+// and the API has no way to repeat a singular field.
+func TestLogRecordSeverityText_MatchesPdata(t *testing.T) {
+	severityText := func(value string) []byte {
+		out := protowire.AppendTag(nil, 3, protowire.BytesType)
+		return protowire.AppendString(out, value)
+	}
+
+	tests := []struct {
+		name     string
+		record   []byte
+		expected []byte
+	}{
+		{name: "absent", record: severityNumberField(plog.SeverityNumberInfo), expected: nil},
+		{name: "present but empty", record: severityText(""), expected: []byte{}},
+		{name: "populated", record: severityText("ERROR"), expected: []byte("ERROR")},
+		{
+			name:     "repeated resolves to the last occurrence",
+			record:   append(severityText("FIRST"), severityText("SECOND")...),
+			expected: []byte("SECOND"),
+		},
+		{
+			name:     "unknown fields around it are skipped",
+			record:   slices.Concat(unknownScalarFields(), severityText("WARN"), severityNumberField(plog.SeverityNumberWarn), unknownScalarFields()),
+			expected: []byte("WARN"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LogRecord(tt.record).SeverityText()
+			require.NoError(t, err)
+			// require.Equal distinguishes a nil []byte from an empty one,
+			// which is the absent-versus-present-empty contract pdata
+			// cannot express. The expected values rely on that.
+			require.Equal(t, tt.expected, got)
+			require.Equal(t, string(tt.expected), pdataSeverityText(t, tt.record))
+		})
+	}
+}
+
+// TestLogRecordSeverityText_CompleteMessageSemantics pins that SeverityText
+// inherits SeverityNumber's schema-aware walk rather than stopping at the
+// first match, so corruption located after the value is still reported.
+func TestLogRecordSeverityText_CompleteMessageSemantics(t *testing.T) {
+	var record LogRecord
+	record = protowire.AppendTag(record, 3, protowire.BytesType)
+	record = protowire.AppendString(record, "INFO")
+	record = appendUnknownGroup(record, 90)
+
+	text, err := record.SeverityText()
+	require.NoError(t, err)
+	require.Equal(t, []byte("INFO"), text)
+
+	trailingMalformed := append(append(LogRecord(nil), record...), 0x80)
+	_, err = trailingMalformed.SeverityText()
+	require.Error(t, err, "a valid early severity text must not hide malformed trailing data")
+
+	trailingWrongWire := append(append(LogRecord(nil), record...), protowire.AppendTag(nil, 3, protowire.VarintType)...)
+	trailingWrongWire = protowire.AppendVarint(trailingWrongWire, 1)
+	_, err = trailingWrongWire.SeverityText()
+	require.Error(t, err, "every severity_text occurrence must use the bytes wire type")
+}
+
+// TestLogRecordSeverity_MalformedParity keeps the two severity accessors from
+// drifting apart: every malformed record fails both, and pdata rejects the
+// same bytes. It is the guard for the accessor-divergence risk in
+// operations.md, so it covers the whole known LogRecord schema rather than
+// only the two severity fields.
+func TestLogRecordSeverity_MalformedParity(t *testing.T) {
 	tests := []struct {
 		name   string
 		record LogRecord
@@ -82,16 +181,70 @@ func TestLogRecordSeverityNumber_PdataMalformedParity(t *testing.T) {
 		{name: "flags wrong wire type", record: LogRecord{0x40, 0x01}},
 		{name: "trace id wrong wire type", record: LogRecord{0x48, 0x01}},
 		{name: "event name wrong wire type", record: LogRecord{0x60, 0x01}},
+		{name: "severity number wrong wire type", record: LogRecord{0x12, 0x01, 0x00, 0x11}},
+		{name: "severity text wrong wire type", record: LogRecord{0x18, 0x01}},
+		{name: "severity text truncated length", record: LogRecord{0x1a, 0x05, 0x49}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, wireErr := tt.record.SeverityNumber()
+			_, textErr := tt.record.SeverityText()
+			_, numberErr := tt.record.SeverityNumber()
 			_, pdataErr := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithRecord(tt.record))
-			require.Error(t, wireErr)
+			require.Error(t, textErr)
+			require.Error(t, numberErr)
 			require.Error(t, pdataErr)
 		})
 	}
+}
+
+// TestLogRecordSeverityText_ViewAndAllocationContract pins what the accessor
+// promises beyond its value: the result aliases the caller's buffer with a
+// clamped capacity, and reading it allocates nothing.
+func TestLogRecordSeverityText_ViewAndAllocationContract(t *testing.T) {
+	logs := plog.NewLogs()
+	logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().SetSeverityText("INFO")
+	record := onlyLogRecord(t, marshalLogs(t, logs))
+
+	text, err := record.SeverityText()
+	require.NoError(t, err)
+	require.Equal(t, len(text), cap(text), "capacity must be clamped so a caller's append reallocates")
+
+	// A copy would keep the old byte.
+	index := bytes.Index(record, []byte("INFO"))
+	require.GreaterOrEqual(t, index, 0)
+	record[index] = 'i'
+	require.Equal(t, []byte("iNFO"), text)
+
+	allocations := testing.AllocsPerRun(100, func() {
+		got, err := record.SeverityText()
+		if err != nil || len(got) == 0 {
+			t.Fatal("unexpected severity text result")
+		}
+	})
+	require.Zero(t, allocations)
+}
+
+// unknownScalarFields are forward-compatibility filler. They deliberately
+// avoid groups: pdata rejects even a well-formed group in an unknown LogRecord
+// field, so a group fixture cannot be compared against it.
+func unknownScalarFields() []byte {
+	out := protowire.AppendTag(nil, 90, protowire.VarintType)
+	out = protowire.AppendVarint(out, 1)
+	out = protowire.AppendTag(out, 91, protowire.BytesType)
+	return protowire.AppendString(out, "ignored")
+}
+
+func severityNumberField(severity plog.SeverityNumber) []byte {
+	out := protowire.AppendTag(nil, 2, protowire.VarintType)
+	return protowire.AppendVarint(out, uint64(severity))
+}
+
+func pdataSeverityText(t *testing.T, record []byte) string {
+	t.Helper()
+	logs, err := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithRecord(record))
+	require.NoError(t, err)
+	return logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).SeverityText()
 }
 
 func TestLogTraversalAndResourceAttributes(t *testing.T) {

--- a/log_iteration_test.go
+++ b/log_iteration_test.go
@@ -202,14 +202,16 @@ func TestLogRecordSeverity_PdataDivergence(t *testing.T) {
 			wireRejects: false,
 		},
 		{
-			// 10-byte varint whose final byte is >= 2: protowire requires
-			// canonical encoding, pdata's generated loop does not.
-			name:        "non-canonical varint in severity_number",
+			// A 10-byte varint carries at most bit 63 in its final byte, so
+			// a final byte >= 2 sets bits the uint64 cannot hold. protowire
+			// rejects the overflow; pdata's generated loop stops shifting at
+			// 64 bits and keeps the truncated value.
+			name:        "overflowing varint in severity_number",
 			record:      LogRecord{0x10, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02},
 			wireRejects: true,
 		},
 		{
-			name:        "non-canonical varint as the severity_text length",
+			name:        "overflowing varint as the severity_text length",
 			record:      LogRecord{0x1a, 0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02, 'X'},
 			wireRejects: true,
 		},

--- a/logs.go
+++ b/logs.go
@@ -114,7 +114,21 @@ func (s ScopeLogs) LogRecordsSeq(yield func(LogRecord, error) bool) {
 // that unexpected negative protobuf enum values remain distinguishable from
 // the positive OTLP severity ranges.
 func (r LogRecord) SeverityNumber() (int32, error) {
-	return parseLogRecordSeverity([]byte(r))
+	number, _, err := parseLogRecordSeverity([]byte(r))
+	return number, err
+}
+
+// SeverityText returns the LogRecord severity_text (field 3) as a view into
+// the underlying buffer. It returns nil when the field is absent and a
+// non-nil zero-length slice when it is present but empty, which pdata cannot
+// distinguish. Repeated occurrences resolve to the last one.
+//
+// Validation matches SeverityNumber: both read the same schema-aware walk of
+// the whole LogRecord, so an early severity_text cannot conceal corruption
+// that follows it.
+func (r LogRecord) SeverityText() ([]byte, error) {
+	_, text, err := parseLogRecordSeverity([]byte(r))
+	return text, err
 }
 
 // countLogRecords counts the number of log records in an OTLP
@@ -139,115 +153,123 @@ func countInScopeLogs(data []byte) (int, error) {
 }
 
 // parseLogRecordSeverity validates every known LogRecord field in pdata v1.64.0
-// while extracting severity_number with protobuf last-scalar-value semantics.
-// This is intentionally schema-aware: an early valid severity cannot conceal a
-// malformed body, attribute, timestamp, identifier, or trailing known field.
-func parseLogRecordSeverity(data []byte) (int32, error) {
+// while extracting severity_number and severity_text with protobuf
+// last-value-wins scalar semantics. This is intentionally schema-aware: an
+// early valid severity cannot conceal a malformed body, attribute, timestamp,
+// identifier, or trailing known field. Both severity accessors share the walk
+// so neither can drift from the other's malformed-input behavior.
+func parseLogRecordSeverity(data []byte) (int32, []byte, error) {
 	pos := 0
-	var result int32
+	var number int32
+	var text []byte
 
 	for pos < len(data) {
 		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
 		if tagLen < 0 {
-			return 0, errors.New("malformed protobuf tag")
+			return 0, nil, errors.New("malformed protobuf tag")
 		}
 		pos += tagLen
 
 		switch num {
 		case 1, 11: // time_unix_nano, observed_time_unix_nano
 			if wireType != protowire.Fixed64Type {
-				return 0, errors.New("wrong wire type for log record timestamp")
+				return 0, nil, errors.New("wrong wire type for log record timestamp")
 			}
 			_, n := protowire.ConsumeFixed64(data[pos:])
 			if n < 0 {
-				return 0, errors.New("invalid fixed64 in log record timestamp")
+				return 0, nil, errors.New("invalid fixed64 in log record timestamp")
 			}
 			pos += n
 		case 2: // severity_number
 			if wireType != protowire.VarintType {
-				return 0, errors.New("wrong wire type for log record severity number")
+				return 0, nil, errors.New("wrong wire type for log record severity number")
 			}
 			value, n := protowire.ConsumeVarint(data[pos:])
 			if n < 0 {
-				return 0, errors.New("invalid varint in log record severity number")
+				return 0, nil, errors.New("invalid varint in log record severity number")
 			}
-			result = int32(value)
+			number = int32(value)
 			pos += n
 		case 3, 12: // severity_text, event_name
 			if wireType != protowire.BytesType {
-				return 0, errors.New("wrong wire type for log record string")
+				return 0, nil, errors.New("wrong wire type for log record string")
 			}
-			_, n := protowire.ConsumeBytes(data[pos:])
+			value, n := protowire.ConsumeBytes(data[pos:])
 			if n < 0 {
-				return 0, errors.New("invalid bytes in log record string")
+				return 0, nil, errors.New("invalid bytes in log record string")
+			}
+			if num == 3 {
+				// Clamped so a caller's append reallocates instead of
+				// overwriting the record fields that follow this one.
+				text = value[:len(value):len(value)]
 			}
 			pos += n
 		case 5: // body
 			if wireType != protowire.BytesType {
-				return 0, errors.New("wrong wire type for log record body")
+				return 0, nil, errors.New("wrong wire type for log record body")
 			}
 			body, n := protowire.ConsumeBytes(data[pos:])
 			if n < 0 {
-				return 0, errors.New("invalid bytes in log record body")
+				return 0, nil, errors.New("invalid bytes in log record body")
 			}
 			if err := parseAnyValue(body, &parsedAnyValue{}); err != nil {
-				return 0, err
+				return 0, nil, err
 			}
 			pos += n
 		case 6: // attributes
 			if wireType != protowire.BytesType {
-				return 0, errors.New("wrong wire type for log record attributes")
+				return 0, nil, errors.New("wrong wire type for log record attributes")
 			}
 			attribute, n := protowire.ConsumeBytes(data[pos:])
 			if n < 0 {
-				return 0, errors.New("invalid bytes in log record attributes")
+				return 0, nil, errors.New("invalid bytes in log record attributes")
 			}
 			if _, _, _, err := parseKeyValue(attribute); err != nil {
-				return 0, err
+				return 0, nil, err
 			}
 			pos += n
 		case 7: // dropped_attributes_count
 			if wireType != protowire.VarintType {
-				return 0, errors.New("wrong wire type for log record dropped attributes count")
+				return 0, nil, errors.New("wrong wire type for log record dropped attributes count")
 			}
 			_, n := protowire.ConsumeVarint(data[pos:])
 			if n < 0 {
-				return 0, errors.New("invalid varint in log record dropped attributes count")
+				return 0, nil, errors.New("invalid varint in log record dropped attributes count")
 			}
 			pos += n
 		case 8: // flags
 			if wireType != protowire.Fixed32Type {
-				return 0, errors.New("wrong wire type for log record flags")
+				return 0, nil, errors.New("wrong wire type for log record flags")
 			}
 			_, n := protowire.ConsumeFixed32(data[pos:])
 			if n < 0 {
-				return 0, errors.New("invalid fixed32 in log record flags")
+				return 0, nil, errors.New("invalid fixed32 in log record flags")
 			}
 			pos += n
 		case 9, 10: // trace_id, span_id
 			if wireType != protowire.BytesType {
-				return 0, errors.New("wrong wire type for log record identifier")
+				return 0, nil, errors.New("wrong wire type for log record identifier")
 			}
 			identifier, n := protowire.ConsumeBytes(data[pos:])
 			if n < 0 {
-				return 0, errors.New("invalid bytes in log record identifier")
+				return 0, nil, errors.New("invalid bytes in log record identifier")
 			}
 			expectedSize := 16
 			if num == 10 {
 				expectedSize = 8
 			}
 			if len(identifier) != 0 && len(identifier) != expectedSize {
-				return 0, errors.New("log record identifier has unexpected size")
+				return 0, nil, errors.New("log record identifier has unexpected size")
 			}
 			pos += n
 		default:
 			n := skipField(data[pos:], num, wireType)
 			if n < 0 {
-				return 0, errors.New("failed to skip field in log record")
+				return 0, nil, errors.New("failed to skip field in log record")
 			}
 			pos += n
 		}
 	}
 
-	return result, nil
+	return number, text, nil
 }

--- a/metric_metadata_test.go
+++ b/metric_metadata_test.go
@@ -1,11 +1,8 @@
 package otlpwire
 
-// Tests for Metric.Metadata and Metric.MetadataSeq (Metric field 12, repeated
-// KeyValue). Fixtures are built with protowire because pdata's Map API cannot
-// emit duplicate keys or malformed shapes; pdata is the oracle for meaning.
-// The shared repeated-field machinery is covered in resource_test.go and
-// scope_test.go; what is pinned here is the field number, wire order across
-// duplicates, and the two variants' contracts.
+// Fixtures use protowire because pdata's Map API cannot emit duplicate keys or
+// malformed shapes; pdata stays the oracle for meaning. The shared
+// repeated-field machinery is covered in resource_test.go and scope_test.go.
 
 import (
 	"bytes"
@@ -18,15 +15,12 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 )
 
-// metadataEntry wraps an encoded KeyValue as one metadata occurrence.
 func metadataEntry(kv []byte) []byte {
 	out := protowire.AppendTag(nil, 12, protowire.BytesType)
 	out = protowire.AppendVarint(out, uint64(len(kv)))
 	return append(out, kv...)
 }
 
-// metricWithMetadata builds a Metric with a name (field 1) and metadata
-// occurrences in order.
 func metricWithMetadata(name string, kvs ...[]byte) []byte {
 	out := protowire.AppendTag(nil, 1, protowire.BytesType)
 	out = protowire.AppendString(out, name)
@@ -36,8 +30,6 @@ func metricWithMetadata(name string, kvs ...[]byte) []byte {
 	return out
 }
 
-// metricsPayloadWithMetric wraps a Metric as a one-resource, one-scope request
-// so pdata can read the same bytes.
 func metricsPayloadWithMetric(metric []byte) []byte {
 	scope := protowire.AppendTag(nil, 2, protowire.BytesType)
 	scope = protowire.AppendVarint(scope, uint64(len(metric)))
@@ -47,8 +39,6 @@ func metricsPayloadWithMetric(metric []byte) []byte {
 
 type metadataPair struct{ key, value string }
 
-// collectMetadata drains both variants, requires they agree, and checks the
-// capacity clamp on every yielded view.
 func collectMetadata(t *testing.T, m Metric) []metadataPair {
 	t.Helper()
 
@@ -134,9 +124,7 @@ func TestMetricMetadata_MatchesPdata(t *testing.T) {
 	}
 }
 
-// TestMetricMetadata_PresentButNotAString covers entries StringValue declines:
-// a zero-length occurrence is a present entry, not an absent field. Both
-// variants must yield it.
+// A zero-length occurrence is a present entry, not an absent field.
 func TestMetricMetadata_PresentButNotAString(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -263,8 +251,6 @@ func TestMetricMetadata_MalformedWire(t *testing.T) {
 	}
 }
 
-// TestMetricMetadata_MalformedKeyValueSurfacesOnAccess separates framing from
-// contents: a well-framed entry whose contents are corrupt fails on read.
 func TestMetricMetadata_MalformedKeyValueSurfacesOnAccess(t *testing.T) {
 	seq, errFunc := Metric(metadataEntry([]byte{0xFF})).Metadata()
 	count := 0
@@ -277,10 +263,8 @@ func TestMetricMetadata_MalformedKeyValueSurfacesOnAccess(t *testing.T) {
 	require.Equal(t, 1, count)
 }
 
-// TestMetricMetadata_EarlyStop covers both halves of the lazy-iteration
-// contract: an early exit still requires the error closure to be checked, and
-// it leaves later bytes unvisited, so trailing corruption surfaces only on a
-// full drain.
+// An early exit leaves later bytes unvisited, so trailing corruption surfaces
+// only on a full drain.
 func TestMetricMetadata_EarlyStop(t *testing.T) {
 	metric := metricWithMetadata("m",
 		stringKeyValue("a", "1"), stringKeyValue("b", "2"), stringKeyValue("c", "3"))
@@ -304,10 +288,6 @@ func TestMetricMetadata_EarlyStop(t *testing.T) {
 	require.Error(t, errFunc(), "draining reaches the corruption")
 }
 
-// TestMetricMetadata_ViewAndAllocationContract pins what the accessors promise
-// beyond their values: yielded KeyValues alias the caller's buffer rather than
-// copying it, the closure form may be ranged more than once, and neither form
-// allocates per element.
 func TestMetricMetadata_ViewAndAllocationContract(t *testing.T) {
 	m := Metric(metricWithMetadata("m",
 		stringKeyValue("a", "1"), stringKeyValue("b", "2")))
@@ -324,8 +304,7 @@ func TestMetricMetadata_ViewAndAllocationContract(t *testing.T) {
 	}
 	require.Equal(t, [2]int{2, 2}, passes, "ranging the same seq twice must agree")
 
-	// Views must alias the metric buffer, not copy it: writing through the
-	// buffer is visible in an already-yielded view.
+	// A copy would keep the old byte.
 	var first KeyValue
 	seq, errFunc = m.Metadata()
 	for kv := range seq {

--- a/metrics.go
+++ b/metrics.go
@@ -137,20 +137,16 @@ func (m Metric) Name() ([]byte, error) {
 // 12). The returned function should be called after iteration to check for
 // errors.
 //
-// metadata is a repeated field: every occurrence is yielded in wire order,
-// duplicate keys included, matching pdata.
+// metadata is repeated, so every occurrence is yielded in wire order with
+// duplicate keys preserved; the singular-field resolution the other accessors
+// apply does not apply here.
 func (m Metric) Metadata() (iter.Seq[KeyValue], func() error) {
 	return repeatedFieldSeq[KeyValue]([]byte(m), 12)
 }
 
-// MetadataSeq is a zero-allocation alternative to Metadata. It has the shape
-// of an iter.Seq2[KeyValue, error] and is meant to be ranged over directly:
-//
-//	for kv, err := range m.MetadataSeq {
-//		if err != nil { ... }
-//	}
-//
-// On a parse error it yields a nil KeyValue with a non-nil error and stops.
+// MetadataSeq is a zero-allocation alternative to Metadata, shaped like an
+// iter.Seq2[KeyValue, error] and meant to be ranged over directly. On a parse
+// error it yields a nil KeyValue with a non-nil error and stops.
 func (m Metric) MetadataSeq(yield func(KeyValue, error) bool) {
 	keyValueSeq([]byte(m), 12, yield)
 }

--- a/operations.md
+++ b/operations.md
@@ -22,6 +22,7 @@ this before releasing the module or changing a consumer rollout boundary.
 | Allocation regression | hypothesized | Higher GC/CPU in high-volume consumers | Extra copies, escaping closures, or full decode added to a hot path | Allocation tests and paired `-benchmem` benchmarks |
 | Consumer contract regression | observed in tests | Compile failure or changed routing/detector result after upgrade | Exported API, aliasing, iterator timing, or `WriteTo` bytes changed | Consumer-focused tests and canary comparison; the transitions below |
 | Benchmark-method error | observed | A performance claim or release decision rests on a delta that does not reproduce | A paired comparison run as sequential blocks (`go test -count=N`) instead of alternating invocations, or a gap claimed from overlapping ranges | Re-run alternating; see the release checklist below |
+| Accessor divergence on one message | hypothesized | Two accessors over the same message disagree on whether a payload is valid, so a consumer sees one field read succeed and the other fail on identical bytes | A second accessor added with its own parser instead of reading from the existing walk | Shared-walk implementation plus a malformed-parity test asserting both accessors fail together; see `TestLogRecordSeverityText_MalformedParity` |
 
 ### Known consumer-visible transitions in the API realignment
 
@@ -44,6 +45,29 @@ The canary decision and its measured pre/post comparison are recorded at
 release time, per "Release and production analysis" below. Confirm the canary
 consumer's telemetry is version-attributed first: see the uncovered-scenario
 note under "Telemetry inventory" below.
+
+### Diagnosing the LogRecord severity accessors
+
+`SeverityNumber` and `SeverityText` share one schema-aware walk of the whole
+LogRecord, so they can never disagree about whether a record is valid. Two
+consequences when reading a consumer's CPU profile:
+
+- **Each call walks the record once.** A consumer reading both fields pays two
+  walks. A severity path showing roughly double the expected parse cost is
+  usually this, not a regression.
+- **The walk descends into the body and every attribute.** Cost tracks record
+  contents, not just field count, unlike the shallow field-scan accessors. A
+  consumer whose records carry large bodies or many attributes pays more per
+  severity read than one whose records are bare, even at identical record
+  counts. [docs/BENCHMARKS.md](docs/BENCHMARKS.md) has the measured comparison
+  against a shallow hand-rolled walk.
+
+**Known divergence:** the scanning LogRecord accessors accept a *well-formed*
+group in an unknown LogRecord field, where pdata rejects the same bytes with
+`unexpected EOF`. This is the mirror of the unclosed-group row above and is
+likewise reachable only on malformed or adversarial input. It matters to
+consumers that pair the wire path with a pdata fallback and expect the two to
+agree on validity. No test covers it.
 
 ## Telemetry inventory
 

--- a/operations.md
+++ b/operations.md
@@ -22,7 +22,7 @@ this before releasing the module or changing a consumer rollout boundary.
 | Allocation regression | hypothesized | Higher GC/CPU in high-volume consumers | Extra copies, escaping closures, or full decode added to a hot path | Allocation tests and paired `-benchmem` benchmarks |
 | Consumer contract regression | observed in tests | Compile failure or changed routing/detector result after upgrade | Exported API, aliasing, iterator timing, or `WriteTo` bytes changed | Consumer-focused tests and canary comparison; the transitions below |
 | Benchmark-method error | observed | A performance claim or release decision rests on a delta that does not reproduce | A paired comparison run as sequential blocks (`go test -count=N`) instead of alternating invocations, or a gap claimed from overlapping ranges | Re-run alternating; see the release checklist below |
-| Accessor divergence on one message | hypothesized | Two accessors over the same message disagree on whether a payload is valid, so a consumer sees one field read succeed and the other fail on identical bytes | A second accessor added with its own parser instead of reading from the existing walk | Shared-walk implementation plus a malformed-parity test asserting both accessors fail together; see `TestLogRecordSeverityText_MalformedParity` |
+| Accessor divergence on one message | hypothesized | Two accessors over the same message disagree on whether a payload is valid, so a consumer sees one field read succeed and the other fail on identical bytes | A second accessor added with its own parser instead of reading from the existing walk | Shared-walk implementation plus a malformed-parity test asserting both accessors fail together; see `TestLogRecordSeverity_MalformedParity` |
 
 ### Known consumer-visible transitions in the API realignment
 
@@ -62,12 +62,23 @@ consequences when reading a consumer's CPU profile:
   counts. [docs/BENCHMARKS.md](docs/BENCHMARKS.md) has the measured comparison
   against a shallow hand-rolled walk.
 
-**Known divergence:** the scanning LogRecord accessors accept a *well-formed*
-group in an unknown LogRecord field, where pdata rejects the same bytes with
-`unexpected EOF`. This is the mirror of the unclosed-group row above and is
-likewise reachable only on malformed or adversarial input. It matters to
-consumers that pair the wire path with a pdata fallback and expect the two to
-agree on validity. No test covers it.
+**Known divergences from pdata.** These matter only to consumers that pair the
+wire path with a pdata fallback and expect the two to agree on validity. All
+are reachable only on malformed or adversarial input, never on conformant OTLP
+from a normal producer, and none is specific to one accessor — they are
+properties of the shared LogRecord walk. No test covers them.
+
+| Input | Wire path | pdata |
+| --- | --- | --- |
+| Well-formed group in an unknown LogRecord field, or inside the body's `AnyValue` | accepts | rejects (`unexpected EOF`) |
+| Non-canonical 10-byte varint (10th byte ≥ 2), in any varint field including a `severity_text` length prefix | rejects | accepts |
+| Field number above `MaxInt32` whose `int32` truncation is positive | rejects (`malformed protobuf tag`) | accepts (truncates, then skips) |
+
+The first row is the mirror of the unclosed-group row above. The last two come
+from `protowire` being stricter than pdata's generated unmarshal: `protowire`
+enforces canonical varint encoding and rejects out-of-range field numbers,
+where the gogo-generated loop does neither. A consumer cannot conclude "pdata
+would also reject this" from a wire-path error, nor the reverse.
 
 ## Telemetry inventory
 

--- a/operations.md
+++ b/operations.md
@@ -73,14 +73,15 @@ rather than as silently different consumer behavior.
 | Input | Wire path | pdata |
 | --- | --- | --- |
 | Well-formed group in an unknown LogRecord field, or inside the body's `AnyValue` | accepts | rejects (`unexpected EOF`) |
-| Non-canonical 10-byte varint (10th byte ≥ 2), in any varint field including a `severity_text` length prefix | rejects | accepts |
+| Varint overflowing uint64 (10 bytes, final byte ≥ 2), in any varint field including a `severity_text` length prefix | rejects | accepts (truncated) |
 | Field number above `MaxInt32` whose `int32` truncation is positive | rejects (`malformed protobuf tag`) | accepts (truncates, then skips) |
 
 The first row is the mirror of the unclosed-group row above. The last two come
 from `protowire` being stricter than pdata's generated unmarshal: `protowire`
-enforces canonical varint encoding and rejects out-of-range field numbers,
-where the gogo-generated loop does neither. A consumer cannot conclude "pdata
-would also reject this" from a wire-path error, nor the reverse.
+rejects a varint whose value exceeds `uint64` and a field number above
+`MaxInt32`, where the generated loop silently truncates both. A consumer
+cannot conclude "pdata would also reject this" from a wire-path error, nor the
+reverse.
 
 ## Telemetry inventory
 

--- a/operations.md
+++ b/operations.md
@@ -66,7 +66,9 @@ consequences when reading a consumer's CPU profile:
 wire path with a pdata fallback and expect the two to agree on validity. All
 are reachable only on malformed or adversarial input, never on conformant OTLP
 from a normal producer, and none is specific to one accessor — they are
-properties of the shared LogRecord walk. No test covers them.
+properties of the shared LogRecord walk. `TestLogRecordSeverity_PdataDivergence`
+pins each one, so a change in either direction shows up as a test failure
+rather than as silently different consumer behavior.
 
 | Input | Wire path | pdata |
 | --- | --- | --- |


### PR DESCRIPTION
## Motivation

`LogRecord.SeverityNumber()` exists; `severity_text` (field 3) did not. sage hand-rolls the walk today in `internal/event/wire.go` as `logRecordSeverityText(data []byte) (string, error)`. This adds the symmetrical accessor.

Closes E-2944, sub-issue 4 of E-2940.

## Approach

```go
func (r LogRecord) SeverityText() ([]byte, error)
```

The design decision worth reviewing: **`SeverityText` reads out of the existing schema-aware `parseLogRecordSeverity` walk rather than calling `extractLastBytesField`.**

A second, shallower parser over the same message is how two accessors come to disagree about whether the same bytes are valid. A field-3-only walk (what a consumer hand-rolls, and what `extractLastBytesField` would give) accepts a malformed body or attribute that `SeverityNumber` rejects — so a consumer reading both fields sees one succeed and one fail on identical input. Sharing the walk makes that impossible by construction; `TestLogRecordSeverity_MalformedParity` pins it.

Contract:

- returns `nil` when absent, a non-nil zero-length slice when present-but-empty — a distinction pdata cannot represent;
- repeated occurrences resolve last-value-wins, as protobuf/pdata do for a singular scalar;
- returned slice aliases the request buffer with capacity clamped, so a caller's `append` cannot overwrite adjacent record fields.

`AGENTS.md` previously told contributors to reach for `extractLastBytesField` for *any* singular scalar — literally the shallow second parser this change exists to avoid. It now records the third branch.

## Compatibility

Additive. No exported signature changed, no behavior changed for existing accessors. Every consumer upgrades with a plain dependency bump.

## Validation

```bash
go build ./...
go vet ./...
go test -v -race ./...
go test -race -shuffle=on -count=1 ./...
git diff --check
```

All pass. Per `CONTRIBUTING.md`, `go mod tidy -diff` is not gated on (pre-existing `go.sum` checksum history); no dependency changed here.

New coverage in `log_iteration_test.go`:

- pdata differentials: absent, present-but-empty, populated, repeated (last wins), repeated resolving *to* an empty last occurrence and *from* an empty first one, unknown scalar fields skipped;
- `TestLogRecordSeverity_MalformedParity` — 9 malformed records, each asserted to fail `SeverityText`, `SeverityNumber` **and** pdata. This replaces `TestLogRecordSeverityNumber_PdataMalformedParity`, whose 6 fixtures it contains verbatim plus 3 new rows, and additionally asserts the second accessor;
- complete-message semantics: trailing corruption and a trailing wrong-wire-type occurrence still error after a valid early value;
- view/allocation contract: capacity clamp, aliasing proven by mutating the buffer, and `testing.AllocsPerRun` == 0;
- `TestLogRecordSeverity_PdataDivergence` — the five inputs where the shared walk and pdata disagree, asserted in both directions, with the two accessors still required to agree with each other.

## Benchmarks

Paired, interleaved single-arm invocations of prebuilt binaries (not `go test -count=N`, which does not interleave arms). i7-11800H, linux/amd64, Go 1.25.12.

**Cost of the shared walk on the existing `SeverityNumber` hot path** — fixture emits no `severity_text`, so this measures only the added branching and return:

| Revision | ns/op (median of 15) | B/op | allocs/op |
|---|---:|---:|---:|
| merge base | 78,744 | 488 | 15 |
| this change | 80,749 | 488 | 15 |

**Median paired delta +2.67%, slower in 14 of 15 rounds, allocations unchanged.** A second independent 15-round session measured +2.00% (12/15). Read the cost as **+2 to +3%**: single rounds range −8.7% to +5.8% under desktop load, so sign consistency is the evidence and the magnitude is stable only to about a percentage point.

**Against sage's hand-rolled walk** (copied verbatim as the comparison arm):

| Benchmark | ns/op (median of 9) | B/op | allocs/op |
|---|---:|---:|---:|
| `_HandRolled` | 40,215 | 2,368 | 514 |
| `SeverityText` | 69,185 | 368 | 14 |

~72% slower, 500 allocations cheaper per batch. The arms are deliberately **not** equivalent work: sage's stops at field 3 and materializes a `string`; this validates every known LogRecord field and returns a view. Both directions are documented in `docs/BENCHMARKS.md` — a consumer that wants the cheap shallow read and does not need `SeverityNumber` parity is better served by its own walk, and should say so on the migration issue.

## Risks

- **Accessor CPU cost, disclosed above.** +2 to +3% on the severity-classification path; allocations unchanged. Not a hot-path regression in allocation terms.
- **Two walks for both fields.** Each accessor runs the walk once, so reading number + text costs two. No combined accessor added — the walk already produces both values so exposing the pair needs no new machinery, but per E-2940's flattened-convenience rule that needs a measured hot path. Concrete trigger recorded: sage adopting `SeverityText` and reading both fields per record.
- **API compatibility:** none, additive.
- **Rollout:** none required. Library-only change; no release or consumer migration in this PR. sage's migration is tracked separately.

## Reviewer notes

Two things I deliberately did **not** do, with the measurements behind them:

1. **Split `case 3, 12` into separate arms** for field-specific error messages. Measured ~0.8pp *slower* split; the shared arm is also house style (`case 9, 10` discriminates the same way). The current error text does not name `severity_text` specifically — flagging in case you'd trade the 0.8pp for the diagnostic.
2. **Reshape `parseLogRecordSeverity` to return a `logRecordFields` struct** instead of threading a third return value. Fair argument that it is the same churn today and zero churn for the next LogRecord accessor. Skipped because this function's cost is measurably sensitive to loop-carried state layout, so reshaping means re-running the full paired benchmark for a benefit that only lands on a hypothetical third accessor. Happy to do it as a follow-up if you'd rather have the shape now.

## Known divergences recorded, not introduced

Adversarial review turned up three classes of wire-vs-pdata disagreement, all pre-existing (`SeverityNumber` behaves identically on `main`) and all reachable only on malformed or adversarial input:

| Input | Wire path | pdata |
|---|---|---|
| Well-formed group in an unknown LogRecord field, or inside the body's `AnyValue` | accepts | rejects |
| Varint overflowing `uint64` (10 bytes, final byte ≥ 2), including a `severity_text` length prefix | rejects | accepts (truncated) |
| Field number above `MaxInt32` truncating positive | rejects | accepts |

The last two are `protowire` being stricter than pdata's generated unmarshal, which silently truncates both. `TestLogRecordSeverity_PdataDivergence` pins all five so a change in either direction fails a test rather than silently altering consumer behavior, and `operations.md` documents them for consumers that pair the wire path with a pdata fallback.

## Adversarial review

Per E-2940's gate. It could not break the accessor:

- **Parity** (the change's central claim): 6.9M structured-grammar and 2.0M raw-byte fuzz executions asserting `(numErr==nil) == (txtErr==nil)` — zero failures.
- **No regression in `SeverityNumber`**: the pre-change parser was copied in as a second implementation and differentially fuzzed over ~11M inputs comparing both error-ness and value — zero disagreements.
- **Aliasing/capacity**: appending 32 bytes through the returned view left the enclosing request bytes byte-identical across populated, empty, repeated and multi-record buffers.
- **Zero-alloc** holds on rich records (body + 3 attributes + trace/span IDs + flags + event_name), not just the bare fixture.

It did find five real defects, all in docs and coverage, fixed in the second commit: a dangling test reference, the incomplete divergence note above, a benchmark recipe whose "before" arm was a `git stash` no-op that would have measured 0%, the understated regression figure, and a missing test for a repeated `severity_text` whose last occurrence is empty — the case where a `len(value) > 0` guard would silently return the earlier value.

## Agent involvement

Per `CONTRIBUTING.md`: this change was implemented with Claude Code. The implementation, tests, docs and all benchmark runs were agent-produced; findings from four cleanup sub-agents and one adversarial sub-agent were verified against the code before being applied or dismissed. A human must review and take ownership before merge.

## Review status

CodeRabbit raised 4 actionable comments across two passes; all are fixed and all four threads are resolved.

- `example_test.go`: the example returned early on an accessor error without invoking `scopesErr`/`resourcesErr`. No error was swallowed, but examples are executable documentation and this one taught a pattern that violates the repository-wide iterator contract. Now one function per level, each checking its own closure.
- `operations.md`: the divergences were documented in prose only — now pinned by a test.
- `README.md`: restored the last-value-wins clause I had trimmed as duplication; it belongs in the API summary.
- `log_iteration_test.go`: I had called the rejected varints "non-canonical". They are *overflowing* — a 10-byte varint carries at most bit 63 in its final byte, so a final byte ≥ 2 exceeds `uint64`. Renamed and corrected in the docs too.
