### PR TITLE
feat(logs): add field-scoped severity lookup [E-2935]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,13 +121,13 @@ accessors, alongside the per-message schema walks `parseLogRecordSeverity` and
   where a real SDK exporter puts them first.
 - Walk *depth* is a separate decision from walk *sharing*. Descend only into
   nested messages a consumer of that accessor reads next: `parseSpanFields` is
-  framing-only below the Span level, where `parseLogRecordSeverity` parses the
-  body and attributes because severity consumers read them. A shallower walk
-  means a narrower validity claim than pdata's — pin the resulting divergences
-  in a test.
-- Malformed tags, lengths, wire types, identifiers, metric bodies, or nested
-  messages must return parse errors. Never silently accept corruption to keep
-  an iterator moving.
+  framing-only below the Span level, while `parseLogRecordSeverity` parses the
+  body and attributes in strict mode. A shallower walk means a narrower validity
+  claim than pdata's — pin the resulting divergences in a test.
+- Malformed input inside the documented validation depth must return a parse
+  error. A field-scoped operation may treat unrelated nested messages as opaque
+  only when its narrower validity claim is explicit and pinned by tests. Never
+  silently accept corruption to keep an iterator moving.
 - `WriteTo` reconstructs the enclosing repeated-field message without a full
   unmarshal. Preserve byte-level output semantics and short-write/error
   propagation.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ ExportLogsServiceRequest (OTLP message bytes)
             └─ LogRecord[]
                  ├─ SeverityNumber()
                  ├─ SeverityText()
-                 └─ Severity()      (both fields, one walk)
+                 ├─ Severity()       (both fields, strict nested validation)
+                 └─ SeverityFields() (both fields, top-level validation)
 
 ExportTracesServiceRequest (OTLP message bytes)
   └─ ResourceSpans[] (one per resource)
@@ -283,6 +284,7 @@ type LogRecord []byte
 func (r LogRecord) SeverityNumber() (int32, error)
 func (r LogRecord) SeverityText() ([]byte, error)
 func (r LogRecord) Severity() (int32, []byte, error) // both fields, one walk
+func (r LogRecord) SeverityFields() (int32, []byte, error) // skips nested body/attribute validation
 
 type Resource []byte
 func (r Resource) Attributes() (iter.Seq[KeyValue], func() error)
@@ -304,6 +306,10 @@ both fields — the single-field pair costs a measured ~1.9x
 described above for each field. Ranking them is consumer policy: the library
 does not classify severity bands, nor decide which field wins when the number
 and the text disagree.
+
+`LogRecord.SeverityFields` shares that top-level walk and field resolution but
+does not recursively validate body or attribute contents. It is the scoped
+operation for detectors that do not consume those nested values next.
 
 `Resource.StringAttribute` is zero-copy and returns a separate `found` value,
 so a missing resource attribute can be distinguished from a present empty

--- a/benchmark_comparison_test.go
+++ b/benchmark_comparison_test.go
@@ -1622,6 +1622,24 @@ func BenchmarkLogRecord_Severity(b *testing.B) {
 	}
 }
 
+func BenchmarkLogRecord_SeverityFields(b *testing.B) {
+	payload := benchSeverityTextPayload(b)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		total := 0
+		forEachBenchLogRecord(b, payload, func(record LogRecord) {
+			number, text, err := record.SeverityFields()
+			if err != nil {
+				b.Fatal(err)
+			}
+			total += int(number) + len(text)
+		})
+		benchSeveritySink = total
+	}
+}
+
 // ========== Span field accessors: overstory's internal-spans detector ==========
 
 // benchSpanFieldsSink prevents the internal-span analysis from being optimized

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -691,6 +691,36 @@ severity read; every arm pays the same. A consumer that wants a
 `string` rather than a view pays for that conversion at its own call site,
 which is where the allocation belongs.
 
+### Field-scoped severity lookup
+
+`SeverityFields` keeps the complete top-level walk but skips recursive body and
+attribute validation. The fixture is the same 5 resources × 100 records used
+above. This comparison ran on an Apple M5, darwin/arm64, Go 1.26.6, using one
+prebuilt binary and 15 alternating 3,000-iteration rounds:
+
+```bash
+go test -c -o /tmp/otlpwire.test .
+for round in $(seq 1 15); do
+  for arm in Severity SeverityFields; do
+    /tmp/otlpwire.test -test.run '^$' -test.benchmem -test.benchtime=3000x \
+      -test.bench "^BenchmarkLogRecord_${arm}\$"
+  done
+done
+```
+
+| Benchmark | validation depth | ns/op (median of 15) | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| `BenchmarkLogRecord_Severity` | nested body and attributes | 36,859 | 368 | 14 |
+| `BenchmarkLogRecord_SeverityFields` | top-level record | 17,948 | 368 | 14 |
+
+The field-scoped operation was **51.2% faster at the paired median and faster
+in all 15 rounds**; paired deltas ranged from −55.6% to −46.9%. Allocations are
+unchanged and belong to the enclosing iterators; both accessors are themselves
+zero-allocation. A separate 15-round merge-base-versus-candidate comparison of
+the existing strict `Severity` path found no regression: the paired median was
+−0.4%, with the candidate faster in 9 of 15 noisy rounds and unchanged
+allocations.
+
 ## Span field accessors (E-2945)
 
 **Environment for every measurement in this section:** 11th Gen Intel Core

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -168,6 +168,14 @@ machinery, since the walk already produced both values, and all three accessors
 share it, so none of them can disagree with another about whether a record is
 valid.
 
+`SeverityFields` uses the same top-level parser and field resolution with a
+narrower depth contract. It validates the complete LogRecord framing and each
+known top-level wire type, but skips semantic parsing inside body and attribute
+messages. This keeps the operation centralized in otlp-wire without making a
+detector that reads only severity pay for unrelated nested values. The strict
+three-accessor contract remains unchanged, and tests pin the intentional
+validity divergence for malformed nested contents.
+
 Severity *classification* stays out of the library. Bands and number/text
 precedence are consumer policy, and nothing in the consumer audit argues
 otherwise. `Severity` returns the raw wire fields; deciding which one wins when
@@ -210,15 +218,12 @@ the divergence risk in [operations.md](../operations.md), taken knowingly here
 rather than engineered away, and pinned by
 `TestSpanIdentifiers_FirstMatchDivergence` so it cannot drift unnoticed.
 
-**The walk is framing-only below the Span level.** It checks the wire type and
-containment of `attributes`, `events`, `links` and `status` without parsing
-their contents, where the LogRecord walk does descend into the body and every
-attribute. The discriminator is what the accessor's own consumer reads next: a
-severity consumer reads the record's attributes, and sage's parity requirement
-made validating them load-bearing, whereas none of the Span fields this package
-exposes depends on a span's attributes, events or links. Descending anyway
-would tie every scalar accessor's cost to a span's event and attribute count
-for no accessor's benefit.
+**Validation depth follows the operation's contract.** The Span walk checks the
+wire type and containment of `attributes`, `events`, `links` and `status`
+without parsing their contents. The strict LogRecord severity accessors descend
+into body and attributes; `SeverityFields` treats them as opaque because its
+consumers read neither. Descending into unrelated values would tie every scalar
+lookup's cost to nested content it does not return.
 
 The cost is a narrower validity claim than pdata's: malformed *contents* inside
 a correctly framed `attributes`, `events`, `links` or `status` are accepted here

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -403,6 +403,12 @@ two walks where `Severity` costs one.
 All three severity accessors read from one schema-aware walk of the whole
 LogRecord, so they accept and reject exactly the same bytes.
 
+`LogRecord.SeverityFields` returns the same pair with the same last-value-wins,
+aliasing, nil, and empty-value contracts. It validates every known top-level
+LogRecord field and complete message framing, but treats body and attribute
+messages as opaque length-delimited values. Malformed contents inside those
+nested values are therefore outside this operation's validity claim.
+
 The library does not classify severity bands, and `Severity` returning the two
 fields together does not rank them: which one wins when the number and the text
 disagree remains consumer policy.

--- a/log_iteration_test.go
+++ b/log_iteration_test.go
@@ -245,6 +245,11 @@ func TestLogRecordSeverity_MatchesPdataAndSingleAccessors(t *testing.T) {
 			// express. The expected values rely on that.
 			require.Equal(t, tt.expectedText, text)
 
+			fieldNumber, fieldText, err := record.SeverityFields()
+			require.NoError(t, err)
+			require.Equal(t, number, fieldNumber)
+			require.Equal(t, text, fieldText)
+
 			singleNumber, err := record.SeverityNumber()
 			require.NoError(t, err)
 			singleText, err := record.SeverityText()
@@ -255,6 +260,71 @@ func TestLogRecordSeverity_MatchesPdataAndSingleAccessors(t *testing.T) {
 			pdataNumber, pdataText := pdataSeverity(t, tt.record)
 			require.Equal(t, tt.expectedNumber, pdataNumber)
 			require.Equal(t, string(tt.expectedText), pdataText)
+		})
+	}
+}
+
+func TestLogRecordSeverityFields_ValidationScope(t *testing.T) {
+	severity := slices.Concat(
+		severityNumberField(plog.SeverityNumberInfo),
+		severityTextField("INFO"),
+	)
+
+	tests := []struct {
+		name   string
+		record LogRecord
+	}{
+		{
+			name:   "malformed body contents",
+			record: slices.Concat(severity, []byte{0x2a, 0x02, 0x0a, 0x80}),
+		},
+		{
+			name:   "malformed attribute contents",
+			record: slices.Concat(severity, []byte{0x32, 0x02, 0x08, 0x01}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			number, text, err := tt.record.SeverityFields()
+			require.NoError(t, err)
+			require.Equal(t, int32(plog.SeverityNumberInfo), number)
+			require.Equal(t, []byte("INFO"), text)
+
+			_, _, err = tt.record.Severity()
+			require.Error(t, err, "Severity retains nested-message validation")
+		})
+	}
+
+}
+
+func TestLogRecordSeverityFields_TopLevelValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		record LogRecord
+	}{
+		{name: "malformed tag", record: LogRecord{0x80}},
+		{name: "time wrong wire type", record: LogRecord{0x0a, 0x01, 0x00}},
+		{name: "observed time wrong wire type", record: LogRecord{0x5a, 0x01, 0x00}},
+		{name: "severity number wrong wire type", record: LogRecord{0x12, 0x01, 0x00}},
+		{name: "severity text wrong wire type", record: LogRecord{0x18, 0x01}},
+		{name: "event name wrong wire type", record: LogRecord{0x60, 0x01}},
+		{name: "body wrong wire type", record: LogRecord{0x28, 0x01}},
+		{name: "body truncated", record: LogRecord{0x2a, 0x02, 0x00}},
+		{name: "attribute wrong wire type", record: LogRecord{0x30, 0x01}},
+		{name: "attribute truncated", record: LogRecord{0x32, 0x02, 0x00}},
+		{name: "dropped attributes wrong wire type", record: LogRecord{0x3a, 0x01, 0x00}},
+		{name: "flags wrong wire type", record: LogRecord{0x40, 0x01}},
+		{name: "trace id wrong wire type", record: LogRecord{0x48, 0x01}},
+		{name: "trace id wrong size", record: LogRecord{0x4a, 0x01, 0x00}},
+		{name: "span id wrong wire type", record: LogRecord{0x50, 0x01}},
+		{name: "span id wrong size", record: LogRecord{0x52, 0x01, 0x00}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := tt.record.SeverityFields()
+			require.Error(t, err)
 		})
 	}
 }
@@ -409,6 +479,10 @@ func TestLogRecordSeverity_ViewAndAllocationContract(t *testing.T) {
 	require.Equal(t, int32(plog.SeverityNumberInfo), number)
 	require.Equal(t, len(text), cap(text), "capacity must be clamped so a caller's append reallocates")
 	require.Equal(t, len(combinedText), cap(combinedText), "capacity must be clamped so a caller's append reallocates")
+	fieldNumber, fieldText, err := record.SeverityFields()
+	require.NoError(t, err)
+	require.Equal(t, number, fieldNumber)
+	require.Equal(t, len(fieldText), cap(fieldText), "capacity must be clamped so a caller's append reallocates")
 
 	require.Equal(t, "INFOoverwritten", string(append(text, "overwritten"...)))
 	require.Equal(t, "INFOoverwritten", string(append(combinedText, "overwritten"...)))
@@ -420,6 +494,7 @@ func TestLogRecordSeverity_ViewAndAllocationContract(t *testing.T) {
 	record[index] = 'i'
 	require.Equal(t, []byte("iNFO"), text)
 	require.Equal(t, []byte("iNFO"), combinedText)
+	require.Equal(t, []byte("iNFO"), fieldText)
 
 	allocations := testing.AllocsPerRun(100, func() {
 		got, err := record.SeverityText()
@@ -433,6 +508,14 @@ func TestLogRecordSeverity_ViewAndAllocationContract(t *testing.T) {
 		number, got, err := record.Severity()
 		if err != nil || number != int32(plog.SeverityNumberInfo) || len(got) == 0 {
 			t.Fatal("unexpected severity result")
+		}
+	})
+	require.Zero(t, allocations)
+
+	allocations = testing.AllocsPerRun(100, func() {
+		number, got, err := record.SeverityFields()
+		if err != nil || number != int32(plog.SeverityNumberInfo) || len(got) == 0 {
+			t.Fatal("unexpected severity fields result")
 		}
 	})
 	require.Zero(t, allocations)

--- a/logs.go
+++ b/logs.go
@@ -146,7 +146,7 @@ func (s ScopeLogs) LogRecordsSeq(yield func(LogRecord, error) bool) {
 // the positive OTLP severity ranges. Use Severity to read both severity fields
 // from one walk.
 func (r LogRecord) SeverityNumber() (int32, error) {
-	number, _, err := parseLogRecordSeverity([]byte(r))
+	number, _, err := parseLogRecordSeverity([]byte(r), true)
 	return number, err
 }
 
@@ -159,7 +159,7 @@ func (r LogRecord) SeverityNumber() (int32, error) {
 // the whole LogRecord, so an early severity_text cannot conceal corruption
 // that follows it. Use Severity to read both severity fields from one walk.
 func (r LogRecord) SeverityText() ([]byte, error) {
-	_, text, err := parseLogRecordSeverity([]byte(r))
+	_, text, err := parseLogRecordSeverity([]byte(r), true)
 	return text, err
 }
 
@@ -172,7 +172,18 @@ func (r LogRecord) SeverityText() ([]byte, error) {
 // These are the raw wire fields. Classifying them into severity bands, and
 // deciding which one wins when they disagree, stay consumer policy.
 func (r LogRecord) Severity() (int32, []byte, error) {
-	return parseLogRecordSeverity([]byte(r))
+	return parseLogRecordSeverity([]byte(r), true)
+}
+
+// SeverityFields returns severity_number (field 2) and severity_text (field 3)
+// while validating the complete top-level LogRecord framing. Unlike Severity,
+// it does not validate the contents of body or attribute messages. Use this
+// operation when those unrelated nested values are not consumed next.
+//
+// Repeated severity fields resolve to the last occurrence. The returned text
+// has the same aliasing, nil, empty, and capacity contracts as SeverityText.
+func (r LogRecord) SeverityFields() (int32, []byte, error) {
+	return parseLogRecordSeverity([]byte(r), false)
 }
 
 // countLogRecords counts the number of log records in an OTLP
@@ -196,13 +207,11 @@ func countInScopeLogs(data []byte) (int, error) {
 	return countOccurrences(data, 2)
 }
 
-// parseLogRecordSeverity validates every known LogRecord field in pdata v1.64.0
-// while extracting severity_number and severity_text with protobuf
-// last-value-wins scalar semantics. This is intentionally schema-aware: an
-// early valid severity cannot conceal a malformed body, attribute, timestamp,
-// identifier, or trailing known field. Both severity accessors share the walk
-// so neither can drift from the other's malformed-input behavior.
-func parseLogRecordSeverity(data []byte) (int32, []byte, error) {
+// parseLogRecordSeverity walks every known top-level LogRecord field while
+// extracting severity_number and severity_text with protobuf last-value-wins
+// scalar semantics. validateNested additionally validates body and attribute
+// contents for the strict severity accessors.
+func parseLogRecordSeverity(data []byte, validateNested bool) (int32, []byte, error) {
 	pos := 0
 	var number int32
 	var text []byte
@@ -256,8 +265,10 @@ func parseLogRecordSeverity(data []byte) (int32, []byte, error) {
 			if n < 0 {
 				return 0, nil, errors.New("invalid bytes in log record body")
 			}
-			if err := parseAnyValue(body, &parsedAnyValue{}); err != nil {
-				return 0, nil, err
+			if validateNested {
+				if err := parseAnyValue(body, &parsedAnyValue{}); err != nil {
+					return 0, nil, err
+				}
 			}
 			pos += n
 		case 6: // attributes
@@ -268,8 +279,10 @@ func parseLogRecordSeverity(data []byte) (int32, []byte, error) {
 			if n < 0 {
 				return 0, nil, errors.New("invalid bytes in log record attributes")
 			}
-			if _, _, _, err := parseKeyValue(attribute); err != nil {
-				return 0, nil, err
+			if validateNested {
+				if _, _, _, err := parseKeyValue(attribute); err != nil {
+					return 0, nil, err
+				}
 			}
 			pos += n
 		case 7: // dropped_attributes_count

--- a/operations.md
+++ b/operations.md
@@ -70,11 +70,21 @@ valid. Two consequences when reading a consumer's CPU profile:
   per-record cost but do not show how it scales with body and attribute
   volume; a consumer suspecting that scaling should measure its own payloads.
 
+`SeverityFields` is the field-scoped alternative for consumers that read only
+the two severity fields. It shares the same complete top-level walk and
+last-value-wins resolution, while treating body and attribute messages as
+opaque length-delimited values. It still rejects malformed record framing,
+wrong top-level wire types, and truncated nested values, but accepts malformed
+contents inside a correctly framed body or attribute. Use the strict accessors
+when those nested values are consumed next or full-record validation is part of
+the caller's contract. `TestLogRecordSeverityFields_ValidationScope` pins this
+boundary.
+
 **Known divergences from pdata.** These matter only to consumers that pair the
-wire path with a pdata fallback and expect the two to agree on validity. All
-are reachable only on malformed or adversarial input, never on conformant OTLP
-from a normal producer, and none is specific to one accessor — they are
-properties of the shared LogRecord walk. `TestLogRecordSeverity_PdataDivergence`
+strict accessors with a pdata fallback and expect the two to agree on validity.
+All are reachable only on malformed or adversarial input, never on conformant
+OTLP from a normal producer, and none is specific to one strict accessor — they
+are properties of the strict LogRecord walk. `TestLogRecordSeverity_PdataDivergence`
 pins each one, so a change in either direction shows up as a test failure
 rather than as silently different consumer behavior.
 


### PR DESCRIPTION
## Summary

- add `LogRecord.SeverityFields` for callers that need severity fields without recursively validating unrelated body and attribute contents
- keep `Severity`, `SeverityNumber`, and `SeverityText` strict and behaviorally unchanged
- pin top-level framing/type/identifier validation, nested-validation scope, last-value-wins, aliasing, and zero-allocation contracts
- document the API, design, operational boundary, and paired benchmark

Closes #41

## Validation

- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- focused `TestLogRecordSeverityFields` suite
- `git diff --check origin/main`
- 15 alternating paired benchmark rounds: `SeverityFields` 51.2% faster at paired median, faster in 15/15 rounds, allocations unchanged
- merge-base versus candidate strict `Severity`: no regression (paired median -0.4%, noisy sign 9/15)

## Compatibility and risk

Additive API. Existing strict accessors are unchanged. The new operation deliberately accepts malformed contents inside correctly framed body and attribute messages; it still validates complete top-level framing, every known top-level wire type, and identifier sizes. This narrower validity claim is opt-in and pinned by tests.

## Rollout

Release the reviewed merge commit, then upgrade Sage to call the field-scoped operation. Preserve Sage transport, fallback, detection, publish, and acknowledgement behavior and validate its malformed-input boundary plus both benchmark shapes before rollout.