### PR TITLE
perf(metrics)!: resolve Metric.Name first-match

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,12 @@ accessors, alongside the per-message schema walks `parseLogRecordSeverity` and
   merge (`extractMergedMessage`) for messages, last-value-wins
   (`extractLastBytesField`) for scalars. Verify the choice against pdata's
   generated unmarshal — merge appends, replacement assigns. Check the `.proto`
-  declaration first: neither helper applies to a `repeated` field. See
-  "Singular field resolution" in [docs/DESIGN.md](docs/DESIGN.md).
+  declaration first: neither helper applies to a `repeated` field. First-match
+  (`extractBytesField`) is a legitimate third answer for a scalar on a hot
+  path, but it is a divergence from pdata and must be priced, pinned by test
+  and recorded in [operations.md](operations.md) — `Metric.Name` (E-2985) and
+  `KeyValue.Key` are the precedents. See "Singular field resolution" in
+  [docs/DESIGN.md](docs/DESIGN.md).
 - Before reaching for either helper, check whether an existing schema-aware
   walk already covers that message — `parseLogRecordSeverity` for `LogRecord`,
   `parseSpanFields` for `Span`. If one does, read the field out of that walk
@@ -108,12 +112,13 @@ accessors, alongside the per-message schema walks `parseLogRecordSeverity` and
   Moving a first-match accessor onto a full walk costs every conformant
   message to change behavior only malformed ones can show, since a conformant
   producer emits each singular field once. E-2945 measured that for `Span` and
-  left `TraceID`/`SpanID`/`ParentSpanID` on first-match; the two parser classes
-  and the divergence they produce are pinned by test and recorded in
+  left `TraceID`/`SpanID`/`ParentSpanID` on first-match; E-2985 measured it for
+  `Metric.Name` and moved it back to first-match. In both cases the two parser
+  classes and the divergence they produce are pinned by test and recorded in
   [operations.md](operations.md). Measure with a paired benchmark against a
   merge-base checkout, and note that a pdata-marshalled fixture hides the cost:
-  pdata writes fields back-to-front, so `trace_id` lands last where a real SDK
-  exporter puts it first.
+  pdata writes fields back-to-front, so `trace_id` and `Metric.name` land last
+  where a real SDK exporter puts them first.
 - Walk *depth* is a separate decision from walk *sharing*. Descend only into
   nested messages a consumer of that accessor reads next: `parseSpanFields` is
   framing-only below the Span level, where `parseLogRecordSeverity` parses the

--- a/README.md
+++ b/README.md
@@ -346,9 +346,11 @@ name, err := scope.Name()
 Fields OTLP declares `repeated` — the attribute fields and `Metric.Metadata` —
 yield every occurrence in wire order instead. Singular *messages*
 (`Resource()`, `Scope()`) merge, while singular *scalars* (`SchemaUrl()`,
-`InstrumentationScope.Name()` and `Version()`, `Metric.Name()`)
-resolve to the last occurrence. `KeyValue.Key` and `KeyValue.ValueRaw` are
-deliberately exempt and stay first-match for hashing hot paths.
+`InstrumentationScope.Name()` and `Version()`)
+resolve to the last occurrence. `Metric.Name()`, `KeyValue.Key` and
+`KeyValue.ValueRaw` are deliberately exempt and stay first-match, because
+resolving them the other way costs a full message walk on every conformant
+payload.
 [docs/DESIGN.md](docs/DESIGN.md) explains why.
 
 `KeyValue.ValueRaw` remains a lightweight view of the first encoded AnyValue

--- a/benchmark_comparison_test.go
+++ b/benchmark_comparison_test.go
@@ -3,6 +3,8 @@ package otlpwire
 import (
 	"errors"
 	"fmt"
+	"math"
+	"slices"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -1244,14 +1246,88 @@ func BenchmarkSchemaUrl_ScanScaling(b *testing.B) {
 	}
 }
 
-// BenchmarkMetric_Name covers the accessor changed from first-match to
-// last-value-wins, which turned an early return into a full scan of the
-// metric's top-level fields. Compare against the same benchmark on main.
+// BenchmarkMetric_Name reads every metric name from a pdata-marshalled
+// payload. pdata's ProtoMarshaler writes fields back-to-front, so name lands
+// last in each metric and a first-match scan has to walk the whole metric
+// anyway. That makes this arm blind to the resolution change on its own --
+// BenchmarkMetric_Name_SDKOrder is the one that sees it. Keep both.
 func BenchmarkMetric_Name(b *testing.B) {
 	metrics := createScrapeShapedMetrics()
 	marshaler := &pmetric.ProtoMarshaler{}
 	payload, err := marshaler.MarshalMetrics(metrics)
 	require.NoError(b, err)
+
+	benchmarkMetricNames(b, payload)
+}
+
+// BenchmarkMetric_Name_SDKOrder reads the same names from the same shape in
+// ascending field order, where the OTLP SDK exporters put name first. This is
+// where first-match and last-value-wins actually differ: last-value-wins has
+// to walk past the datapoint body to prove no later name occurrence exists,
+// while first-match returns at the first tag.
+func BenchmarkMetric_Name_SDKOrder(b *testing.B) {
+	benchmarkMetricNames(b, createScrapeShapedMetricsSDKOrder())
+}
+
+// BenchmarkMetric_Name_Accessor isolates the accessor from the iteration
+// around it, on the metric shape a Prometheus receiver produces: name, unit,
+// a datapoint body and three metadata entries. The two arms differ only in
+// field order, so the gap between them is the cost of resolving name against
+// fields that follow it.
+func BenchmarkMetric_Name_Accessor(b *testing.B) {
+	for _, ascending := range []bool{true, false} {
+		label := "PdataOrder"
+		if ascending {
+			label = "SDKOrder"
+		}
+		metric := prometheusShapedMetric(ascending)
+		b.Run(label, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := metric.Name(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// prometheusShapedMetric builds one Metric carrying the fields a Prometheus
+// receiver sets. ascending emits fields 1, 3, 5 and 12 in wire order the way
+// the SDK exporters do; otherwise it emits them back-to-front the way pdata
+// does.
+func prometheusShapedMetric(ascending bool) Metric {
+	name := protowire.AppendString(protowire.AppendTag(nil, 1, protowire.BytesType), "process_metric_1234_total")
+	unit := protowire.AppendString(protowire.AppendTag(nil, 3, protowire.BytesType), "1")
+	body := bytesField(5, bytesField(1, numberDataPoint(42)))
+
+	var metadata []byte
+	for _, entry := range [][2]string{
+		{"prometheus.type", "counter"},
+		{"prometheus.help", "total processed items"},
+		{"otel.scope.name", "prometheus-receiver"},
+	} {
+		metadata = append(metadata, metadataEntry(stringKeyValue(entry[0], entry[1]))...)
+	}
+
+	if ascending {
+		return Metric(slices.Concat(name, unit, body, metadata))
+	}
+	return Metric(slices.Concat(metadata, body, unit, name))
+}
+
+// numberDataPoint builds a NumberDataPoint in ascending field order:
+// time_unix_nano (3), as_double (4), then any attributes (7).
+func numberDataPoint(value float64, attrs ...[]byte) []byte {
+	dp := protowire.AppendTag(nil, 3, protowire.Fixed64Type)
+	dp = protowire.AppendFixed64(dp, 1000000000)
+	dp = protowire.AppendTag(dp, 4, protowire.Fixed64Type)
+	dp = protowire.AppendFixed64(dp, math.Float64bits(value))
+	return appendRepeatedMessages(dp, 7, attrs...)
+}
+
+func benchmarkMetricNames(b *testing.B, payload []byte) {
+	b.Helper()
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -1278,6 +1354,45 @@ func BenchmarkMetric_Name(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+// createScrapeShapedMetricsSDKOrder builds the same scrape shape as
+// createScrapeShapedMetrics -- one resource, one scope, 4800 metrics with one
+// datapoint each -- but emits every message with ascending field numbers, the
+// way stock protobuf runtimes and therefore the OTLP SDK exporters do. It is
+// built with protowire rather than pdata precisely because pdata cannot
+// produce this order.
+func createScrapeShapedMetricsSDKOrder() []byte {
+	resource := appendRepeatedMessages(nil, 1,
+		stringKeyValue("service.name", "scraped-service"),
+		stringKeyValue("host.name", "host-1"),
+	)
+
+	scope := protowire.AppendString(protowire.AppendTag(nil, 1, protowire.BytesType), "prometheus-receiver")
+	scopeMetrics := bytesField(1, scope)
+
+	for i := 0; i < 4800; i++ {
+		points := bytesField(1, numberDataPoint(float64(i),
+			stringKeyValue("job", "node-exporter"),
+			stringKeyValue("instance", fmt.Sprintf("10.0.0.%d:9100", i%250)),
+			stringKeyValue("le", "0.5"),
+			stringKeyValue("quantile", "0.99"),
+		))
+
+		metric := protowire.AppendString(protowire.AppendTag(nil, 1, protowire.BytesType), fmt.Sprintf("process_metric_%d_total", i))
+		if i%2 == 0 {
+			metric = append(metric, bytesField(5, points)...)
+		} else {
+			sum := append(points, varintField(2, uint64(pmetric.AggregationTemporalityCumulative))...)
+			sum = append(sum, varintField(3, 1)...)
+			metric = append(metric, bytesField(7, sum)...)
+		}
+
+		scopeMetrics = appendRepeatedMessages(scopeMetrics, 2, metric)
+	}
+
+	resourceMetrics := append(bytesField(1, resource), bytesField(2, scopeMetrics)...)
+	return wrapAsRequest(resourceMetrics)
 }
 
 // ========== Metric.Metadata ==========

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -237,26 +237,23 @@ machine; this machine's absolute numbers differ from the Apple M4 figures
 recorded for this benchmark above since they are different hardware, but the
 before/after comparison on identical hardware is what matters here).
 
-## Scope, schema_url and Metric.Name (E-2942)
+## Scope and schema_url (E-2942)
 
 E-2942 added `Scope()` to `ScopeMetrics`, `ScopeLogs` and `ScopeSpans`,
 `SchemaUrl()` to all six containers, and the `InstrumentationScope`
-accessors. It also changed `Metric.Name()` from
-first-match to protobuf singular-scalar (last-value-wins) resolution. Both
-new resolutions must scan the whole enclosing message, so these benchmarks
-quantify that scan and confirm the zero-allocation gates still hold.
+accessors. Both new resolutions must scan the whole enclosing message, so
+these benchmarks quantify that scan and confirm the zero-allocation gates
+still hold. (`Metric.Name` was moved to last-value-wins here too and moved
+back in E-2985; its current figures are in "Metric.Name resolution" below.)
 
 **Environment:** 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz, linux/amd64,
-Go 1.25.12. `Metric.Name` was compared against the identical benchmark with
-only the accessor body reverted to `extractBytesField`, so the two sides run
-the same fixture and harness on the same machine in the same session.
+Go 1.25.12.
 
 **Commands:**
 
 ```bash
 go test -run '^$' -bench 'BenchmarkScope_(SingleOccurrence|MultipleOccurrences|NameVersion_WireFormat|NameVersion_Unmarshal)$' -benchmem -count=10 ./...
 go test -run '^$' -bench 'ScanScaling' -benchmem -count=5 ./...
-go test -run '^$' -bench 'BenchmarkMetric_Name$' -benchmem -count=6 ./...
 ```
 
 ### Scope access versus full decode
@@ -319,38 +316,6 @@ Findings:
 - Each skipped field is still cheap: `protowire.ConsumeFieldValue` reads the
   length prefix and steps over the body without descending. Growth is in the
   number of tags, not their size.
-
-### `Metric.Name` — first-match to last-value-wins
-
-**Fixture:** the E-2608 scrape shape (one resource, one scope, 4800 metrics
-with one datapoint each), iterating every metric and reading its name. The two
-revisions differ only in `Metric.Name`'s body; everything else, including the
-capacity clamp in `forEachRepeatedField`, is identical. Measured by
-alternating the two builds (two rounds, `-count=6` each) rather than running
-one after the other, because a single sequential pair on this machine drifts
-enough to understate the gap.
-
-| Revision | ns/op (round 1, round 2) | B/op | allocs/op |
-|---|---:|---:|---:|
-| first-match (previous) | 116,093 / 115,150 | 112 | 6 |
-| last-value-wins (this change) | 129,147 / 130,234 | 112 | 6 |
-
-About **12% slower** across 4800 metrics — roughly 2.9 ns more per metric —
-with allocations unchanged. The observed ranges do not overlap, so the gap is
-real rather than noise.
-
-The cost is bounded and does not scale with payload size: a `Metric`'s
-top-level fields are its name, description, unit, one oneof body and optional
-metadata, and `protowire.ConsumeFieldValue` on the length-delimited body reads
-its length prefix and steps over it without descending into the datapoints.
-What the scan buys is pdata parity on a repeated `name`; what it costs is the
-early return. A consumer reading names across millions of metrics per scrape
-should weigh that 12% deliberately — it is the largest single regression in
-this change. The correctness reason is in [DESIGN.md](DESIGN.md).
-
-An earlier revision of this section reported ~3% from a non-interleaved
-measurement taken while the machine was under other load. The figures above
-supersede it.
 
 ### Gates unchanged
 
@@ -827,3 +792,77 @@ actually takes.
 
 Drop the hand-rolled arm and this subsection once overstory moves to the Span
 accessors.
+
+## Metric.Name resolution (E-2985)
+
+E-2985 moved `Metric.Name` back to first-match (`extractBytesField`) from the
+last-value-wins scan E-2942 gave it. The accessor is called once per metric, so
+the cost scales with metric count; marigold reads it across ~4,800-metric
+scrape payloads.
+
+**The measurement only works on a fixture built by hand.** pdata's
+`ProtoMarshaler` writes fields back-to-front — a marshalled `Metric` here comes
+out as `[5 1]`, body then `name` — so `name` lands *last* and a first-match
+scan has to walk the whole metric to reach it anyway. Against that fixture the
+two resolutions are nearly indistinguishable, which is why
+`BenchmarkMetric_Name` did not catch the regression it was added to guard.
+Stock protobuf runtimes, and therefore the OTLP SDK exporters, emit ascending
+field numbers with `name` first. `createScrapeShapedMetricsSDKOrder` builds
+that order with `protowire` because pdata cannot produce it. Both arms are
+kept: the pdata one reflects collector-relayed traffic, the SDK one reflects
+direct exporters.
+
+**Environment:** Apple M5, darwin/arm64, Go 1.26.6.
+
+**Method:** two prebuilt binaries differing only in `Metric.Name`'s body,
+alternated for 6 rounds rather than run as consecutive blocks. Medians of 6.
+
+```bash
+go test -c -o after.test .
+# revert Metric.Name to extractLastBytesField
+go test -c -o before.test .
+for round in 1 2 3 4 5 6; do
+  for arm in before after; do
+    ./$arm.test -test.run '^$' -test.bench 'BenchmarkMetric_Name' -test.benchmem
+  done
+done
+```
+
+### The accessor alone
+
+One metric carrying what a Prometheus receiver sets: name, unit, a datapoint
+body and three metadata entries. The two arms are the same 168 bytes in
+different field order.
+
+| Field order | last-value-wins | first-match (current) | change |
+|---|---:|---:|---:|
+| ascending (SDK exporters, `name` first) | 26.9 ns | 4.2 ns | **−84%** |
+| back-to-front (pdata, `name` last) | 25.9 ns | 25.7 ns | none |
+
+Both remain 0 B/op, 0 allocs/op. The second row is the point: where `name` is
+emitted last, first-match buys nothing, because proving it is the first
+occurrence and reaching the last one are the same walk.
+
+### Across a scrape payload
+
+The E-2608 scrape shape — one resource, one scope, 4800 metrics with one
+datapoint each — iterated in full, reading every name.
+
+| Fixture | last-value-wins | first-match (current) | change |
+|---|---:|---:|---:|
+| `BenchmarkMetric_Name` (pdata order) | 69.4 µs | 63.0 µs | −9% |
+| `BenchmarkMetric_Name_SDKOrder` | 70.8 µs | 41.7 µs | **−41%** |
+
+Both stay at 112 B/op, 6 allocs/op — the allocations are the iterators being
+opened, not the accessor.
+
+Read the two rows differently. The SDK-order ranges are far apart
+(67.8–72.2 µs against 40.2–45.9 µs) and the gap is the early return. The
+pdata-order ranges **overlap** (67.2–71.0 µs against 61.2–67.3 µs), so treat
+that −9% as suggestive rather than established: on that fixture both
+resolutions traverse identical bytes, and the accessor-level arm above shows no
+change at all. Any real residual there is `extractLastBytesField` reaching its
+occurrence through a `forEachRepeatedField` closure where `extractBytesField`
+runs a flat loop — a per-call cost the remaining last-value-wins accessors
+still pay. Isolating it needs its own paired benchmark, which this change does
+not add.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -843,6 +843,24 @@ Both remain 0 B/op, 0 allocs/op. The second row is the point: where `name` is
 emitted last, first-match buys nothing, because proving it is the first
 occurrence and reaching the last one are the same walk.
 
+### Clamping the first-match view
+
+Moving `Metric.Name` onto `extractBytesField` exposed that the helper returned
+`protowire.ConsumeBytes`'s slice unclamped, so a caller appending to the
+returned name could overwrite the fields behind it. The helper now clamps, the
+way `forEachRepeatedField` and `extractMergedMessage` already did. That also
+clamps `KeyValue.Key` and `KeyValue.ValueRaw`, the library's hottest path, so
+it was measured: paired binaries differing only in the slice expression,
+4 alternating rounds.
+
+`BenchmarkMetrics_DeepIteration_WireFormat` medians 36.0 µs unclamped against
+37.1 µs clamped, and `BenchmarkMetrics_ScrapeDeepIteration_WireFormat` 701.8 µs
+against 713.1 µs. Both pairs of ranges overlap (35.4–36.4 against 35.9–38.4;
+686.9–709.4 against 695.9–735.7), so the difference is not separable from noise
+at this sample size. Allocations are byte-identical on both arms
+(20912 B/op, 1033 allocs/op and 460986 B/op, 19207 allocs/op), which is the
+guardrail that matters here.
+
 ### Across a scrape payload
 
 The E-2608 scrape shape — one resource, one scope, 4800 metrics with one

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -65,7 +65,7 @@ Parsing composes a small set of helpers around
 - repeated-field counting;
 - repeated-field iteration;
 - length-delimited and scalar extraction, in first-match and last-value-wins
-  forms;
+  forms, chosen per accessor rather than per field kind;
 - merged singular-message extraction and resource re-wrapping;
 - field skipping with matching-group validation;
 - bounded semantic parsing for KeyValue, AnyValue, Resource, LogRecord and
@@ -321,15 +321,31 @@ scope in E-2942:
 
 ### Singular scalars: last occurrence wins
 
-`SchemaUrl`, `InstrumentationScope.Name`, `InstrumentationScope.Version` and
-`Metric.Name` share `extractLastBytesField`. Because a later occurrence
-replaces an earlier one, the extractor cannot stop at the first match; it
-records the most recent occurrence and returns after the walk completes.
+`SchemaUrl`, `InstrumentationScope.Name` and `InstrumentationScope.Version`
+share `extractLastBytesField`. Because a later occurrence replaces an earlier
+one, the extractor cannot stop at the first match; it records the most recent
+occurrence and returns after the walk completes.
 
-`Metric.Name` returned the first occurrence before E-2942. That was a
-divergence from pdata of the same kind E-2941 fixed for `Resource()`, so it
-was corrected here rather than left to differ from the new accessors beside
-it.
+**`Metric.Name` is the priced exception.** It resolves first-match via
+`extractBytesField`, returning the first `name` occurrence where pdata takes
+the last. This is the `Span` identifier trade applied to metrics: reaching the
+last occurrence means walking every metric to its end, and the only thing that
+buys is different behavior on malformed input, since a conformant producer
+emits `name` once. The cost is not small and it is producer-shaped. Against
+one Prometheus-shaped metric, first-match measures 4.2 ns where the full walk
+measures 26.9 ns — but only when `name` is emitted first, as the OTLP SDK
+exporters emit it. On pdata-marshalled bytes, where `name` lands last, the two
+resolutions traverse the same fields and the gap nearly vanishes. That is why
+the benchmark that guarded this accessor could not see the regression it was
+meant to guard: it was built from a pdata fixture.
+[BENCHMARKS.md](BENCHMARKS.md) has both arms.
+
+The consequence accepted with it is a narrower validity claim than pdata's:
+`Name` returns before any corruption that follows the `name` field, so it
+accepts metrics pdata rejects. `Metric` therefore carries two parser classes
+the way `Span` does — `Metadata` and `DataPoints` still walk what they read.
+`TestMetricName_FirstMatchDivergesFromPdata` and
+`TestMetricName_MalformedTrailingFieldNotReported` pin both directions.
 
 `KeyValue.Key` and `KeyValue.ValueRaw` keep first-match semantics via
 `extractBytesField`, and this is a known divergence rather than an

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -342,18 +342,23 @@ fallback disagree, it is the safe direction, and it is deliberate: `AGENTS.md`
 requires that corruption never be silently accepted to keep a walk moving.
 Groups are a proto2 construct that OTLP never emits, so the shapes affected
 are malformed or adversarial rather than anything a conformant producer
-emits. `Metric.Name` is not subject to this: it returns at the first `name`
-field and never reaches a trailing unknown field.
-`TestMetricName_UnclosedGroupIsStricterThanPdata` pins the divergence so it
-stays a decision rather than an accident.
+emits. `Metric.Name` is subject to this only when the group *precedes* the
+`name` field: it returns at the first `name`, so a group after that field is
+never reached, while one before it is skipped and rejected.
+`TestSchemaUrl_UnclosedGroupIsStricterThanPdata` and
+`TestMetricName_LeadingUnclosedGroupRejected` pin the divergence so it stays a
+decision rather than an accident.
 
 **`Metric.Name` behavior change (unreleased, E-2985).** It resolves
 first-match. E-2942 (v0.2.0) moved it to last-value-wins for consistency with
 the scalar accessors added beside it; E-2985 priced that consistency — a walk
 to the end of every metric, 84% of the accessor's time on SDK-ordered
 bytes — and moved it back. Consumers upgrading across this see a changed
-answer only on a repeated `Metric.name`, and only if they upgraded through
-v0.2.x in the first place. The signature is unchanged. `KeyValue.Key` and
+answer on a repeated `Metric.name`, and a changed *verdict* on corruption
+located anywhere after the `name` field — including inside the datapoint body,
+which the enclosing iterators do not descend into, so such a payload now
+traverses without an error from any accessor. Both require malformed or
+unusual input; neither is reachable from a conformant producer. The signature is unchanged. `KeyValue.Key` and
 `ValueRaw` keep first-match semantics deliberately, as documented above — they
 are hashing-oriented views, not parity accessors.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -308,7 +308,7 @@ field 1; the accessors absorb the difference, but anyone writing new wire code
 against this hierarchy must not assume they match.
 
 **Singular scalars resolve to the last occurrence (E-2942).** `SchemaUrl`,
-`InstrumentationScope.Name`, `InstrumentationScope.Version`, and `Metric.Name`
+`InstrumentationScope.Name` and `InstrumentationScope.Version`
 return the *last* occurrence when a field is repeated, which is what protobuf
 and pdata do. The distinction from the merge rule for singular messages is a
 behavioral contract, not an implementation detail: a consumer relying on
@@ -319,6 +319,17 @@ Two consequences follow, both mirroring the `Resource()` change: these
 accessors scan the whole enclosing message, so a malformed field located
 *after* the last occurrence is reported as an error; and cost grows with the
 enclosing message's field count while staying allocation-free.
+
+**`Metric.Name` resolves first-match instead (E-2985).** It returns the
+*first* `name` occurrence where pdata takes the last, and stops at that field
+rather than scanning the rest of the metric. Neither consequence above applies
+to it: corruption located after `name` is accepted, and cost does not grow
+with the metric's field count. This is a deliberate divergence bought for the
+early return — a full walk costs every conformant payload to change an answer
+only malformed payloads can produce — and it is the same trade the `Span`
+identifier accessors take. `KeyValue.Key` and `KeyValue.ValueRaw` are
+first-match for the same class of reason. [DESIGN.md](DESIGN.md) records the
+measurement.
 
 **Where the widened scan is stricter than pdata.** Skipping a field applies
 this library's group validation, which requires a start-group wire type to
@@ -331,19 +342,20 @@ fallback disagree, it is the safe direction, and it is deliberate: `AGENTS.md`
 requires that corruption never be silently accepted to keep a walk moving.
 Groups are a proto2 construct that OTLP never emits, so the shapes affected
 are malformed or adversarial rather than anything a conformant producer
-emits. `Metric.Name` is newly subject to this because it now scans; before
-E-2942 it returned at the first `name` field and never reached such a field.
+emits. `Metric.Name` is not subject to this: it returns at the first `name`
+field and never reaches a trailing unknown field.
 `TestMetricName_UnclosedGroupIsStricterThanPdata` pins the divergence so it
 stays a decision rather than an accident.
 
-**`Metric.Name` behavior change (unreleased, E-2942, v0.1.0).** It previously
-returned the first occurrence. That diverged from pdata in exactly the way
-`Resource()` did before E-2941, so it was corrected rather than left
-inconsistent with the accessors added beside it. The signature is unchanged
-and no consumer surveyed depends on the old resolution; a producer emitting a
-repeated `Metric.name` was already outside what its pdata fallback would agree
-with. `KeyValue.Key` and `ValueRaw` keep first-match semantics deliberately,
-as documented above — they are hashing-oriented views, not parity accessors.
+**`Metric.Name` behavior change (unreleased, E-2985).** It resolves
+first-match. E-2942 (v0.2.0) moved it to last-value-wins for consistency with
+the scalar accessors added beside it; E-2985 priced that consistency — a walk
+to the end of every metric, 84% of the accessor's time on SDK-ordered
+bytes — and moved it back. Consumers upgrading across this see a changed
+answer only on a repeated `Metric.name`, and only if they upgraded through
+v0.2.x in the first place. The signature is unchanged. `KeyValue.Key` and
+`ValueRaw` keep first-match semantics deliberately, as documented above — they
+are hashing-oriented views, not parity accessors.
 
 ### Metrics depth
 

--- a/metrics.go
+++ b/metrics.go
@@ -165,10 +165,17 @@ func (s ScopeMetrics) Metrics() (iter.Seq[Metric], func() error) {
 }
 
 // Name returns the metric name (field 1) as a view into the underlying
-// buffer. Returns nil if the field is not present. Repeated occurrences
-// resolve to the last one; see extractLastBytesField.
+// buffer. Returns nil if the field is not present.
+//
+// Name scans first-match and stops at the field. A repeated name therefore
+// resolves to the first occurrence where pdata takes the last, and corruption
+// after that occurrence is not reported. Both are deliberate divergences,
+// recorded in docs/DESIGN.md and operations.md: a conformant producer emits
+// name once, so the difference is observable only on malformed input, and
+// walking to the end of every metric to reach it costs every conformant
+// payload instead.
 func (m Metric) Name() ([]byte, error) {
-	return extractLastBytesField([]byte(m), 1)
+	return extractBytesField([]byte(m), 1)
 }
 
 // Metadata returns an iterator over the Metric's metadata KeyValues (field

--- a/operations.md
+++ b/operations.md
@@ -37,8 +37,8 @@ published one means a consumer version pin.
 | `ResourceLogs.StringAttribute` removed | E-2941 | mulch (only consumer with source to change) |
 | `Resource()` returns `(nil, nil)` for an absent Resource instead of an error | E-2941 | Any consumer treating that error as a signal; not firing in production as of 2026-08-07 |
 | `Resource()` merges repeated occurrences instead of returning the first | E-2941 | Consumers reading resource attributes from multi-occurrence payloads |
-| `Resource()`, `Scope()` and the singular-scalar accessors report corruption located after the last relevant occurrence | E-2941, E-2942 | Consumers that previously parsed such payloads without error |
-| `Metric.Name()` returns the last occurrence of a repeated `name` instead of the first | E-2942 | Consumers reading names from payloads with a repeated `Metric.name` |
+| `Resource()`, `Scope()` and the last-value-wins scalar accessors report corruption located after the last relevant occurrence | E-2941, E-2942 | Consumers that previously parsed such payloads without error |
+| `Metric.Name()` returns the first occurrence of a repeated `name`, where pdata takes the last, and accepts corruption located after the `name` field | E-2985 | Consumers pairing the wire path with a pdata fallback; only reachable on a repeated or malformed `Metric.name` |
 | Scanning accessors reject an unclosed group in an unknown trailing field, which pdata accepts | E-2942 | Consumers pairing the wire path with a pdata fallback; only reachable on malformed or adversarial input, never on conformant OTLP |
 
 The canary decision and its measured pre/post comparison are recorded at
@@ -144,6 +144,39 @@ LogRecord equivalent, since `parseLogRecordSeverity` does descend into the body
 and attributes. [docs/DESIGN.md](docs/DESIGN.md) records both decisions. A
 consumer cannot conclude "pdata would also accept this" from a successful Span
 accessor read.
+
+### Diagnosing the Metric accessors
+
+`Metric.Name` scans first-match and stops at field 1. `Metric.Metadata`,
+`MetadataSeq` and `DataPoints` walk what they read. Two consequences when
+reading a consumer's CPU profile:
+
+- **`Name` is cheap and its cost does not track the metric's field count.**
+  A metric path that slows down is not `Name`; look at the datapoint and
+  attribute iteration instead. This is the opposite of the last-value-wins
+  scalars on the containers above, whose cost does grow with the enclosing
+  message.
+- **What `Name` costs depends on where the producer puts the field.** It
+  returns at the first `name` tag, so an SDK exporter emitting ascending field
+  numbers pays almost nothing, while pdata-marshalled bytes put `name` last
+  and make it walk the metric anyway. A benchmark built only from pdata
+  fixtures cannot see the difference between the two resolutions — that is how
+  the regression E-2985 fixed stayed invisible to the benchmark meant to guard
+  it. `BenchmarkMetric_Name_SDKOrder` exists for this reason; keep both arms.
+
+[docs/BENCHMARKS.md](docs/BENCHMARKS.md) carries the figures, with the fixture,
+environment and commands. Do not copy them here.
+
+**Known divergences from pdata.** These matter only to consumers that pair the
+wire path with a pdata fallback and expect the two to agree. Both are reachable
+only on malformed or adversarial input, never on conformant OTLP.
+`TestMetricName_FirstMatchDivergesFromPdata` and
+`TestMetricName_MalformedTrailingFieldNotReported` pin them.
+
+| Input | Wire path | pdata |
+| --- | --- | --- |
+| Repeated `Metric.name` | reports the **first** occurrence | reports the last |
+| Corruption located after the `name` field | `Name` accepts | rejects |
 
 ### The deprecated scope containers (field 1000)
 

--- a/operations.md
+++ b/operations.md
@@ -38,7 +38,7 @@ published one means a consumer version pin.
 | `Resource()` returns `(nil, nil)` for an absent Resource instead of an error | E-2941 | Any consumer treating that error as a signal; not firing in production as of 2026-08-07 |
 | `Resource()` merges repeated occurrences instead of returning the first | E-2941 | Consumers reading resource attributes from multi-occurrence payloads |
 | `Resource()`, `Scope()` and the last-value-wins scalar accessors report corruption located after the last relevant occurrence | E-2941, E-2942 | Consumers that previously parsed such payloads without error |
-| `Metric.Name()` returns the first occurrence of a repeated `name`, where pdata takes the last, and accepts corruption located after the `name` field | E-2985 | Consumers pairing the wire path with a pdata fallback; only reachable on a repeated or malformed `Metric.name` |
+| `Metric.Name()` returns the first occurrence of a repeated `name`, where pdata takes the last, and accepts corruption located anywhere after the `name` field | E-2985 | Consumers pairing the wire path with a pdata fallback. The corruption case is **not** limited to the `name` field: a metric whose datapoint body is truncated now traverses without an error from any accessor, because the enclosing iterators check framing only |
 | Scanning accessors reject an unclosed group in an unknown trailing field, which pdata accepts | E-2942 | Consumers pairing the wire path with a pdata fallback; only reachable on malformed or adversarial input, never on conformant OTLP |
 
 The canary decision and its measured pre/post comparison are recorded at
@@ -176,7 +176,9 @@ only on malformed or adversarial input, never on conformant OTLP.
 | Input | Wire path | pdata |
 | --- | --- | --- |
 | Repeated `Metric.name` | reports the **first** occurrence | reports the last |
-| Corruption located after the `name` field | `Name` accepts | rejects |
+| Corruption anywhere after the `name` field, including inside the datapoint body | `Name` accepts | rejects |
+| Later `name` occurrence carrying a wrong wire type | `Name` accepts, returning the first | rejects |
+| Unclosed group in an unknown field *before* `name` | `Name` rejects | accepts |
 
 ### The deprecated scope containers (field 1000)
 

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -1574,6 +1574,108 @@ func TestMetricName_MalformedTrailingFieldNotReported(t *testing.T) {
 		"pdata decodes the whole metric and rejects the truncated unit")
 }
 
+// TestMetricName_ViewAndAllocationContract pins the aliasing contract every
+// view accessor in this package shares: the result aliases the caller's buffer
+// with a clamped capacity, so a caller appending to it reallocates instead of
+// overwriting the fields that follow.
+func TestMetricName_ViewAndAllocationContract(t *testing.T) {
+	var m Metric
+	m = protowire.AppendTag(m, 1, protowire.BytesType)
+	m = protowire.AppendString(m, "requests")
+	m = protowire.AppendTag(m, 3, protowire.BytesType)
+	m = protowire.AppendString(m, "ms")
+	original := string(m)
+
+	name, err := m.Name()
+	require.NoError(t, err)
+	require.Equal(t, len(name), cap(name), "capacity must be clamped so a caller's append reallocates")
+
+	_ = append(name, ':', 'k')
+	require.Equal(t, original, string(m), "appending to the view must not reach the unit field")
+
+	// A copy would keep the old byte.
+	index := bytes.Index(m, []byte("requests"))
+	require.GreaterOrEqual(t, index, 0)
+	m[index] = 'R'
+	require.Equal(t, []byte("Requests"), name)
+}
+
+// TestMetricName_LeadingUnclosedGroupRejected pins the direction in which
+// first-match resolution is still stricter than pdata. A group before the
+// name field is skipped on the way to it, and this package's skip requires a
+// matching end-group where pdata's does not. A group *after* name is never
+// reached -- TestMetricName_MalformedTrailingFieldNotReported covers that.
+func TestMetricName_LeadingUnclosedGroupRejected(t *testing.T) {
+	var m Metric
+	m = protowire.AppendTag(m, 8, protowire.StartGroupType)
+	m = protowire.AppendTag(m, 6, protowire.Fixed32Type)
+	m = protowire.AppendFixed32(m, 0)
+	m = protowire.AppendTag(m, 1, protowire.BytesType)
+	m = protowire.AppendString(m, "requests")
+
+	_, err := m.Name()
+	require.Error(t, err, "otlp-wire rejects it: group validation is strict")
+
+	req := pmetricotlp.NewExportRequest()
+	require.NoError(t, req.UnmarshalProto(metricsPayloadWithMetric(m)),
+		"pdata tolerates the unclosed group")
+}
+
+// TestMetricName_MalformedFirstOccurrence covers the error branches first-match
+// resolution still reaches. Corruption at or before the name field is reported;
+// only corruption behind it is not.
+func TestMetricName_MalformedFirstOccurrence(t *testing.T) {
+	t.Run("wrong wire type", func(t *testing.T) {
+		var m Metric
+		m = protowire.AppendTag(m, 1, protowire.VarintType)
+		m = protowire.AppendVarint(m, 7)
+
+		_, err := m.Name()
+		require.Error(t, err)
+	})
+
+	t.Run("truncated length prefix", func(t *testing.T) {
+		var m Metric
+		m = protowire.AppendTag(m, 1, protowire.BytesType)
+		m = protowire.AppendVarint(m, 64) // declares more than it carries
+		m = append(m, "requests"...)
+
+		_, err := m.Name()
+		require.Error(t, err)
+	})
+
+	t.Run("malformed field before name", func(t *testing.T) {
+		var m Metric
+		m = protowire.AppendTag(m, 3, protowire.BytesType)
+		m = protowire.AppendVarint(m, 64) // declares more than it carries
+		m = protowire.AppendTag(m, 1, protowire.BytesType)
+		m = protowire.AppendString(m, "requests")
+
+		_, err := m.Name()
+		require.Error(t, err)
+	})
+}
+
+// TestMetricName_LaterOccurrenceWrongWireTypeAccepted pins the widened
+// acceptance first-match brings: a second name occurrence is never examined,
+// so its wire type is never validated. pdata decodes the whole metric and
+// rejects it.
+func TestMetricName_LaterOccurrenceWrongWireTypeAccepted(t *testing.T) {
+	var m Metric
+	m = protowire.AppendTag(m, 1, protowire.BytesType)
+	m = protowire.AppendString(m, "first")
+	m = protowire.AppendTag(m, 1, protowire.VarintType)
+	m = protowire.AppendVarint(m, 7)
+
+	name, err := m.Name()
+	require.NoError(t, err)
+	require.Equal(t, "first", string(name))
+
+	req := pmetricotlp.NewExportRequest()
+	require.Error(t, req.UnmarshalProto(metricsPayloadWithMetric(m)),
+		"pdata rejects the wrong wire type on the second occurrence")
+}
+
 // buildAllTypesMetrics builds one metric of each of the five types, each
 // with two datapoints carrying attributes {"method":"GET","status":"200"}
 // and timestamp 1000000000.

--- a/otlpwire_test.go
+++ b/otlpwire_test.go
@@ -1488,10 +1488,14 @@ func TestMetricName_Absent(t *testing.T) {
 	require.Nil(t, name)
 }
 
-// TestMetricName_LastValueWins covers the E-2942 change from first-match to
-// protobuf singular-scalar semantics. pdata assigns on each occurrence, so the
-// last one wins; the previous first-match behavior diverged.
-func TestMetricName_LastValueWins(t *testing.T) {
+// TestMetricName_FirstMatchDivergesFromPdata pins the E-2985 divergence.
+// pdata assigns on each occurrence, so a repeated name resolves to the last
+// one there; Name scans first-match and returns the first. The divergence is
+// deliberate -- reaching the last occurrence means walking every metric to its
+// end, which a conformant producer never makes necessary. See the "Singular
+// scalars" section of docs/DESIGN.md and the deviation table in
+// operations.md.
+func TestMetricName_FirstMatchDivergesFromPdata(t *testing.T) {
 	var m Metric
 	m = protowire.AppendTag(m, 1, protowire.BytesType)
 	m = protowire.AppendString(m, "first")
@@ -1502,25 +1506,20 @@ func TestMetricName_LastValueWins(t *testing.T) {
 
 	name, err := m.Name()
 	require.NoError(t, err)
-	require.Equal(t, "second", string(name))
+	require.Equal(t, "first", string(name), "otlp-wire returns the first occurrence")
 
-	// pdata is the oracle: wrap the metric into a full request and compare.
-	sm := protowire.AppendTag(nil, 2, protowire.BytesType)
-	sm = protowire.AppendVarint(sm, uint64(len(m)))
-	sm = append(sm, m...)
-	rm := protowire.AppendTag(nil, 2, protowire.BytesType)
-	rm = protowire.AppendVarint(rm, uint64(len(sm)))
-	rm = append(rm, sm...)
-
+	// pdata is the oracle for what we are diverging from: wrap the metric into
+	// a full request and show it resolves the other way.
 	req := pmetricotlp.NewExportRequest()
-	require.NoError(t, req.UnmarshalProto(wrapAsRequest(rm)))
+	require.NoError(t, req.UnmarshalProto(metricsPayloadWithMetric(m)))
 	require.Equal(t, "second",
-		req.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+		req.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name(),
+		"pdata resolves the same bytes to the last occurrence")
 }
 
-// TestMetricName_UnclosedGroupIsStricterThanPdata pins the one direction in
-// which the widened scan disagrees with pdata. protowire's field skip requires
-// a start-group to have its matching end-group; pdata's unknown-field skip
+// TestSchemaUrl_UnclosedGroupIsStricterThanPdata pins the one direction in
+// which a full scan disagrees with pdata. protowire's field skip requires a
+// start-group to have its matching end-group; pdata's unknown-field skip
 // returns as soon as it consumes a non-group wire type, even inside an
 // unclosed group. So this payload is an error here and accepted there.
 //
@@ -1528,43 +1527,51 @@ func TestMetricName_LastValueWins(t *testing.T) {
 // "Instrumentation scope and schema URL" section of docs/specification.md).
 // Groups are proto2-only and OTLP never emits them. This test exists so the
 // behavior cannot change silently.
-func TestMetricName_UnclosedGroupIsStricterThanPdata(t *testing.T) {
-	var m Metric
-	m = protowire.AppendTag(m, 1, protowire.BytesType)
-	m = protowire.AppendString(m, "requests")
+//
+// It covers ScopeMetrics.SchemaUrl rather than Metric.Name: since E-2985 Name
+// scans first-match and stops before any trailing corruption, so the accessors
+// that still walk to the end of the message are the ones that carry this
+// behavior.
+func TestSchemaUrl_UnclosedGroupIsStricterThanPdata(t *testing.T) {
+	var sm ScopeMetrics
+	sm = protowire.AppendTag(sm, 3, protowire.BytesType)
+	sm = protowire.AppendString(sm, "https://example.com/schema")
 	// Unknown field 8 as a start-group holding a fixed32, with no end-group.
-	m = protowire.AppendTag(m, 8, protowire.StartGroupType)
-	m = protowire.AppendTag(m, 6, protowire.Fixed32Type)
-	m = protowire.AppendFixed32(m, 0)
-
-	sm := protowire.AppendTag(nil, 2, protowire.BytesType)
-	sm = protowire.AppendVarint(sm, uint64(len(m)))
-	sm = append(sm, m...)
-	rm := protowire.AppendTag(nil, 2, protowire.BytesType)
-	rm = protowire.AppendVarint(rm, uint64(len(sm)))
-	rm = append(rm, sm...)
+	sm = protowire.AppendTag(sm, 8, protowire.StartGroupType)
+	sm = protowire.AppendTag(sm, 6, protowire.Fixed32Type)
+	sm = protowire.AppendFixed32(sm, 0)
 
 	req := pmetricotlp.NewExportRequest()
-	require.NoError(t, req.UnmarshalProto(wrapAsRequest(rm)),
+	require.NoError(t, req.UnmarshalProto(wrapAsRequest(resourceContainerWithScope(sm))),
 		"pdata tolerates the unclosed group")
-	require.Equal(t, "requests",
-		req.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+	require.Equal(t, "https://example.com/schema",
+		req.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).SchemaUrl())
 
-	_, err := m.Name()
+	_, err := sm.SchemaUrl()
 	require.Error(t, err, "otlp-wire rejects it: group validation is strict")
 }
 
-// TestMetricName_MalformedTrailingField pins the validation-scope consequence
-// of the full scan: corruption after the last name occurrence is now reported.
-func TestMetricName_MalformedTrailingField(t *testing.T) {
+// TestMetricName_MalformedTrailingFieldNotReported pins the validation-scope
+// consequence of first-match: Name returns at field 1 and never reaches the
+// corruption behind it, so these bytes are valid here and rejected by pdata,
+// which decodes the whole message. This is the narrower validity claim
+// E-2985 accepted in exchange for the early return; accessors that still walk
+// the message keep reporting trailing corruption, as
+// TestResource_MalformedTrailingFieldAfterResource covers.
+func TestMetricName_MalformedTrailingFieldNotReported(t *testing.T) {
 	var m Metric
 	m = protowire.AppendTag(m, 1, protowire.BytesType)
 	m = protowire.AppendString(m, "requests")
 	m = protowire.AppendTag(m, 3, protowire.BytesType)
 	m = protowire.AppendVarint(m, 64) // declares more than it carries
 
-	_, err := m.Name()
-	require.Error(t, err)
+	name, err := m.Name()
+	require.NoError(t, err)
+	require.Equal(t, "requests", string(name))
+
+	req := pmetricotlp.NewExportRequest()
+	require.Error(t, req.UnmarshalProto(metricsPayloadWithMetric(m)),
+		"pdata decodes the whole metric and rejects the truncated unit")
 }
 
 // buildAllTypesMetrics builds one metric of each of the five types, each

--- a/wire.go
+++ b/wire.go
@@ -274,7 +274,9 @@ func extractMergedMessage(data []byte, fieldNum protowire.Number) ([]byte, error
 
 // extractBytesField extracts the first occurrence of a length-delimited
 // field from protobuf data. Returns nil (not an error) if absent.
-// The returned slice aliases data; no copy is made.
+// The returned slice aliases data with its capacity clamped to its length;
+// no copy is made. It stops at the first match, so corruption located after
+// that occurrence is not reported.
 func extractBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
 	pos := 0
 
@@ -293,7 +295,10 @@ func extractBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
 			if n < 0 {
 				return nil, errors.New("invalid bytes in field")
 			}
-			return msgBytes, nil
+			// ConsumeBytes hands back a slice whose capacity runs to the end
+			// of the enclosing buffer. Clamp it so a caller appending to the
+			// returned view cannot overwrite the fields that follow.
+			return msgBytes[:len(msgBytes):len(msgBytes)], nil
 		}
 
 		n := skipField(data[pos:], num, wireType)


### PR DESCRIPTION
## Motivation

`Metric.Name()` resolves singular-scalar `name` last-value-wins (E-2942), which
means walking to the end of every metric to prove no later occurrence exists.
E-2985 reported that as a regression in marigold, whose payloads come from a
Prometheus receiver and whose throughput has an operational floor (E-2902).

Last-value-wins is what pdata does, so this is not a parity fix — it is a
deliberate divergence, taken on the same reasoning E-2945 already applied to
`Span.TraceID`/`SpanID`/`ParentSpanID`: a conformant producer emits `name`
once, so first-match and last-value-wins return the same answer on all
conformant traffic, and the walk costs that traffic to change behavior only
malformed traffic can exhibit.

## Approach

`Metric.Name` moves to `extractBytesField`. `SchemaUrl`,
`InstrumentationScope.Name` and `Version` keep last-value-wins.

Two things surfaced while measuring, both recorded in docs/BENCHMARKS.md:

1. **The existing benchmark could not observe this.** pdata's `ProtoMarshaler`
   emits a `Metric` as `[5 1]` -- body, then `name` last -- so first-match had
   to walk the whole metric anyway on that fixture. `BenchmarkMetric_Name_SDKOrder`
   builds the ascending order stock protobuf runtimes and the OTLP SDK
   exporters emit, with `protowire`, because pdata cannot produce it. Both arms
   are kept.
2. **The pdata-order arm barely moves, and that is expected.** Where `name` is
   emitted last, first-match and last-value-wins traverse the same bytes. The
   payload-level pdata arm shows -9%, but its ranges overlap, so it is
   suggestive rather than established -- any real residual is
   `extractLastBytesField` reaching its occurrence through a closure where
   `extractBytesField` runs a flat loop. The remaining last-value-wins
   accessors still pay that; isolating it needs its own benchmark and is not
   addressed here.

## Validation

```bash
go build ./...
go vet ./...
go test -race -shuffle=on -count=1 ./...
git diff --check
go test -run '^$' -bench 'BenchmarkMetric_Name' -benchmem -count=6 ./...
```

All pass. `go mod tidy -diff` reports the go.sum baseline drift CONTRIBUTING.md
documents; go.mod/go.sum are untouched by this PR.

**Benchmarks** (Apple M5, darwin/arm64, Go 1.26.6). Two prebuilt binaries
differing only in `Metric.Name`'s body, alternated for 6 rounds rather than run
as consecutive blocks; medians of 6.

| Benchmark | before | after | change |
|---|---:|---:|---:|
| accessor, SDK order (`name` first) | 26.9 ns | 4.2 ns | **−84%** |
| accessor, pdata order (`name` last) | 25.9 ns | 25.7 ns | none |
| `BenchmarkMetric_Name` (4800 metrics, pdata order) | 69.4 µs | 63.0 µs | −9%, ranges overlap |
| `BenchmarkMetric_Name_SDKOrder` (4800 metrics) | 70.8 µs | 41.7 µs | **−41%** |

The SDK-order ranges are cleanly separated (67.8–72.2 µs vs 40.2–45.9 µs). The
pdata-order ones are not (67.2–71.0 µs vs 61.2–67.3 µs) and are reported as
suggestive in docs/BENCHMARKS.md rather than claimed as a win.

Allocations unchanged: accessor 0 B/op 0 allocs/op, payload arms 112 B/op
6 allocs/op (the iterators, not the accessor).

## Risks

- **API compatibility:** signature unchanged. Behavior changes only for a
  repeated `Metric.name`, and only for consumers who upgraded through v0.2.x.
- **Correctness / pdata parity:** two deliberate divergences, both pinned by
  test and recorded in operations.md -- a repeated `name` resolves to the first
  occurrence, and corruption located after the `name` field is accepted where
  pdata rejects it. `Metric` now carries two parser classes the way `Span`
  does.
- **Test coverage moved, not dropped:** the unclosed-group strictness pin moved
  from `Metric.Name` to `ScopeMetrics.SchemaUrl`, since `Name` no longer
  reaches a trailing unknown field. That divergence still applies to every
  accessor that walks.
- **Allocation:** none.
- **Rollout:** library only; no deployment. Consumer validation (marigold)
  is separate work.

## Docs

docs/DESIGN.md, docs/specification.md, docs/BENCHMARKS.md, operations.md
(new "Diagnosing the Metric accessors" section with the pdata divergence
table), README.md and AGENTS.md updated.

Closes E-2985.

---

Agent involvement: implemented with Claude Code; benchmarks, gates and the
pdata field-order claims were measured on this machine, not asserted.
