### PR TITLE
feat: add allocation-free container iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ otlp-wire operates on wire format bytes:
 - 35-55x faster counting than unmarshaling (zero allocations)
 - 1,100-2,800x faster iteration than unmarshal+iterate (2 allocations)
 - 2,800-3,700x faster splitting than unmarshal+remarshal (2 allocations)
-- Minimal GC pressure (only 24 bytes per batch for error handling)
+- Zero-allocation sequence variants for hot container and per-element walks
 - Zero dependencies (only stdlib + protowire)
 
 See [BENCHMARKS.md](docs/BENCHMARKS.md) for detailed comparison.
@@ -157,14 +157,17 @@ InstrumentationScope (from any Scope())
 type ExportMetricsServiceRequest []byte
 func (m ExportMetricsServiceRequest) DataPointCount() (int, error)
 func (m ExportMetricsServiceRequest) ResourceMetrics() (iter.Seq[ResourceMetrics], func() error)
+func (m ExportMetricsServiceRequest) ResourceMetricsSeq(yield func(ResourceMetrics, error) bool)
 
 type ExportLogsServiceRequest []byte
 func (l ExportLogsServiceRequest) LogRecordCount() (int, error)
 func (l ExportLogsServiceRequest) ResourceLogs() (iter.Seq[ResourceLogs], func() error)
+func (l ExportLogsServiceRequest) ResourceLogsSeq(yield func(ResourceLogs, error) bool)
 
 type ExportTracesServiceRequest []byte
 func (t ExportTracesServiceRequest) SpanCount() (int, error)
 func (t ExportTracesServiceRequest) ResourceSpans() (iter.Seq[ResourceSpans], func() error)
+func (t ExportTracesServiceRequest) ResourceSpansSeq(yield func(ResourceSpans, error) bool)
 ```
 
 **Resource-level operations:**
@@ -174,6 +177,8 @@ func (r ResourceMetrics) DataPointCount() (int, error)
 func (r ResourceMetrics) Resource() (Resource, error)
 func (r ResourceMetrics) SchemaUrl() ([]byte, error)
 func (r ResourceMetrics) WriteTo(w io.Writer) (int64, error)
+func (r ResourceMetrics) ScopeMetrics() (iter.Seq[ScopeMetrics], func() error)
+func (r ResourceMetrics) ScopeMetricsSeq(yield func(ScopeMetrics, error) bool)
 
 type ResourceLogs []byte
 func (r ResourceLogs) LogRecordCount() (int, error)
@@ -181,6 +186,7 @@ func (r ResourceLogs) Resource() (Resource, error)
 func (r ResourceLogs) SchemaUrl() ([]byte, error)
 func (r ResourceLogs) WriteTo(w io.Writer) (int64, error)
 func (r ResourceLogs) ScopeLogs() (iter.Seq[ScopeLogs], func() error)
+func (r ResourceLogs) ScopeLogsSeq(yield func(ScopeLogs, error) bool)
 
 type ResourceSpans []byte
 func (r ResourceSpans) SpanCount() (int, error)
@@ -188,6 +194,7 @@ func (r ResourceSpans) Resource() (Resource, error)
 func (r ResourceSpans) SchemaUrl() ([]byte, error)
 func (r ResourceSpans) WriteTo(w io.Writer) (int64, error)
 func (r ResourceSpans) ScopeSpans() (iter.Seq[ScopeSpans], func() error)
+func (r ResourceSpans) ScopeSpansSeq(yield func(ScopeSpans, error) bool)
 ```
 
 **Instrumentation scope (all three signals):**

--- a/container_seq_test.go
+++ b/container_seq_test.go
@@ -1,0 +1,289 @@
+package otlpwire
+
+import (
+	"iter"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+func TestContainerSeq_AdapterParity(t *testing.T) {
+	first := []byte{0x08, 0x01}
+	second := []byte{0x08, 0x02}
+	valid := appendRepeatedMessages(nil, 1, first, second)
+	malformed := append(append([]byte(nil), valid...), 0x80)
+
+	t.Run("logs resources", func(t *testing.T) {
+		assertSeqParity(t, ExportLogsServiceRequest(malformed).ResourceLogs,
+			ExportLogsServiceRequest(malformed).ResourceLogsSeq, first, second)
+	})
+	t.Run("logs scopes", func(t *testing.T) {
+		container := appendRepeatedMessages(nil, 2, first, second)
+		container = append(container, 0x80)
+		assertSeqParity(t, ResourceLogs(container).ScopeLogs,
+			ResourceLogs(container).ScopeLogsSeq, first, second)
+	})
+	t.Run("metrics resources", func(t *testing.T) {
+		assertSeqParity(t, ExportMetricsServiceRequest(malformed).ResourceMetrics,
+			ExportMetricsServiceRequest(malformed).ResourceMetricsSeq, first, second)
+	})
+	t.Run("metrics scopes", func(t *testing.T) {
+		container := appendRepeatedMessages(nil, 2, first, second)
+		container = append(container, 0x80)
+		assertSeqParity(t, ResourceMetrics(container).ScopeMetrics,
+			ResourceMetrics(container).ScopeMetricsSeq, first, second)
+	})
+	t.Run("traces resources", func(t *testing.T) {
+		assertSeqParity(t, ExportTracesServiceRequest(malformed).ResourceSpans,
+			ExportTracesServiceRequest(malformed).ResourceSpansSeq, first, second)
+	})
+	t.Run("traces scopes", func(t *testing.T) {
+		container := appendRepeatedMessages(nil, 2, first, second)
+		container = append(container, 0x80)
+		assertSeqParity(t, ResourceSpans(container).ScopeSpans,
+			ResourceSpans(container).ScopeSpansSeq, first, second)
+	})
+}
+
+func TestContainerSeq_EarlyStopLeavesLaterCorruptionUnvisited(t *testing.T) {
+	first := []byte{0x08, 0x01}
+	payload := appendRepeatedMessages(nil, 1, first)
+	payload = append(payload, 0x80)
+
+	yields := 0
+	for resource, err := range ExportLogsServiceRequest(payload).ResourceLogsSeq {
+		require.NoError(t, err)
+		require.Equal(t, ResourceLogs(first), resource)
+		yields++
+		break
+	}
+	require.Equal(t, 1, yields)
+
+	resource := appendRepeatedMessages(nil, 2, first)
+	resource = append(resource, 0x80)
+	yields = 0
+	for scope, err := range ResourceLogs(resource).ScopeLogsSeq {
+		require.NoError(t, err)
+		require.Equal(t, ScopeLogs(first), scope)
+		yields++
+		break
+	}
+	require.Equal(t, 1, yields)
+}
+
+func TestContainerSeq_MalformedWire(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+	}{
+		{name: "selected field has wrong wire type", payload: protowire.AppendTag(nil, 1, protowire.VarintType)},
+		{name: "selected field has truncated length", payload: append(protowire.AppendTag(nil, 1, protowire.BytesType), 0x02, 0x01)},
+		{name: "unknown group is malformed", payload: protowire.AppendTag(nil, 7, protowire.StartGroupType)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yields := 0
+			for value, err := range ExportLogsServiceRequest(tt.payload).ResourceLogsSeq {
+				require.Nil(t, value)
+				require.Error(t, err)
+				yields++
+			}
+			require.Equal(t, 1, yields)
+		})
+	}
+}
+
+func TestContainerSeq_UnknownGroupAndCapacityClamp(t *testing.T) {
+	unknown := protowire.AppendTag(nil, 7, protowire.StartGroupType)
+	unknown = protowire.AppendTag(unknown, 8, protowire.VarintType)
+	unknown = protowire.AppendVarint(unknown, 1)
+	unknown = protowire.AppendTag(unknown, 7, protowire.EndGroupType)
+
+	first := []byte{0x08, 0x01}
+	second := []byte{0x08, 0x02}
+	payload := append(unknown, appendRepeatedMessages(nil, 1, first, second)...)
+
+	var values []ResourceLogs
+	for resource, err := range ExportLogsServiceRequest(payload).ResourceLogsSeq {
+		require.NoError(t, err)
+		require.Equal(t, len(resource), cap(resource))
+		values = append(values, resource)
+	}
+	require.Len(t, values, 2)
+
+	firstBefore := append([]byte(nil), values[0]...)
+	_ = append(values[0], 0xff)
+	require.Equal(t, firstBefore, []byte(values[0]))
+	require.Equal(t, second, []byte(values[1]))
+}
+
+func TestContainerSeq_ZeroAllocations(t *testing.T) {
+	resource := appendRepeatedMessages(nil, 2, []byte{0x08, 0x01})
+	payload := appendRepeatedMessages(nil, 1, resource)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		for resource, err := range ExportLogsServiceRequest(payload).ResourceLogsSeq {
+			if err != nil {
+				panic(err)
+			}
+			for _, err := range resource.ScopeLogsSeq {
+				if err != nil {
+					panic(err)
+				}
+			}
+		}
+	})
+	require.Zero(t, allocs)
+
+	allocs = testing.AllocsPerRun(1000, func() {
+		for resource, err := range ExportMetricsServiceRequest(payload).ResourceMetricsSeq {
+			if err != nil {
+				panic(err)
+			}
+			for _, err := range resource.ScopeMetricsSeq {
+				if err != nil {
+					panic(err)
+				}
+			}
+		}
+	})
+	require.Zero(t, allocs)
+
+	allocs = testing.AllocsPerRun(1000, func() {
+		for resource, err := range ExportTracesServiceRequest(payload).ResourceSpansSeq {
+			if err != nil {
+				panic(err)
+			}
+			for _, err := range resource.ScopeSpansSeq {
+				if err != nil {
+					panic(err)
+				}
+			}
+		}
+	})
+	require.Zero(t, allocs)
+}
+
+var containerSeqBenchmarkSink int
+
+func BenchmarkContainerSeq(b *testing.B) {
+	for _, shape := range []struct {
+		name              string
+		resources, scopes int
+		records           int
+	}{
+		{name: "record-heavy", resources: 5, scopes: 2, records: 100},
+		{name: "resource-heavy", resources: 20, scopes: 1, records: 5},
+	} {
+		payload := containerSeqBenchmarkPayload(shape.resources, shape.scopes, shape.records)
+
+		b.Run(shape.name+"/Ordinary", func(b *testing.B) {
+			for b.Loop() {
+				total := 0
+				resources, resourcesErr := ExportLogsServiceRequest(payload).ResourceLogs()
+				for resource := range resources {
+					scopes, scopesErr := resource.ScopeLogs()
+					for scope := range scopes {
+						for _, err := range scope.LogRecordsSeq {
+							if err != nil {
+								b.Fatal(err)
+							}
+							total++
+						}
+					}
+					if err := scopesErr(); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := resourcesErr(); err != nil {
+					b.Fatal(err)
+				}
+				containerSeqBenchmarkSink = total
+			}
+		})
+
+		b.Run(shape.name+"/Seq", func(b *testing.B) {
+			for b.Loop() {
+				total := 0
+				for resource, err := range ExportLogsServiceRequest(payload).ResourceLogsSeq {
+					if err != nil {
+						b.Fatal(err)
+					}
+					for scope, err := range resource.ScopeLogsSeq {
+						if err != nil {
+							b.Fatal(err)
+						}
+						for _, err := range scope.LogRecordsSeq {
+							if err != nil {
+								b.Fatal(err)
+							}
+							total++
+						}
+					}
+				}
+				containerSeqBenchmarkSink = total
+			}
+		})
+	}
+}
+
+func containerSeqBenchmarkPayload(resources, scopes, records int) []byte {
+	record := []byte{0x08, 0x01}
+	scope := make([]byte, 0, records*len(record))
+	for range records {
+		scope = appendRepeatedMessages(scope, 2, record)
+	}
+	resource := make([]byte, 0, scopes*len(scope))
+	for range scopes {
+		resource = appendRepeatedMessages(resource, 2, scope)
+	}
+	payload := make([]byte, 0, resources*len(resource))
+	for range resources {
+		payload = appendRepeatedMessages(payload, 1, resource)
+	}
+	return payload
+}
+
+func assertSeqParity[T ~[]byte](
+	t *testing.T,
+	adapter func() (iter.Seq[T], func() error),
+	seq func(func(T, error) bool),
+	want ...[]byte,
+) {
+	t.Helper()
+
+	ordinary, ordinaryErr := adapter()
+	var ordinaryValues [][]byte
+	for value := range ordinary {
+		ordinaryValues = append(ordinaryValues, append([]byte(nil), value...))
+	}
+	adapterErr := ordinaryErr()
+	require.Error(t, adapterErr)
+
+	var seqValues [][]byte
+	var seqErr error
+	errYields := 0
+	for value, err := range seq {
+		if err != nil {
+			seqErr = err
+			errYields++
+			continue
+		}
+		seqValues = append(seqValues, append([]byte(nil), value...))
+	}
+	require.Error(t, seqErr)
+	require.Equal(t, 1, errYields)
+	require.Equal(t, adapterErr.Error(), seqErr.Error())
+	require.Equal(t, want, ordinaryValues)
+	require.Equal(t, ordinaryValues, seqValues)
+}
+
+func appendRepeatedMessages(dst []byte, field protowire.Number, messages ...[]byte) []byte {
+	for _, message := range messages {
+		dst = protowire.AppendTag(dst, field, protowire.BytesType)
+		dst = protowire.AppendBytes(dst, message)
+	}
+	return dst
+}

--- a/container_seq_test.go
+++ b/container_seq_test.go
@@ -51,25 +51,15 @@ func TestContainerSeq_EarlyStopLeavesLaterCorruptionUnvisited(t *testing.T) {
 	payload := appendRepeatedMessages(nil, 1, first)
 	payload = append(payload, 0x80)
 
-	yields := 0
-	for resource, err := range ExportLogsServiceRequest(payload).ResourceLogsSeq {
-		require.NoError(t, err)
-		require.Equal(t, ResourceLogs(first), resource)
-		yields++
-		break
-	}
-	require.Equal(t, 1, yields)
+	assertSeqEarlyStop(t, ExportLogsServiceRequest(payload).ResourceLogsSeq, ResourceLogs(first))
+	assertSeqEarlyStop(t, ExportMetricsServiceRequest(payload).ResourceMetricsSeq, ResourceMetrics(first))
+	assertSeqEarlyStop(t, ExportTracesServiceRequest(payload).ResourceSpansSeq, ResourceSpans(first))
 
 	resource := appendRepeatedMessages(nil, 2, first)
 	resource = append(resource, 0x80)
-	yields = 0
-	for scope, err := range ResourceLogs(resource).ScopeLogsSeq {
-		require.NoError(t, err)
-		require.Equal(t, ScopeLogs(first), scope)
-		yields++
-		break
-	}
-	require.Equal(t, 1, yields)
+	assertSeqEarlyStop(t, ResourceLogs(resource).ScopeLogsSeq, ScopeLogs(first))
+	assertSeqEarlyStop(t, ResourceMetrics(resource).ScopeMetricsSeq, ScopeMetrics(first))
+	assertSeqEarlyStop(t, ResourceSpans(resource).ScopeSpansSeq, ScopeSpans(first))
 }
 
 func TestContainerSeq_MalformedWire(t *testing.T) {
@@ -84,13 +74,14 @@ func TestContainerSeq_MalformedWire(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			yields := 0
-			for value, err := range ExportLogsServiceRequest(tt.payload).ResourceLogsSeq {
-				require.Nil(t, value)
-				require.Error(t, err)
-				yields++
-			}
-			require.Equal(t, 1, yields)
+			assertSeqError(t, ExportLogsServiceRequest(tt.payload).ResourceLogsSeq)
+			assertSeqError(t, ExportMetricsServiceRequest(tt.payload).ResourceMetricsSeq)
+			assertSeqError(t, ExportTracesServiceRequest(tt.payload).ResourceSpansSeq)
+
+			scopePayload := remapField(tt.payload, 1, 2)
+			assertSeqError(t, ResourceLogs(scopePayload).ScopeLogsSeq)
+			assertSeqError(t, ResourceMetrics(scopePayload).ScopeMetricsSeq)
+			assertSeqError(t, ResourceSpans(scopePayload).ScopeSpansSeq)
 		})
 	}
 }
@@ -278,6 +269,41 @@ func assertSeqParity[T ~[]byte](
 	require.Equal(t, adapterErr.Error(), seqErr.Error())
 	require.Equal(t, want, ordinaryValues)
 	require.Equal(t, ordinaryValues, seqValues)
+}
+
+func assertSeqEarlyStop[T ~[]byte](t *testing.T, seq func(func(T, error) bool), want T) {
+	t.Helper()
+	yields := 0
+	for value, err := range seq {
+		require.NoError(t, err)
+		require.Equal(t, want, value)
+		yields++
+		break
+	}
+	require.Equal(t, 1, yields)
+}
+
+func assertSeqError[T ~[]byte](t *testing.T, seq func(func(T, error) bool)) {
+	t.Helper()
+	yields := 0
+	for value, err := range seq {
+		require.Nil(t, value)
+		require.Error(t, err)
+		yields++
+	}
+	require.Equal(t, 1, yields)
+}
+
+func remapField(payload []byte, from, to protowire.Number) []byte {
+	if len(payload) == 0 {
+		return nil
+	}
+	num, typ, n := protowire.ConsumeTag(payload)
+	if n < 0 || num != from {
+		return append([]byte(nil), payload...)
+	}
+	result := protowire.AppendTag(nil, to, typ)
+	return append(result, payload[n:]...)
 }
 
 func appendRepeatedMessages(dst []byte, field protowire.Number, messages ...[]byte) []byte {

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -517,6 +517,38 @@ point in a batch, such as scrape-shaped or high-cardinality workloads.
 
 ---
 
+## Allocation-free container iteration (E-3008)
+
+`BenchmarkContainerSeq` walks every resource, scope and log record using either
+the ordinary closure/error-function adapters or the `ResourceLogsSeq` and
+`ScopeLogsSeq` method values. The two fixtures isolate different production
+shapes: record-heavy is 5 resources × 2 scopes × 100 records; resource-heavy
+is 20 resources × 1 scope × 5 records. Both arms use `LogRecordsSeq` at the
+record level, so the difference is only the two container levels.
+
+**Environment-specific result:** 11th Gen Intel Core i7-11800H, linux/amd64,
+Go 1.25.12:
+
+```bash
+go test -run 'TestContainerSeq' -bench '^BenchmarkContainerSeq$' -benchmem -count=1
+```
+
+Time varied with machine load and is not claimed here. Allocation counts are
+toolchain-specific; zero allocations on the supported toolchain is the gate.
+
+| Shape | Iterator | B/op | allocs/op |
+|---|---|---:|---:|
+| record-heavy | ordinary | 424 | 15 |
+| record-heavy | sequence | 0 | 0 |
+| resource-heavy | ordinary | 1,264 | 45 |
+| resource-heavy | sequence | 0 | 0 |
+
+The sequence form removes every container-iterator allocation in both shapes.
+The ordinary API remains available as an adapter with unchanged wire order,
+lazy error timing and early-stop behavior. Metrics and traces expose the same
+sequence forms because their resource/scope container layout and escape
+behavior are identical; `TestContainerSeq_ZeroAllocations` pins all three.
+
 ## Log severity classification (E-2892)
 
 This benchmark models an insight consumer that reads resource context through

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -89,15 +89,23 @@ the range syntax simple; the error closure captures a parse error discovered
 during lazy traversal. It must be checked after the range.
 
 This form costs two small allocations when opened because its closures escape.
-At outer levels that cost is paid once per request, resource or scope and is
-small compared with materializing a pdata object graph.
+At outer levels that cost is paid once per request, resource or scope. It is
+small compared with materializing a pdata object graph, but a container-heavy
+consumer can still make it a material share of its allocation rate.
 
 ### Hot-path form
 
-Opening an ordinary iterator once per metric or log record would multiply the
-closure cost by thousands of elements. The deepest hot paths therefore expose
-yield methods shaped like `iter.Seq2[T, error]`:
+Opening an ordinary iterator once per metric or log record multiplies the
+closure cost by thousands of elements. Container-heavy consumers also capture
+state in an outer iterator's loop body, forcing that state to the heap. Hot
+paths therefore expose yield methods shaped like `iter.Seq2[T, error]`:
 
+- `ExportMetricsServiceRequest.ResourceMetricsSeq` and
+  `ResourceMetrics.ScopeMetricsSeq`;
+- `ExportLogsServiceRequest.ResourceLogsSeq` and
+  `ResourceLogs.ScopeLogsSeq`;
+- `ExportTracesServiceRequest.ResourceSpansSeq` and
+  `ResourceSpans.ScopeSpansSeq`;
 - `Metric.DataPointsSeq`;
 - `Metric.MetadataSeq`;
 - `DataPoint.AttributesSeq`;
@@ -105,9 +113,9 @@ yield methods shaped like `iter.Seq2[T, error]`:
 - `ScopeLogs.LogRecordsSeq`.
 
 These yield errors inline and keep the per-element walk on the stack. The
-ordinary methods provide the same external traversal semantics;
-`Metric.DataPoints` and `ScopeLogs.LogRecords` are adapters over their hot
-forms.
+ordinary methods provide the same external traversal semantics and are
+adapters over their hot forms. The container variants cover all three signals
+deliberately: their protobuf shape and compiler escape behavior are identical.
 
 Both forms stop on consumer cancellation or the first parse error. Because
 iteration is lazy, an early stop intentionally leaves later bytes unvisited.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -149,10 +149,12 @@ The error function must be checked after iteration, including after an early
 exit. Iteration is lazy: breaking early stops parsing, so corruption later in
 the unvisited input cannot be reported.
 
-Hot per-element paths additionally expose yield-based methods such as
+Hot per-element and per-container paths additionally expose yield-based
+methods: the `Resource*Seq` and `Scope*Seq` container iterators, plus
 `DataPointsSeq`, `MetadataSeq`, `AttributesSeq`, and `LogRecordsSeq`. They
 yield `(value, error)` inline, stop after the first error, and avoid the
-escaping closures of the ordinary form. Both forms preserve wire order.
+escaping closures of the ordinary form. Both forms preserve wire order; the
+ordinary container iterators are adapters over their yield-based counterparts.
 
 Changing the ordinary `(iter.Seq[T], func() error)` shape or the inline-error
 shape of the hot variants is a breaking API change.
@@ -446,9 +448,10 @@ is part of this library's purpose and compatibility surface.
 
 - Counting valid requests is zero-allocation.
 - Ordinary iterator opens have the documented small closure cost.
-- `DataPointsSeq`, `MetadataSeq`, `AttributesSeq` (on both `Resource` and
-  `InstrumentationScope`), and `LogRecordsSeq` remain zero-allocation on their
-  per-element paths.
+- `ResourceMetricsSeq`, `ScopeMetricsSeq`, `ResourceLogsSeq`, `ScopeLogsSeq`,
+  `ResourceSpansSeq`, `ScopeSpansSeq`, `DataPointsSeq`, `MetadataSeq`,
+  `AttributesSeq` (on both `Resource` and `InstrumentationScope`), and
+  `LogRecordsSeq` remain zero-allocation on their per-element paths.
 - Accessors return aliased slices rather than copying payload data, with one
   documented exception: `Resource()` and `Scope()` alias the input when a
   container holds a single occurrence of that field (the case every real

--- a/example_test.go
+++ b/example_test.go
@@ -294,34 +294,20 @@ func ExampleLogRecord_Severity() {
 }
 
 func printLogSeverities(data []byte) error {
-	resources, resourcesErr := otlpwire.ExportLogsServiceRequest(data).ResourceLogs()
-	var failure error
-	for resourceLogs := range resources {
-		if failure = printResourceLogSeverities(resourceLogs); failure != nil {
-			break
+	for resourceLogs, err := range otlpwire.ExportLogsServiceRequest(data).ResourceLogsSeq {
+		if err != nil {
+			return err
+		}
+		for scope, err := range resourceLogs.ScopeLogsSeq {
+			if err != nil {
+				return err
+			}
+			if err := printScopeLogSeverities(scope); err != nil {
+				return err
+			}
 		}
 	}
-	// The error closure must be checked even when the loop exited early,
-	// so the split into one function per level is the point of this shape,
-	// not incidental.
-	if err := resourcesErr(); err != nil {
-		return err
-	}
-	return failure
-}
-
-func printResourceLogSeverities(resourceLogs otlpwire.ResourceLogs) error {
-	scopes, scopesErr := resourceLogs.ScopeLogs()
-	var failure error
-	for scope := range scopes {
-		if failure = printScopeLogSeverities(scope); failure != nil {
-			break
-		}
-	}
-	if err := scopesErr(); err != nil {
-		return err
-	}
-	return failure
+	return nil
 }
 
 // printScopeLogSeverities needs no closure check: LogRecordsSeq yields its

--- a/logs.go
+++ b/logs.go
@@ -13,10 +13,29 @@ func (l ExportLogsServiceRequest) LogRecordCount() (int, error) {
 	return countLogRecords([]byte(l))
 }
 
-// ResourceLogs returns an iterator over ResourceLogs in the batch.
-// The returned function should be called after iteration to check for errors.
+// ResourceLogs returns an iterator over ResourceLogs in the batch. The
+// returned function should be called after iteration to check for errors.
+// ResourceLogs is a thin adapter over ResourceLogsSeq.
 func (l ExportLogsServiceRequest) ResourceLogs() (iter.Seq[ResourceLogs], func() error) {
-	return repeatedFieldSeq[ResourceLogs]([]byte(l), 1)
+	var iterErr error
+	seq := func(yield func(ResourceLogs) bool) {
+		l.ResourceLogsSeq(func(resource ResourceLogs, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(resource)
+		})
+	}
+	return seq, func() error { return iterErr }
+}
+
+// ResourceLogsSeq is the zero-allocation alternative to ResourceLogs. It is
+// shaped like iter.Seq2[ResourceLogs, error] and meant to be ranged over
+// directly. On a parse error it yields a nil ResourceLogs with a non-nil error
+// and stops.
+func (l ExportLogsServiceRequest) ResourceLogsSeq(yield func(ResourceLogs, error) bool) {
+	repeatedFieldSeq2([]byte(l), 1, yield)
 }
 
 // LogRecordCount returns the number of log records in this resource.
@@ -52,8 +71,26 @@ func (r ResourceLogs) WriteTo(w io.Writer) (int64, error) {
 // ScopeLogs returns an iterator over ScopeLogs in this ResourceLogs.
 // Field 2 in the ResourceLogs protobuf message.
 // The returned function should be called after iteration to check for errors.
+// ScopeLogs is a thin adapter over ScopeLogsSeq.
 func (r ResourceLogs) ScopeLogs() (iter.Seq[ScopeLogs], func() error) {
-	return repeatedFieldSeq[ScopeLogs]([]byte(r), 2)
+	var iterErr error
+	seq := func(yield func(ScopeLogs) bool) {
+		r.ScopeLogsSeq(func(scope ScopeLogs, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(scope)
+		})
+	}
+	return seq, func() error { return iterErr }
+}
+
+// ScopeLogsSeq is the zero-allocation alternative to ScopeLogs. It is shaped
+// like iter.Seq2[ScopeLogs, error] and meant to be ranged over directly. On a
+// parse error it yields a nil ScopeLogs with a non-nil error and stops.
+func (r ResourceLogs) ScopeLogsSeq(yield func(ScopeLogs, error) bool) {
+	repeatedFieldSeq2([]byte(r), 2, yield)
 }
 
 // Scope returns the InstrumentationScope for this ScopeLogs. It returns
@@ -100,13 +137,7 @@ func (s ScopeLogs) LogRecords() (iter.Seq[LogRecord], func() error) {
 // directly. On a parse error it yields a nil LogRecord with a non-nil error and
 // stops.
 func (s ScopeLogs) LogRecordsSeq(yield func(LogRecord, error) bool) {
-	forEachRepeatedField([]byte(s), 2, func(rb []byte, err error) bool {
-		if err != nil {
-			yield(nil, err)
-			return false
-		}
-		return yield(LogRecord(rb), nil)
-	})
+	repeatedFieldSeq2([]byte(s), 2, yield)
 }
 
 // SeverityNumber returns the LogRecord severity_number enum (field 2).

--- a/metrics.go
+++ b/metrics.go
@@ -57,10 +57,29 @@ func (m ExportMetricsServiceRequest) DataPointCount() (int, error) {
 	return countMetricDataPoints([]byte(m))
 }
 
-// ResourceMetrics returns an iterator over ResourceMetrics in the batch.
-// The returned function should be called after iteration to check for errors.
+// ResourceMetrics returns an iterator over ResourceMetrics in the batch. The
+// returned function should be called after iteration to check for errors.
+// ResourceMetrics is a thin adapter over ResourceMetricsSeq.
 func (m ExportMetricsServiceRequest) ResourceMetrics() (iter.Seq[ResourceMetrics], func() error) {
-	return repeatedFieldSeq[ResourceMetrics]([]byte(m), 1)
+	var iterErr error
+	seq := func(yield func(ResourceMetrics) bool) {
+		m.ResourceMetricsSeq(func(resource ResourceMetrics, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(resource)
+		})
+	}
+	return seq, func() error { return iterErr }
+}
+
+// ResourceMetricsSeq is the zero-allocation alternative to ResourceMetrics.
+// It is shaped like iter.Seq2[ResourceMetrics, error] and meant to be ranged
+// over directly. On a parse error it yields a nil ResourceMetrics with a
+// non-nil error and stops.
+func (m ExportMetricsServiceRequest) ResourceMetricsSeq(yield func(ResourceMetrics, error) bool) {
+	repeatedFieldSeq2([]byte(m), 1, yield)
 }
 
 // DataPointCount returns the number of metric data points in this resource.
@@ -96,8 +115,27 @@ func (r ResourceMetrics) WriteTo(w io.Writer) (int64, error) {
 // ScopeMetrics returns an iterator over ScopeMetrics in this ResourceMetrics.
 // Field 2 in the ResourceMetrics protobuf message.
 // The returned function should be called after iteration to check for errors.
+// ScopeMetrics is a thin adapter over ScopeMetricsSeq.
 func (r ResourceMetrics) ScopeMetrics() (iter.Seq[ScopeMetrics], func() error) {
-	return repeatedFieldSeq[ScopeMetrics]([]byte(r), 2)
+	var iterErr error
+	seq := func(yield func(ScopeMetrics) bool) {
+		r.ScopeMetricsSeq(func(scope ScopeMetrics, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(scope)
+		})
+	}
+	return seq, func() error { return iterErr }
+}
+
+// ScopeMetricsSeq is the zero-allocation alternative to ScopeMetrics. It is
+// shaped like iter.Seq2[ScopeMetrics, error] and meant to be ranged over
+// directly. On a parse error it yields a nil ScopeMetrics with a non-nil error
+// and stops.
+func (r ResourceMetrics) ScopeMetricsSeq(yield func(ScopeMetrics, error) bool) {
+	repeatedFieldSeq2([]byte(r), 2, yield)
 }
 
 // Scope returns the InstrumentationScope for this ScopeMetrics. It returns

--- a/operations.md
+++ b/operations.md
@@ -186,6 +186,22 @@ production validation.
 **Uncovered scenarios:** A consumer without version-attributed processing and
 queue telemetry cannot distinguish an idle path from a parser regression.
 
+### Diagnosing container-iterator allocations
+
+The ordinary request/resource iterators return closures and an error function.
+When a consumer ranges over one of those function-typed values, its loop body
+and captured state may escape to the heap once per opened iterator. The effect
+scales with resource and scope count, so a record-heavy benchmark can hide a
+cost that becomes material on resource-heavy traffic.
+
+Hot paths can range directly over `ResourceMetricsSeq`/`ScopeMetricsSeq`,
+`ResourceLogsSeq`/`ScopeLogsSeq`, or `ResourceSpansSeq`/`ScopeSpansSeq` to
+receive errors inline and keep container traversal allocation-free. The
+ordinary methods remain the ergonomic form and preserve their deferred-error
+contract. `TestContainerSeq_ZeroAllocations` is the library gate; production
+impact must still be established in the importing service because this module
+emits no allocation or GC telemetry of its own.
+
 ## Release and production analysis
 
 1. Verify race tests, vet, malformed-wire coverage, allocation gates, and

--- a/traces.go
+++ b/traces.go
@@ -13,10 +13,29 @@ func (t ExportTracesServiceRequest) SpanCount() (int, error) {
 	return countSpans([]byte(t))
 }
 
-// ResourceSpans returns an iterator over ResourceSpans in the batch.
-// The returned function should be called after iteration to check for errors.
+// ResourceSpans returns an iterator over ResourceSpans in the batch. The
+// returned function should be called after iteration to check for errors.
+// ResourceSpans is a thin adapter over ResourceSpansSeq.
 func (t ExportTracesServiceRequest) ResourceSpans() (iter.Seq[ResourceSpans], func() error) {
-	return repeatedFieldSeq[ResourceSpans]([]byte(t), 1)
+	var iterErr error
+	seq := func(yield func(ResourceSpans) bool) {
+		t.ResourceSpansSeq(func(resource ResourceSpans, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(resource)
+		})
+	}
+	return seq, func() error { return iterErr }
+}
+
+// ResourceSpansSeq is the zero-allocation alternative to ResourceSpans. It is
+// shaped like iter.Seq2[ResourceSpans, error] and meant to be ranged over
+// directly. On a parse error it yields a nil ResourceSpans with a non-nil
+// error and stops.
+func (t ExportTracesServiceRequest) ResourceSpansSeq(yield func(ResourceSpans, error) bool) {
+	repeatedFieldSeq2([]byte(t), 1, yield)
 }
 
 // SpanCount returns the number of spans in this resource.
@@ -52,8 +71,26 @@ func (r ResourceSpans) WriteTo(w io.Writer) (int64, error) {
 // ScopeSpans returns an iterator over ScopeSpans in this ResourceSpans.
 // Field 2 in the ResourceSpans protobuf message.
 // The returned function should be called after iteration to check for errors.
+// ScopeSpans is a thin adapter over ScopeSpansSeq.
 func (r ResourceSpans) ScopeSpans() (iter.Seq[ScopeSpans], func() error) {
-	return repeatedFieldSeq[ScopeSpans]([]byte(r), 2)
+	var iterErr error
+	seq := func(yield func(ScopeSpans) bool) {
+		r.ScopeSpansSeq(func(scope ScopeSpans, err error) bool {
+			if err != nil {
+				iterErr = err
+				return false
+			}
+			return yield(scope)
+		})
+	}
+	return seq, func() error { return iterErr }
+}
+
+// ScopeSpansSeq is the zero-allocation alternative to ScopeSpans. It is shaped
+// like iter.Seq2[ScopeSpans, error] and meant to be ranged over directly. On a
+// parse error it yields a nil ScopeSpans with a non-nil error and stops.
+func (r ResourceSpans) ScopeSpansSeq(yield func(ScopeSpans, error) bool) {
+	repeatedFieldSeq2([]byte(r), 2, yield)
 }
 
 // SpanCount returns the number of spans in this ScopeSpans.

--- a/wire.go
+++ b/wire.go
@@ -22,6 +22,19 @@ func repeatedFieldSeq[T ~[]byte](data []byte, fieldNum protowire.Number) (iter.S
 	return seq, func() error { return iterErr }
 }
 
+// repeatedFieldSeq2 is the allocation-free form of repeatedFieldSeq. Public
+// methods with this shape are meant to be ranged over directly as method
+// values, keeping the consumer's loop body on the stack.
+func repeatedFieldSeq2[T ~[]byte](data []byte, fieldNum protowire.Number, yield func(T, error) bool) {
+	forEachRepeatedField(data, fieldNum, func(item []byte, err error) bool {
+		if err != nil {
+			yield(nil, err)
+			return false
+		}
+		return yield(T(item), nil)
+	})
+}
+
 // skipField skips a field value after its tag has been consumed. The field
 // number is required for groups so ConsumeFieldValue can verify the matching
 // end-group marker and recursively validate its contents.


### PR DESCRIPTION
## Motivation

Ranging over the closure-based resource and scope iterators can make consumer loop bodies escape once per container. This adds a direct sequence form for allocation-sensitive callers.

## Changes

- add `Resource*Seq` and `Scope*Seq` zero-allocation iterator forms for logs, metrics, and traces;
- retain existing iterator APIs as compatible adapters;
- preserve wire order, lazy early-stop behavior, inline parse errors, and capacity-clamped aliased views;
- add malformed-wire, adapter-parity, early-stop, capacity, and zero-allocation tests;
- update executable examples, public API documentation, design notes, benchmarks, and operational guidance.

## Compatibility and risk

The change is additive. Existing APIs and their deferred error-closure contract remain available. Metrics and traces receive the same methods because all three signals share the same resource/scope container layout and parser helper.

The main risk is parser-contract drift between the ordinary and sequence forms. Tests compare their values and errors and exercise wrong wire types, truncated lengths, malformed groups, unknown groups, early stops, and append isolation.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test -v -race ./...`
- `go test -race -shuffle=on -count=1 ./...`
- `go test -run 'TestContainerSeq' -bench '^BenchmarkContainerSeq$' -benchmem -count=1`
- `git diff --check`

The focused benchmark records:

- record-heavy: ordinary 15 allocs/op, sequence 0;
- resource-heavy: ordinary 45 allocs/op, sequence 0.

`golangci-lint run` fails identically on clean `upstream/main` with `no go files to analyze`; it is not a repository CI gate. `go mod tidy -diff` reports the documented baseline checksum-history drift and no dependency files were changed.

## Delivery

This PR changes only the library. No release or rollout is included.

Material agent assistance was used for implementation, testing, documentation, and adversarial review. The contributor remains responsible for reviewing and owning the result.

Closes E-3008.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added zero-allocation sequence iteration APIs for resource and scope data across metrics, logs, and traces.
  - Sequence callbacks provide parsed values and errors, preserve wire order, support early termination, and stop safely on malformed data.
  - Existing iterator APIs retain deferred error handling and compatibility.

- **Documentation**
  - Expanded API, design, specification, operations, and benchmark documentation with usage and allocation guidance.

- **Tests**
  - Added coverage and benchmarks for parity, malformed data, early stopping, capacity handling, nested traversal, and zero allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->