### PR TITLE
refactor: consolidate key-value sequence iteration

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -32,21 +32,6 @@ func (kv KeyValue) StringValue() ([]byte, bool, error) {
 	return value.stringValue, true, nil
 }
 
-// keyValueSeq walks the repeated KeyValue field at fieldNum, yielding each
-// element inline. The field number differs per container, so the caller
-// supplies it and documents its own choice. On a parse error it yields a nil
-// KeyValue with a non-nil error and stops. Nothing escapes, so iterating
-// allocates nothing.
-func keyValueSeq(data []byte, fieldNum protowire.Number, yield func(KeyValue, error) bool) {
-	forEachRepeatedField(data, fieldNum, func(rb []byte, err error) bool {
-		if err != nil {
-			yield(nil, err)
-			return false
-		}
-		return yield(KeyValue(rb), nil)
-	})
-}
-
 // Attributes returns an iterator over the Resource's attribute KeyValues.
 // The returned function should be called after iteration to check for errors.
 func (r Resource) Attributes() (iter.Seq[KeyValue], func() error) {
@@ -58,7 +43,7 @@ func (r Resource) Attributes() (iter.Seq[KeyValue], func() error) {
 // directly. On a parse error it yields a nil KeyValue with a non-nil error and
 // stops.
 func (r Resource) AttributesSeq(yield func(KeyValue, error) bool) {
-	keyValueSeq([]byte(r), 1, yield)
+	repeatedFieldSeq2([]byte(r), 1, yield)
 }
 
 // StringAttribute returns the string value of the first resource attribute

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -549,6 +549,25 @@ lazy error timing and early-stop behavior. Metrics and traces expose the same
 sequence forms because their resource/scope container layout and escape
 behavior are identical; `TestContainerSeq_ZeroAllocations` pins all three.
 
+E-3051 measured whether those ordinary adapter bodies could be replaced by
+direct calls to the existing generic `repeatedFieldSeq` helper. On the same
+i7-11800H / linux-amd64 / Go 1.25.12 environment, 15 alternating invocations
+of prebuilt before/after test binaries kept the counts at 15 and 45 allocs/op
+but added exactly 24 B/op to both shapes (424 → 448 and 1,264 → 1,288). A
+generic method-value adapter was worse at 27/87 allocs and 720/2,281 B/op.
+The explicit ordinary adapters are therefore performance-bearing under the
+supported compiler and remain intentionally duplicated.
+
+The same issue removed the type-specific `keyValueSeq` wrapper and routed the
+four allocation-free KeyValue APIs directly through `repeatedFieldSeq2`.
+Fifteen alternating before/after invocations (`-benchtime=200x`) of
+`BenchmarkMetric_Metadata_Seq` and
+`BenchmarkMetrics_ScrapeDeepIterationSeq_WireFormat` were indistinguishable:
+the after arm was slower in 7/15 and 6/15 pairs respectively, with median
+paired deltas of about +0.4% and -1.2%. The dedicated allocation tests for
+resource, scope, metadata and datapoint attribute sequences remain the
+zero-allocation gate.
+
 ## Log severity classification (E-2892)
 
 This benchmark models an insight consumer that reads resource context through

--- a/metrics.go
+++ b/metrics.go
@@ -49,7 +49,7 @@ func (d DataPoint) Attributes() (iter.Seq[KeyValue], func() error) {
 //
 // On a parse error it yields a nil KeyValue with a non-nil error and stops.
 func (d DataPoint) AttributesSeq(yield func(KeyValue, error) bool) {
-	keyValueSeq(d.raw, d.attributesFieldNum(), yield)
+	repeatedFieldSeq2(d.raw, d.attributesFieldNum(), yield)
 }
 
 // DataPointCount returns the total number of metric data points in the batch.
@@ -186,7 +186,7 @@ func (m Metric) Metadata() (iter.Seq[KeyValue], func() error) {
 // iter.Seq2[KeyValue, error] and meant to be ranged over directly. On a parse
 // error it yields a nil KeyValue with a non-nil error and stops.
 func (m Metric) MetadataSeq(yield func(KeyValue, error) bool) {
-	keyValueSeq([]byte(m), 12, yield)
+	repeatedFieldSeq2([]byte(m), 12, yield)
 }
 
 // DataPoints returns an iterator over datapoints in this Metric, descending

--- a/operations.md
+++ b/operations.md
@@ -202,6 +202,13 @@ contract. `TestContainerSeq_ZeroAllocations` is the library gate; production
 impact must still be established in the importing service because this module
 emits no allocation or GC telemetry of its own.
 
+The ordinary adapter bodies are intentionally explicit rather than delegated
+to `repeatedFieldSeq`. E-3051 measured that seemingly mechanical cleanup at an
+additional 24 B per `BenchmarkContainerSeq` operation with no allocation-count
+or credible runtime benefit under Go 1.25.12. If a future compiler changes
+escape behavior, rerun that benchmark with alternating prebuilt binaries
+before trying the consolidation again.
+
 ## Release and production analysis
 
 1. Verify race tests, vet, malformed-wire coverage, allocation gates, and

--- a/scope.go
+++ b/scope.go
@@ -35,5 +35,5 @@ func (s InstrumentationScope) Attributes() (iter.Seq[KeyValue], func() error) {
 // directly. On a parse error it yields a nil KeyValue with a non-nil error and
 // stops.
 func (s InstrumentationScope) AttributesSeq(yield func(KeyValue, error) bool) {
-	keyValueSeq([]byte(s), 3, yield)
+	repeatedFieldSeq2([]byte(s), 3, yield)
 }


### PR DESCRIPTION
## Motivation

The four allocation-free KeyValue sequence APIs used a private `keyValueSeq` wrapper that duplicated the generic `repeatedFieldSeq2` implementation. E-3051 removes that redundant path while preserving field numbers, inline error delivery, early stopping, view aliasing, and zero-allocation behavior.

The initially proposed larger cleanup—routing ordinary resource/scope iterators through `repeatedFieldSeq`—was rejected after paired benchmarks found a 24 B/op regression. The benchmark and operational documentation now record why those explicit adapters remain.

Linear: https://linear.app/ollygarden/issue/E-3051/otlp-wire-simplify-repeated-field-iterator-internals-without

## Change

- route Resource and InstrumentationScope attributes, Metric metadata, and DataPoint attributes directly through `repeatedFieldSeq2`;
- remove `keyValueSeq`;
- document the rejected ordinary-adapter consolidation and its allocation evidence.

## Compatibility and risk

- Public API: unchanged.
- Wire semantics: unchanged; both implementations delegate to `forEachRepeatedField` with identical error and early-stop control flow.
- Allocations: the dedicated Resource, Scope, Metadata, and DataPoint sequence gates remain zero-allocation.
- Permissions and side effects: none; this is a Go library refactor.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test -v -race ./...`
- focused malformed-wire, early-stop, view, and allocation tests
- `git diff --check`
- `git diff --exit-code -- go.mod go.sum`

`go mod tidy` was run and its unrelated removal of retained checksum history was intentionally discarded, per CONTRIBUTING.md.

Paired prebuilt binaries, 15 alternating rounds at `-benchtime=200x`:

- `BenchmarkMetric_Metadata_Seq`: after slower 7/15, median paired delta about +0.4%;
- `BenchmarkMetrics_ScrapeDeepIterationSeq_WireFormat`: after slower 6/15, median paired delta about -1.2%.

No material runtime difference was detected.

## Release

After merge, verify the exact merge SHA with the full gates and tag it as `v0.2.4`. This repository has no release workflow or deployment. No consumer rollout is part of E-3051.

## Agent involvement

OpenAI Codex materially assisted with repository analysis, implementation, tests, benchmarks, documentation, and adversarial review. The human contributor remains responsible for reviewing and owning the result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added benchmark results confirming no measurable runtime impact for key-value sequence iteration changes.
  * Documented allocation considerations and the rationale for retaining explicit iterator adapters.
* **Refactor**
  * Consolidated attribute and metadata sequence iteration through a shared implementation.
  * Preserved existing iterator signatures and error-reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->