### PR TITLE
chore: upgrade Go to 1.26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.x'
+        go-version: '1.26.6'
         cache: true
 
     - name: Run tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ commit, and pull-request expectations.
 
 ## Development commands
 
-Use Go 1.25 or newer to match the module directive and iterator APIs. CI uses
+Use Go 1.26.6 or newer to match the module directive and iterator APIs. CI uses
 the latest stable Go release.
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ commit, and pull-request expectations.
 
 ## Development commands
 
-Use Go 1.26.6 or newer to match the module directive and iterator APIs. CI uses
-the latest stable Go release.
+Use Go 1.26.6 or newer to match the module directive and iterator APIs. CI
+pins Go 1.26.6.
 
 ```bash
 go mod tidy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ guardrails, testing patterns, and change-specific validation matrix.
 
 ## Set up and validate
 
-Use Go 1.26.6 or newer. CI uses the latest stable Go release.
+Use Go 1.26.6 or newer. CI pins Go 1.26.6.
 
 ```bash
 go test -v -race ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ guardrails, testing patterns, and change-specific validation matrix.
 
 ## Set up and validate
 
-Use Go 1.25 or newer. CI uses the latest stable Go release.
+Use Go 1.26.6 or newer. CI uses the latest stable Go release.
 
 ```bash
 go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ For detailed benchmarks and methodology, see [BENCHMARKS.md](docs/BENCHMARKS.md)
 
 ## Requirements
 
-- Go 1.25+
+- Go 1.26.6+
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.olly.garden/otlp-wire
 
-go 1.25.0
+go 1.26.6
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## Summary

- update the module Go directive to 1.26.6
- pin GitHub Actions to Go 1.26.6 so it matches the module directive
- update the applicable contributor and README Go-version requirements

## Validation

- `git diff --check` passed
- local Go build, vet, race, lint, and tidy commands were intentionally not run to protect the constrained laptop; GitHub Actions is the compilation and test gate for this PR

## Risk and release

No API, behavior, dependency, or allocation changes. This is a tag-only library with no release workflow; the next stable tag would be `v0.2.5`, but merge and tagging are outside this PR-only run contract.