### PR TITLE
docs: refresh release history, record the field-1000 deviation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,8 @@ code is split by domain: public types in `types.go`, signal traversal in
 `attributes.go`, signal-generic instrumentation-scope accessors in `scope.go`,
 and low-level protobuf walking in `wire.go`. Functional tests are in
 `otlpwire_test.go`, `log_iteration_test.go`, `resource_test.go`,
-`scope_test.go`, and `metric_metadata_test.go`, usage examples in
-`example_test.go`, and comparative benchmarks in
+`scope_test.go`, `metric_metadata_test.go`, and `span_fields_test.go`, usage
+examples in `example_test.go`, and comparative benchmarks in
 `benchmark_comparison_test.go`.
 
 Public wire types are byte slices or small wrappers over byte slices. They

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -499,6 +499,9 @@ Past feature rollouts established the following sequence:
 | v0.0.3 | Metrics-depth traversal and zero-allocation variants (E-2608, PR #18) | Release the primitive first, then migrate metrics consumers such as Marigold with parity and production evidence |
 | v0.0.4 | Log traversal, severity and resource strings (E-2892, PR #22) | Release the primitive first, then use separate Bindweed, Mulch and Sage adoption issues (E-2900, E-2905, E-2906) |
 | v0.1.0 (released 2026-08-07) | Typed, absence-tolerant, merged `Resource()`; removes `ResourceLogs.StringAttribute` (E-2941) | Breaking: `Resource()` now returns `(Resource, error)` (direct calls stay compatible since `Resource` assigns to `[]byte`, but interfaces and method values typed on the old signature must be updated) and no longer errors on an absent Resource field; `rl.StringAttribute(k)` callers migrate to `rl.Resource()` then `res.StringAttribute(k)`. Release the primitive, then coordinate consumer releases per the acceptance gates below before broad upgrades |
+| v0.2.0 (released 2026-08-08) | `InstrumentationScope` and `SchemaUrl` on every container (E-2942); `Metric.Metadata` and `MetadataSeq` (E-2943); `LogRecord.SeverityText` (E-2944) | Breaking: `Scope()` replaces per-container scope handling and the singular-scalar accessors report corruption located after the last relevant occurrence. Marigold adopts `Metric.Metadata` per E-2952 |
+| v0.2.1 (released 2026-08-08) | `Span` name, kind and start/end timestamps (E-2945) | Additive. Overstory adopts the accessors per E-2964, which also retires the hand-rolled comparison arm |
+| v0.2.2 (released 2026-08-09) | `LogRecord.Severity`, both severity fields from one walk (E-2957) | Additive. Sage adopted it in E-2954 and measured −33% CPU and −94.7% allocations on text-only payloads |
 
 Future capabilities and refactors should follow the same staged model:
 

--- a/operations.md
+++ b/operations.md
@@ -145,6 +145,38 @@ and attributes. [docs/DESIGN.md](docs/DESIGN.md) records both decisions. A
 consumer cannot conclude "pdata would also accept this" from a successful Span
 accessor read.
 
+### The deprecated scope containers (field 1000)
+
+`ResourceLogs`, `ResourceSpans` and `ResourceMetrics` each carry a field 1000
+holding the pre-rename scope container — `deprecated_scope_logs` and its
+siblings, from the OTLP `InstrumentationLibrary` → `Scope` transition. The
+traversal treats it as an unknown field: framing is checked, contents are not,
+and the records inside are **not** traversed.
+
+That is a deliberate deviation from pdata, taken on the reasoning below. It is
+recorded here rather than fixed, so a consumer investigating a count that looks
+low can rule it in or out quickly.
+
+| Input | Wire path | pdata |
+| --- | --- | --- |
+| Wrong wire type on field 1000 | accepts | rejects (`wrong wireType ... for field DeprecatedScopeLogs`) |
+| Well-formed records in field 1000, none in field 2 | counts zero, no error | `plog.ProtoUnmarshaler` also counts zero; `plogotlp.ExportRequest` and the gRPC server path migrate them and count them |
+
+The second row is the one that could bite, and it depends on which pdata door a
+consumer uses. `otlp.MigrateLogs` promotes field 1000 into `ScopeLogs` when
+`ScopeLogs` is empty, but it is called only from `plogotlp/grpc.go`,
+`plogotlp/request.go` and `plog/json.go` — **not** from `plog.ProtoUnmarshaler`,
+despite that function's own comment requiring every unmarshaler to call it. The
+downstream consumers use `ProtoUnmarshaler`, so they and the wire path agree.
+Raincatcher, at the ingest edge, uses the migrating API; whether a field-1000
+payload can reach downstream at all therefore depends on whether raincatcher
+re-marshals after pdata migrates it, which has not been established.
+
+No producer has emitted field 1000 in years, which is why this is accepted
+rather than closed. If a consumer ever reports logs, spans or metrics counted as
+zero on a payload another tool reads as non-empty, check for field 1000 before
+anything else. E-2976 holds the full measurements.
+
 ## Telemetry inventory
 
 The library emits no telemetry. Importing services own throughput, error,

--- a/operations.md
+++ b/operations.md
@@ -153,7 +153,7 @@ siblings, from the OTLP `InstrumentationLibrary` → `Scope` transition. The
 traversal treats it as an unknown field: framing is checked, contents are not,
 and the records inside are **not** traversed.
 
-That is a deliberate deviation from pdata, taken on the reasoning below. It is
+That is a deliberate deviation from pdata, made for the reasons below. It is
 recorded here rather than fixed, so a consumer investigating a count that looks
 low can rule it in or out quickly.
 


### PR DESCRIPTION
Documentation only. No code, no public API change, no benchmark claim altered.

Three things had drifted behind the code.

## 1. `docs/specification.md` — release table was three releases stale

It stopped at v0.1.0. Added rows for v0.2.0 (E-2942/E-2943/E-2944, breaking `Scope()`), v0.2.1 (E-2945, additive) and v0.2.2 (E-2957, additive), each with the consumer rollout pattern the table's other rows carry. Verified against the tags: v0.2.0 → `7a777b5`, v0.2.1 → `761c095`, v0.2.2 → `5b422f3`.

## 2. `operations.md` — the field-1000 deviation was undocumented

`ResourceLogs`, `ResourceSpans` and `ResourceMetrics` each carry a field 1000 holding the pre-rename scope container, from the OTLP `InstrumentationLibrary` → `Scope` transition. The traversal treats it as unknown: framing checked, contents not, records inside not traversed.

That deviates from pdata, and the deviation is deliberate — E-2976 was cancelled after measuring it. What was missing is the operational consequence, which is now a subsection with the measured behavior:

| Input | Wire path | pdata |
|---|---|---|
| Wrong wire type on field 1000 | accepts | rejects |
| Well-formed records in field 1000, none in field 2 | counts zero, no error | `plog.ProtoUnmarshaler` also counts zero; `plogotlp.ExportRequest` and the gRPC server path migrate and count them |

The asymmetry in row two is real and worth knowing: `otlp.MigrateLogs` promotes field 1000 into `ScopeLogs`, but is called only from `plogotlp/grpc.go`, `plogotlp/request.go` and `plog/json.go` — **not** from `plog.ProtoUnmarshaler`, despite that function's own comment saying every unmarshaler must call it. Our downstream consumers use `ProtoUnmarshaler`, so they agree with the wire path.

The point of the entry is diagnostic: if a consumer ever reports a zero count on a payload another tool reads as non-empty, field 1000 is the first thing to check rather than the last.

It went in as its own subsection rather than a row in the "Known divergences from pdata" tables, since those are explicitly scoped to the LogRecord and Span walks and this is container-level.

## 3. `AGENTS.md` — missing test file

`span_fields_test.go` was absent from the functional-test list (since E-2945).

## Validation

`go test -count=1 ./...` green, `git diff --check` clean, relative links in the edited files resolve. `CLAUDE.md` is a symlink to `AGENTS.md`, so only `AGENTS.md` was edited — the file is shared, not duplicated.

## Agent involvement

Written with Claude Code (Opus 5); the field-1000 behavior in the new section was measured rather than inferred, and the measurements are recorded on E-2976. A human maintainer is reviewing and takes ownership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to include an additional functional test file.
  * Documented v0.2.0, v0.2.1, and v0.2.2 capabilities and compatibility details.
  * Added guidance for handling deprecated OTLP scope containers, including validation behavior, migration considerations, and diagnostic interpretation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->