### PR TITLE
feat(logs): add LogRecord.Severity combined accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,10 @@ LogRecord, so they accept and reject exactly the same bytes; see
 [docs/DESIGN.md](docs/DESIGN.md) for why they share one parser. Each call runs
 that walk once, so `LogRecord.Severity` is the accessor for consumers reading
 both fields — the single-field pair costs a measured ~1.9x
-([docs/BENCHMARKS.md](docs/BENCHMARKS.md)).
+([docs/BENCHMARKS.md](docs/BENCHMARKS.md)). Its two results carry the contracts
+described above for each field. Ranking them is consumer policy: the library
+does not classify severity bands, nor decide which field wins when the number
+and the text disagree.
 
 `Resource.StringAttribute` is zero-copy and returns a separate `found` value,
 so a missing resource attribute can be distinguished from a present empty

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ ExportLogsServiceRequest (OTLP message bytes)
             ├─ SchemaUrl()
             └─ LogRecord[]
                  ├─ SeverityNumber()
-                 └─ SeverityText()
+                 ├─ SeverityText()
+                 └─ Severity()      (both fields, one walk)
 
 ExportTracesServiceRequest (OTLP message bytes)
   └─ ResourceSpans[] (one per resource)
@@ -274,6 +275,7 @@ func (s ScopeLogs) LogRecordsSeq(yield func(LogRecord, error) bool) // zero-allo
 type LogRecord []byte
 func (r LogRecord) SeverityNumber() (int32, error)
 func (r LogRecord) SeverityText() ([]byte, error)
+func (r LogRecord) Severity() (int32, []byte, error) // both fields, one walk
 
 type Resource []byte
 func (r Resource) Attributes() (iter.Seq[KeyValue], func() error)
@@ -284,9 +286,14 @@ func (r Resource) StringAttribute(key string) ([]byte, bool, error)
 `LogRecord.SeverityText` returns raw bytes aliasing the request buffer, and
 `nil` when `severity_text` is absent, which distinguishes an absent field from
 a present empty one. Repeated occurrences resolve to the last, the protobuf
-singular-scalar rule. It shares `SeverityNumber`'s schema-aware walk of the
-whole LogRecord, so reading both fields costs two walks; see
-[docs/DESIGN.md](docs/DESIGN.md) for why they share one parser.
+singular-scalar rule.
+
+All three severity accessors read from one schema-aware walk of the whole
+LogRecord, so they accept and reject exactly the same bytes; see
+[docs/DESIGN.md](docs/DESIGN.md) for why they share one parser. Each call runs
+that walk once, so `LogRecord.Severity` is the accessor for consumers reading
+both fields — the single-field pair costs a measured ~1.9x
+([docs/BENCHMARKS.md](docs/BENCHMARKS.md)).
 
 `Resource.StringAttribute` is zero-copy and returns a separate `found` value,
 so a missing resource attribute can be distinguished from a present empty

--- a/benchmark_comparison_test.go
+++ b/benchmark_comparison_test.go
@@ -1406,47 +1406,10 @@ func BenchmarkMetric_Metadata_Seq(b *testing.B) {
 	}
 }
 
-// ========== LogRecord.SeverityText ==========
+// ========== LogRecord severity accessors ==========
 
-// benchSeverityTextSink prevents the severity-text arms from being optimized
-// away.
-var benchSeverityTextSink int
-
-// logRecordSeverityTextHandRolled is the field-3 walk sage hand-rolls in
-// internal/event/wire.go, copied verbatim as the "before" arm so the
-// comparison reproduces from this repository alone. It is deliberately not
-// equivalent work: it stops at field 3 and materializes a string, where
-// LogRecord.SeverityText validates every known LogRecord field and returns a
-// view. Drop this arm and its docs/BENCHMARKS.md section once sage moves to
-// LogRecord.SeverityText.
-func logRecordSeverityTextHandRolled(data []byte) (string, error) {
-	var text []byte
-	for len(data) > 0 {
-		num, typ, n := protowire.ConsumeTag(data)
-		if n < 0 {
-			return "", errors.New("malformed protobuf tag in log record")
-		}
-		data = data[n:]
-		if num == 3 {
-			if typ != protowire.BytesType {
-				return "", errors.New("wrong wire type for severity_text")
-			}
-			value, m := protowire.ConsumeBytes(data)
-			if m < 0 {
-				return "", errors.New("malformed severity_text field")
-			}
-			text = value
-			data = data[m:]
-			continue
-		}
-		n = protowire.ConsumeFieldValue(num, typ, data)
-		if n < 0 {
-			return "", errors.New("malformed field in log record")
-		}
-		data = data[n:]
-	}
-	return string(text), nil
-}
+// benchSeveritySink prevents the severity arms from being optimized away.
+var benchSeveritySink int
 
 func benchSeverityTextPayload(b *testing.B) []byte {
 	b.Helper()
@@ -1480,24 +1443,8 @@ func forEachBenchLogRecord(b *testing.B, payload []byte, fn func(LogRecord)) {
 	}
 }
 
-func BenchmarkLogRecord_SeverityText_HandRolled(b *testing.B) {
-	payload := benchSeverityTextPayload(b)
-
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		total := 0
-		forEachBenchLogRecord(b, payload, func(record LogRecord) {
-			text, err := logRecordSeverityTextHandRolled([]byte(record))
-			if err != nil {
-				b.Fatal(err)
-			}
-			total += len(text)
-		})
-		benchSeverityTextSink = total
-	}
-}
-
+// BenchmarkLogRecord_SeverityText is the single-field baseline: one walk per
+// record, which is what a consumer reading only severity_text pays.
 func BenchmarkLogRecord_SeverityText(b *testing.B) {
 	payload := benchSeverityTextPayload(b)
 
@@ -1512,7 +1459,51 @@ func BenchmarkLogRecord_SeverityText(b *testing.B) {
 			}
 			total += len(text)
 		})
-		benchSeverityTextSink = total
+		benchSeveritySink = total
+	}
+}
+
+// BenchmarkLogRecord_SeverityNumberAndText reads both fields through the
+// single-field accessors, which runs the shared walk twice per record. It is
+// the arm BenchmarkLogRecord_Severity replaces; keep the two doing identical
+// work at the call site so the delta is the second walk and nothing else.
+func BenchmarkLogRecord_SeverityNumberAndText(b *testing.B) {
+	payload := benchSeverityTextPayload(b)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		total := 0
+		forEachBenchLogRecord(b, payload, func(record LogRecord) {
+			number, err := record.SeverityNumber()
+			if err != nil {
+				b.Fatal(err)
+			}
+			text, err := record.SeverityText()
+			if err != nil {
+				b.Fatal(err)
+			}
+			total += int(number) + len(text)
+		})
+		benchSeveritySink = total
+	}
+}
+
+func BenchmarkLogRecord_Severity(b *testing.B) {
+	payload := benchSeverityTextPayload(b)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		total := 0
+		forEachBenchLogRecord(b, payload, func(record LogRecord) {
+			number, text, err := record.Severity()
+			if err != nil {
+				b.Fatal(err)
+			}
+			total += int(number) + len(text)
+		})
+		benchSeveritySink = total
 	}
 }
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -577,13 +577,13 @@ paired median (between +3% and +6.5% across runs) and the sign, which held in
 one indirect call per element; the clamp is the guarantee a caller's `append`
 cannot reach the neighbouring entry, which the hand-rolled walk lacks.
 
-## `LogRecord.SeverityText` (E-2944)
+## LogRecord severity accessors (E-2944, E-2957)
 
-`SeverityText` reads `severity_text` out of the same schema-aware walk
-`SeverityNumber` already used, rather than getting its own extractor. Two
-measurements matter: what that shared walk costs the existing `SeverityNumber`
-hot path, and how the new accessor compares to the shallow walk sage
-hand-rolls today.
+`SeverityNumber`, `SeverityText` and `Severity` all read from one schema-aware
+walk of the whole LogRecord rather than getting their own extractors. Two
+measurements matter: what threading `severity_text` out of that walk costs the
+`SeverityNumber` hot path, and what the combined accessor saves a consumer
+reading both fields.
 
 **Environment:** 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz, linux/amd64,
 Go 1.25.12, developer desktop. Both comparisons alternate single-arm
@@ -629,57 +629,51 @@ delta this size on this machine — it understated the median by roughly a
 percentage point against both 15-round sessions. Use 15 or more.
 
 This is the price of one walk instead of two implementations, and it is
-deliberate: see [DESIGN.md](DESIGN.md) for why drift between the two severity
+deliberate: see [DESIGN.md](DESIGN.md) for why drift between the severity
 accessors is the failure being bought out.
 
-### Against sage's hand-rolled walk
+### Reading both fields: `Severity` against the single-field pair
 
 **Fixture:** `createBenchLogs` — 5 resources × 100 records, each with a body,
 a timestamp, two attributes, a severity number and `severity_text`.
 
-`logRecordSeverityTextHandRolled` is sage's `internal/event/wire.go` walk
-copied verbatim so the comparison reproduces from this repository alone. The
-arms are **not** equivalent work: sage's stops at field 3 and steps over the
-body and attributes without descending, then materializes a `string`;
-`SeverityText` validates every known LogRecord field — including parsing the
-body's `AnyValue` and every attribute `KeyValue` — and returns a view.
+Three arms of one binary, alternated. `SeverityText` is the single-field
+baseline — one walk per record — and `SeverityNumberAndText` calls both
+single-field accessors, which runs that walk twice:
 
 ```bash
 go test -c -o /tmp/otlpwire.test .
-for round in $(seq 1 9); do
-  for arm in _HandRolled ''; do
+for round in $(seq 1 15); do
+  for arm in SeverityText SeverityNumberAndText Severity; do
     /tmp/otlpwire.test -test.run '^$' -test.benchmem -test.benchtime=3000x \
-      -test.bench "^BenchmarkLogRecord_SeverityText${arm}\$"
+      -test.bench "^BenchmarkLogRecord_${arm}\$"
   done
 done
 ```
 
-| Benchmark | ns/op (median of 9) | B/op | allocs/op |
-|---|---:|---:|---:|
-| `BenchmarkLogRecord_SeverityText_HandRolled` | 40,215 | 2,368 | 514 |
-| `BenchmarkLogRecord_SeverityText` | 69,185 | 368 | 14 |
+| Benchmark | fields / walks | ns/op (median of 15) | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| `BenchmarkLogRecord_SeverityText` | one / one | 89,783 | 368 | 14 |
+| `BenchmarkLogRecord_SeverityNumberAndText` | two / two | 170,990 | 368 | 14 |
+| `BenchmarkLogRecord_Severity` | two / one | 89,669 | 368 | 14 |
 
-**About 72% slower and 500 allocations cheaper per batch**, slower in 9 of 9
-rounds. Both directions are real and neither is noise:
+**Median paired saving 48% against the two-accessor pair, cheaper in 15 of 15
+rounds**, allocations unchanged. Put the other way round, reading both fields
+through the single-field accessors costs roughly **double**: the pair is 92%
+more expensive at the median, per-round deltas spanning +76% to +110%. An
+earlier 11-round session on the same machine measured a 44% saving, so take
+the effect as "about half the cost, give or take a few points" rather than
+either figure exactly.
 
-- The CPU cost is the schema-aware validation. It is what makes `SeverityText`
-  and `SeverityNumber` accept and reject identical bytes; the hand-rolled walk
-  cannot make that promise, because it never looks at the body or attributes.
-- The allocation saving is the returned view. sage's walk allocates one string
-  per record — 500 in this fixture — where the accessor aliases the request
-  buffer with a clamped capacity.
+The combined arm lands on the single-field one — median +1.1%, per-round
+deltas from −7.4% to +29.0%, slower in only 9 of 15 rounds, so the sign does
+not hold and the two are indistinguishable here. That is the property being
+claimed: reading both fields costs one walk, not two.
 
-A consumer on a GC-sensitive ingest path is trading CPU for allocations here,
-not simply losing. A consumer that wants the cheap shallow read and does not
-need `SeverityNumber` parity is better served by its own walk, and should say
-so on the migration issue rather than adopting this accessor by default.
-
-Reading both severity fields runs the walk twice. No combined accessor exists;
-the trigger for adding one is sage adopting `SeverityText` and reading both
-fields per record.
-
-Drop the hand-rolled arm and this subsection once sage moves to
-`LogRecord.SeverityText`.
+The 14 allocations are the resource and scope iterator openings, not the
+severity read; every arm pays the same. A consumer that wants a
+`string` rather than a view pays for that conversion at its own call site,
+which is where the allocation belongs.
 
 ## Span field accessors (E-2945)
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -148,16 +148,22 @@ makes that impossible by construction.
 
 Threading the value out of the walk costs a measured 2–3% on the
 severity-classification path with allocations unchanged
-([BENCHMARKS.md](BENCHMARKS.md)), and a consumer reading both severity fields
-pays two walks, because each accessor runs the walk once. No combined accessor
-exists. The walk already produces both values, so exposing the pair would need
-no new machinery — but per the flattened-convenience rule in E-2940 a
-convenience needs a measured hot path, and the concrete trigger is sage
-adopting `SeverityText` and reading both fields per record.
+([BENCHMARKS.md](BENCHMARKS.md)).
+
+`Severity` returns both fields from one walk. Each single-field accessor runs
+the walk once, so a consumer reading both through them pays for two — a
+measured ~1.9x the combined call over the same records. This is the
+flattened convenience E-2940 permits rather than one it forbids: that rule asks
+a convenience to name a measured hot path, and E-2954 measured one — sage's
+per-record scan loop reads both fields. Exposing the pair added no parsing
+machinery, since the walk already produced both values, and all three accessors
+share it, so none of them can disagree with another about whether a record is
+valid.
 
 Severity *classification* stays out of the library. Bands and number/text
 precedence are consumer policy, and nothing in the consumer audit argues
-otherwise.
+otherwise. `Severity` returns the raw wire fields; deciding which one wins when
+they disagree is the consumer's.
 
 Resource context comes from `ResourceLogs.Resource()`, which merges every
 Resource occurrence for this container (see "Resource extraction" below) so

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -376,12 +376,17 @@ distinction pdata cannot represent; both compare equal to `""`. Repeated
 occurrences resolve to the last one, as protobuf and pdata do for a singular
 scalar.
 
-Both severity accessors read from one schema-aware walk of the whole
-LogRecord, so they accept and reject exactly the same bytes. Each call runs
-that walk once, so a consumer reading both fields pays for two.
+`LogRecord.Severity` returns both fields at once, each carrying the contract
+its single-field accessor states. It is the accessor for consumers reading both
+per record: every accessor runs the walk once, so the single-field pair costs
+two walks where `Severity` costs one.
 
-The library does not classify severity bands or combine severity number with
-severity text. That remains consumer policy.
+All three severity accessors read from one schema-aware walk of the whole
+LogRecord, so they accept and reject exactly the same bytes.
+
+The library does not classify severity bands, and `Severity` returning the two
+fields together does not rank them: which one wins when the number and the text
+disagree remains consumer policy.
 
 ### Trace depth
 

--- a/example_test.go
+++ b/example_test.go
@@ -264,11 +264,13 @@ func ExampleResourceLogs_Resource() {
 	// Output: checkout severity=13
 }
 
-// ExampleLogRecord_SeverityText reads both severity fields together, which is
-// what a severity gate needs: the number orders records, the text carries the
-// producer's own label. SeverityText returns a view into the request buffer,
-// and nil distinguishes an absent severity_text from a present empty one.
-func ExampleLogRecord_SeverityText() {
+// ExampleLogRecord_Severity reads both severity fields together, which is what
+// a severity gate needs: the number orders records, the text carries the
+// producer's own label. Severity returns the pair from one walk of the record,
+// where the single-field accessors would each run that walk again. The text is
+// a view into the request buffer, and nil distinguishes an absent
+// severity_text from a present empty one.
+func ExampleLogRecord_Severity() {
 	logs := plog.NewLogs()
 	records := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords()
 	labelled := records.AppendEmpty()
@@ -329,11 +331,7 @@ func printScopeLogSeverities(scope otlpwire.ScopeLogs) error {
 		if err != nil {
 			return err
 		}
-		number, err := record.SeverityNumber()
-		if err != nil {
-			return err
-		}
-		text, err := record.SeverityText()
+		number, text, err := record.Severity()
 		if err != nil {
 			return err
 		}

--- a/log_iteration_test.go
+++ b/log_iteration_test.go
@@ -104,10 +104,7 @@ func TestLogRecordSeverityText(t *testing.T) {
 // pdata's setter cannot emit: proto3 drops an empty severity_text on marshal,
 // and the API has no way to repeat a singular field.
 func TestLogRecordSeverityText_MatchesPdata(t *testing.T) {
-	severityText := func(value string) []byte {
-		out := protowire.AppendTag(nil, 3, protowire.BytesType)
-		return protowire.AppendString(out, value)
-	}
+	severityText := severityTextField
 
 	tests := []struct {
 		name     string
@@ -178,6 +175,109 @@ func TestLogRecordSeverityText_CompleteMessageSemantics(t *testing.T) {
 	require.Error(t, err, "every severity_text occurrence must use the bytes wire type")
 }
 
+// TestLogRecordSeverity_MatchesPdataAndSingleAccessors pins the combined
+// accessor against pdata and against the pair of single-field accessors it
+// replaces, over every presence combination of the two fields. The records are
+// hand-built because pdata's setters cannot emit an empty severity_text or a
+// repeated singular field.
+func TestLogRecordSeverity_MatchesPdataAndSingleAccessors(t *testing.T) {
+	tests := []struct {
+		name           string
+		record         []byte
+		expectedNumber int32
+		expectedText   []byte
+	}{
+		{
+			name:   "neither field present",
+			record: unknownScalarFields(),
+		},
+		{
+			name:           "number only",
+			record:         severityNumberField(plog.SeverityNumberWarn),
+			expectedNumber: 13,
+		},
+		{
+			name:         "text only",
+			record:       severityTextField("WARN"),
+			expectedText: []byte("WARN"),
+		},
+		{
+			name:           "both present",
+			record:         append(severityNumberField(plog.SeverityNumberError), severityTextField("ERROR")...),
+			expectedNumber: 17,
+			expectedText:   []byte("ERROR"),
+		},
+		{
+			name:           "text present but empty",
+			record:         append(severityNumberField(plog.SeverityNumberInfo), severityTextField("")...),
+			expectedNumber: 9,
+			expectedText:   []byte{},
+		},
+		{
+			name:           "repeated number resolves to the last occurrence",
+			record:         slices.Concat(severityNumberField(plog.SeverityNumberDebug), severityTextField("KEPT"), severityNumberField(plog.SeverityNumberFatal)),
+			expectedNumber: 21,
+			expectedText:   []byte("KEPT"),
+		},
+		{
+			name:           "repeated text resolves to the last occurrence",
+			record:         slices.Concat(severityTextField("FIRST"), severityNumberField(plog.SeverityNumberInfo), severityTextField("SECOND")),
+			expectedNumber: 9,
+			expectedText:   []byte("SECOND"),
+		},
+		{
+			name:           "unknown fields around both",
+			record:         slices.Concat(unknownScalarFields(), severityTextField("TRACE"), unknownScalarFields(), severityNumberField(plog.SeverityNumberTrace), unknownScalarFields()),
+			expectedNumber: 1,
+			expectedText:   []byte("TRACE"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := LogRecord(tt.record)
+
+			number, text, err := record.Severity()
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedNumber, number)
+			// require.Equal distinguishes a nil []byte from an empty one,
+			// which is the absent-versus-present-empty contract pdata cannot
+			// express. The expected values rely on that.
+			require.Equal(t, tt.expectedText, text)
+
+			singleNumber, err := record.SeverityNumber()
+			require.NoError(t, err)
+			singleText, err := record.SeverityText()
+			require.NoError(t, err)
+			require.Equal(t, singleNumber, number, "the combined accessor must return what SeverityNumber returns")
+			require.Equal(t, singleText, text, "the combined accessor must return what SeverityText returns")
+
+			pdataNumber, pdataText := pdataSeverity(t, tt.record)
+			require.Equal(t, tt.expectedNumber, pdataNumber)
+			require.Equal(t, string(tt.expectedText), pdataText)
+		})
+	}
+}
+
+// TestLogRecordSeverity_CompleteMessageSemantics pins that the combined
+// accessor inherits the whole-record walk rather than stopping once both
+// fields are in hand, so corruption located after them is still reported.
+func TestLogRecordSeverity_CompleteMessageSemantics(t *testing.T) {
+	var record LogRecord
+	record = append(record, severityNumberField(plog.SeverityNumberInfo)...)
+	record = append(record, severityTextField("INFO")...)
+	record = appendUnknownGroup(record, 90)
+
+	number, text, err := record.Severity()
+	require.NoError(t, err)
+	require.Equal(t, int32(plog.SeverityNumberInfo), number)
+	require.Equal(t, []byte("INFO"), text)
+
+	trailingMalformed := append(append(LogRecord(nil), record...), 0x80)
+	_, _, err = trailingMalformed.Severity()
+	require.Error(t, err, "a valid early severity must not hide malformed trailing data")
+}
+
 // TestLogRecordSeverity_PdataDivergence pins the inputs where the shared
 // LogRecord walk and pdata disagree about validity. They are the exception to
 // the parity the rest of the suite asserts, they are all reachable only on
@@ -228,12 +328,15 @@ func TestLogRecordSeverity_PdataDivergence(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, textErr := tt.record.SeverityText()
 			_, numberErr := tt.record.SeverityNumber()
+			_, _, combinedErr := tt.record.Severity()
 			_, pdataErr := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithRecord(tt.record))
 
-			// The divergence is wire-versus-pdata. The two accessors still
+			// The divergence is wire-versus-pdata. The three accessors still
 			// agree with each other, which is the property that matters.
 			require.Equal(t, textErr == nil, numberErr == nil,
-				"severity accessors must agree even where pdata disagrees with both")
+				"severity accessors must agree even where pdata disagrees with all of them")
+			require.Equal(t, textErr == nil, combinedErr == nil,
+				"severity accessors must agree even where pdata disagrees with all of them")
 
 			if tt.wireRejects {
 				require.Error(t, textErr, "wire path must reject")
@@ -246,9 +349,9 @@ func TestLogRecordSeverity_PdataDivergence(t *testing.T) {
 	}
 }
 
-// TestLogRecordSeverity_MalformedParity keeps the two severity accessors from
-// drifting apart: every malformed record fails both, and pdata rejects the
-// same bytes. It is the guard for the accessor-divergence risk in
+// TestLogRecordSeverity_MalformedParity keeps the three severity accessors
+// from drifting apart: every malformed record fails all of them, and pdata
+// rejects the same bytes. It is the guard for the accessor-divergence risk in
 // operations.md, so it covers the whole known LogRecord schema rather than
 // only the two severity fields.
 func TestLogRecordSeverity_MalformedParity(t *testing.T) {
@@ -271,36 +374,65 @@ func TestLogRecordSeverity_MalformedParity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, textErr := tt.record.SeverityText()
 			_, numberErr := tt.record.SeverityNumber()
+			_, _, combinedErr := tt.record.Severity()
 			_, pdataErr := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithRecord(tt.record))
 			require.Error(t, textErr)
 			require.Error(t, numberErr)
+			require.Error(t, combinedErr)
 			require.Error(t, pdataErr)
 		})
 	}
 }
 
-// TestLogRecordSeverityText_ViewAndAllocationContract pins what the accessor
-// promises beyond its value: the result aliases the caller's buffer with a
-// clamped capacity, and reading it allocates nothing.
-func TestLogRecordSeverityText_ViewAndAllocationContract(t *testing.T) {
-	logs := plog.NewLogs()
-	logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().SetSeverityText("INFO")
-	record := onlyLogRecord(t, marshalLogs(t, logs))
+// TestLogRecordSeverity_ViewAndAllocationContract pins what the text-returning
+// accessors promise beyond their value: the result aliases the caller's buffer
+// with a clamped capacity, and reading it allocates nothing.
+//
+// The record is hand-built with event_name after severity_text. protowire
+// returns a slice whose capacity runs to the end of the record, so the clamp
+// is what stops a caller's append from rewriting the field that follows — and
+// only a neighbour on that side can show it. A pdata-marshalled fixture cannot:
+// pdata writes fields in descending order, which leaves severity_text last and
+// makes the capacity assertion pass with or without the clamp.
+func TestLogRecordSeverity_ViewAndAllocationContract(t *testing.T) {
+	record := LogRecord(slices.Concat(
+		severityNumberField(plog.SeverityNumberInfo),
+		severityTextField("INFO"),
+		eventNameField("checkout.completed"),
+	))
+	untouched := slices.Clone([]byte(record))
 
 	text, err := record.SeverityText()
 	require.NoError(t, err)
+	number, combinedText, err := record.Severity()
+	require.NoError(t, err)
+	require.Equal(t, int32(plog.SeverityNumberInfo), number)
 	require.Equal(t, len(text), cap(text), "capacity must be clamped so a caller's append reallocates")
+	require.Equal(t, len(combinedText), cap(combinedText), "capacity must be clamped so a caller's append reallocates")
+
+	require.Equal(t, "INFOoverwritten", string(append(text, "overwritten"...)))
+	require.Equal(t, "INFOoverwritten", string(append(combinedText, "overwritten"...)))
+	require.Equal(t, untouched, []byte(record), "appending to the view must not reach the field that follows it")
 
 	// A copy would keep the old byte.
 	index := bytes.Index(record, []byte("INFO"))
 	require.GreaterOrEqual(t, index, 0)
 	record[index] = 'i'
 	require.Equal(t, []byte("iNFO"), text)
+	require.Equal(t, []byte("iNFO"), combinedText)
 
 	allocations := testing.AllocsPerRun(100, func() {
 		got, err := record.SeverityText()
 		if err != nil || len(got) == 0 {
 			t.Fatal("unexpected severity text result")
+		}
+	})
+	require.Zero(t, allocations)
+
+	allocations = testing.AllocsPerRun(100, func() {
+		number, got, err := record.Severity()
+		if err != nil || number != int32(plog.SeverityNumberInfo) || len(got) == 0 {
+			t.Fatal("unexpected severity result")
 		}
 	})
 	require.Zero(t, allocations)
@@ -321,11 +453,28 @@ func severityNumberField(severity plog.SeverityNumber) []byte {
 	return protowire.AppendVarint(out, uint64(severity))
 }
 
+func severityTextField(value string) []byte {
+	out := protowire.AppendTag(nil, 3, protowire.BytesType)
+	return protowire.AppendString(out, value)
+}
+
+func eventNameField(value string) []byte {
+	out := protowire.AppendTag(nil, 12, protowire.BytesType)
+	return protowire.AppendString(out, value)
+}
+
 func pdataSeverityText(t *testing.T, record []byte) string {
+	t.Helper()
+	_, text := pdataSeverity(t, record)
+	return text
+}
+
+func pdataSeverity(t *testing.T, record []byte) (int32, string) {
 	t.Helper()
 	logs, err := (&plog.ProtoUnmarshaler{}).UnmarshalLogs(exportLogsWithRecord(record))
 	require.NoError(t, err)
-	return logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).SeverityText()
+	logRecord := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	return int32(logRecord.SeverityNumber()), logRecord.SeverityText()
 }
 
 func TestLogTraversalAndResourceAttributes(t *testing.T) {

--- a/logs.go
+++ b/logs.go
@@ -112,7 +112,8 @@ func (s ScopeLogs) LogRecordsSeq(yield func(LogRecord, error) bool) {
 // SeverityNumber returns the LogRecord severity_number enum (field 2).
 // It returns 0 when the field is absent. Values are represented as int32 so
 // that unexpected negative protobuf enum values remain distinguishable from
-// the positive OTLP severity ranges.
+// the positive OTLP severity ranges. Use Severity to read both severity fields
+// from one walk.
 func (r LogRecord) SeverityNumber() (int32, error) {
 	number, _, err := parseLogRecordSeverity([]byte(r))
 	return number, err
@@ -125,10 +126,22 @@ func (r LogRecord) SeverityNumber() (int32, error) {
 //
 // Validation matches SeverityNumber: both read the same schema-aware walk of
 // the whole LogRecord, so an early severity_text cannot conceal corruption
-// that follows it.
+// that follows it. Use Severity to read both severity fields from one walk.
 func (r LogRecord) SeverityText() ([]byte, error) {
 	_, text, err := parseLogRecordSeverity([]byte(r))
 	return text, err
+}
+
+// Severity returns severity_number (field 2) and severity_text (field 3) from
+// one walk of the record. SeverityNumber and SeverityText each run that walk
+// once, so a consumer reading both fields separately pays for two.
+//
+// Each value carries the contract its single-field accessor documents.
+//
+// These are the raw wire fields. Classifying them into severity bands, and
+// deciding which one wins when they disagree, stay consumer policy.
+func (r LogRecord) Severity() (int32, []byte, error) {
+	return parseLogRecordSeverity([]byte(r))
 }
 
 // countLogRecords counts the number of log records in an OTLP

--- a/operations.md
+++ b/operations.md
@@ -48,19 +48,27 @@ note under "Telemetry inventory" below.
 
 ### Diagnosing the LogRecord severity accessors
 
-`SeverityNumber` and `SeverityText` share one schema-aware walk of the whole
-LogRecord, so they can never disagree about whether a record is valid. Two
-consequences when reading a consumer's CPU profile:
+`SeverityNumber`, `SeverityText` and `Severity` share one schema-aware walk of
+the whole LogRecord, so they can never disagree about whether a record is
+valid. Two consequences when reading a consumer's CPU profile:
 
-- **Each call walks the record once.** A consumer reading both fields pays two
-  walks. A severity path showing roughly double the expected parse cost is
-  usually this, not a regression.
+- **Each call walks the record once.** A severity path showing roughly double
+  the expected parse cost is usually a consumer calling `SeverityNumber` and
+  `SeverityText` on the same record, not a regression — that pair costs a
+  measured ~1.9x what `Severity` costs, which returns both from one walk.
+  Confirm it
+  from the call site rather than the profile shape: both arrangements attribute
+  their time to the same function, so only the call count separates them. A
+  consumer that guards its `severity_text` read behind the number pays the same
+  either way once it uses `Severity`, so a sparse-missing-severity shape and an
+  every-record shape converge on the same cost.
 - **The walk descends into the body and every attribute.** Cost tracks record
   contents, not just field count, unlike the shallow field-scan accessors. A
   consumer whose records carry large bodies or many attributes pays more per
   severity read than one whose records are bare, even at identical record
-  counts. [docs/BENCHMARKS.md](docs/BENCHMARKS.md) has the measured comparison
-  against a shallow hand-rolled walk.
+  counts. The published benchmarks all use one record shape, so they size the
+  per-record cost but do not show how it scales with body and attribute
+  volume; a consumer suspecting that scaling should measure its own payloads.
 
 **Known divergences from pdata.** These matter only to consumers that pair the
 wire path with a pdata fallback and expect the two to agree on validity. All


### PR DESCRIPTION
Closes E-2957. Discharges E-2954's final acceptance criterion.

## Motivation

`SeverityNumber` and `SeverityText` are both projections of one call to `parseLogRecordSeverity`, so a consumer reading both fields per record runs that whole schema-aware walk twice over identical bytes. E-2954 measured sage's real scan loop and found that migrating it to `SeverityText` would be a **+40% regression** — it recomputes a number the call site already had in hand.

`Severity()` returns the pair from one walk. It is strictly cheaper than sage's code today, not merely cheaper than the two-accessor migration: it deletes the second walk instead of upgrading it.

E-2940 admits a flattened convenience only when a measured hot path justifies it. This is that case, and the walk already produced both values, so no new parsing machinery was added.

## API

```go
func (r LogRecord) Severity() (int32, []byte, error)
```

Each value carries the contract its single-field accessor documents: `0` for an absent number, `nil` text for an absent `severity_text` against a non-nil zero-length slice for a present empty one, last-value-wins on repeated occurrences, and a text view aliasing the request buffer with its capacity clamped. Purely additive — no existing signature or behavior changes.

`Severity` returns the raw wire fields. Classifying them into bands, and deciding which wins when they disagree, remain consumer policy (`docs/DESIGN.md`).

## Evidence

**Correctness.** All three accessors are the same call, so no input can separate them. `TestLogRecordSeverity_MalformedParity` and `TestLogRecordSeverity_PdataDivergence` now assert that across all three; a new `TestLogRecordSeverity_MatchesPdataAndSingleAccessors` pins the combined result against both pdata and the single-field pair over every presence, repetition and empty-vs-absent shape. Additionally, an ad-hoc differential fuzz run (scratch, not committed) exercised **2.4M inputs** with zero disagreements on validity, value, or nil-vs-empty.

**Performance.** 5 resources x 100 records, alternating single-arm invocations of one prebuilt binary over 15 rounds (i7-11800H, linux/amd64, Go 1.25.12, `-benchmem -test.benchtime=3000x`). `go test -count=N` is not used — it runs a benchmark's iterations consecutively rather than interleaving arms.

| Benchmark | fields / walks | ns/op (median of 15) | B/op | allocs/op |
|---|---|---:|---:|---:|
| `BenchmarkLogRecord_SeverityText` | one / one | 89,783 | 368 | 14 |
| `BenchmarkLogRecord_SeverityNumberAndText` | two / two | 170,990 | 368 | 14 |
| `BenchmarkLogRecord_Severity` | two / one | 89,669 | 368 | 14 |

Median saving **48% against the pair, cheaper in 15 of 15 rounds**; the pair costs ~1.9x. The combined arm is indistinguishable from the single-field read (median +1.1%, slower in only 9 of 15 rounds — the sign does not hold), which is the property claimed: both fields, one walk. Allocations are unchanged and are all iterator openings, not the severity read.

**Validation.** `go test -v -race ./...`, `go vet ./...`, `gofmt -l .`, `git diff --check` — all clean. Per E-2940, `go mod tidy -diff` is deliberately not a gate here.

## A test that was not testing anything

`TestLogRecordSeverity_ViewAndAllocationContract` (inherited from E-2944) built its fixture with pdata. pdata marshals fields in **descending** order, so `severity_text` lands last in the record and `protowire`'s returned capacity already stops at the record boundary — the capacity assertion passed with the clamp in `logs.go` deleted. Verified by mutation: removing `text = value[:len(value):len(value)]` kept the whole suite green.

The test now builds the record by hand with `event_name` (field 12) after `severity_text`, asserts the clamp on both accessors, and asserts that appending into the returned view leaves the following field intact. With the clamp removed it now fails (`cap 28 != len 4`). This is the mirror of the fixture trap `docs/BENCHMARKS.md` already records for `trace_id`.

## Scope note

Removing `logRecordSeverityTextHandRolled`, `BenchmarkLogRecord_SeverityText_HandRolled` and the "Against sage's hand-rolled walk" subsection is explicitly in E-2957's scope, not bundled cleanup. The old comment gated removal on "once sage moves to `SeverityText`" — sage is instead moving to `Severity`, which supersedes that path, and E-2954 also showed the subsection's headline allocation advantage was illusory: the 500 allocations were the `string(text)` conversion at sage's call site, not the walk.

## Risks

- **API compatibility:** none — additive method.
- **Behavior:** none for existing accessors; `parseLogRecordSeverity` is untouched.
- **Documentation:** `LogRecord.SeverityText` loses its godoc example, since `ExampleLogRecord_SeverityText` was renamed to `ExampleLogRecord_Severity` and now demonstrates the recommended path. Deliberate; the method's own doc comment cross-references `Severity`.
- **Rollout:** **no release is being cut.** sage consumes this as a pseudo-version off `main`; a tag follows only once that migration proves out. `SeverityText` (E-2944) is itself still unreleased — v0.1.0 predates it.

## Agent involvement

Implemented with Claude Code (Opus 5). The diff was put through the repo's quality review and an adversarial review pass before this PR; the inverted "44% more" figure in README/DESIGN.md, an 11-round measurement where the doc's own rule requires 15+, a dangling BENCHMARKS.md cross-reference in `operations.md`, and the vacuous clamp assertion above were all found and fixed as a result. A human maintainer is reviewing and takes ownership of the result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a combined severity accessor that returns severity number and text in one call.
  * Preserved existing individual severity accessors and their behavior.

* **Documentation**
  * Updated API guidance, examples, design notes, and specifications for combined severity access.
  * Documented performance differences, including the measured benefit of combined reads.

* **Tests**
  * Expanded coverage for combined severity results, malformed data, repeated fields, and allocation behavior.
  * Updated benchmarks to compare individual and combined accessors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->