### PR TITLE
feat(attributes): expose combined KeyValue fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ func (d DataPoint) AttributesSeq(yield func(KeyValue, error) bool)   // zero-all
 type KeyValue []byte
 func (kv KeyValue) Key() ([]byte, error)
 func (kv KeyValue) ValueRaw() ([]byte, error)
+func (kv KeyValue) Fields() (key, valueRaw []byte, err error)
 func (kv KeyValue) StringValue() ([]byte, bool, error)
 
 type MetricType int
@@ -359,11 +360,12 @@ resolving them the other way costs a full message walk on every conformant
 payload.
 [docs/DESIGN.md](docs/DESIGN.md) explains why.
 
-`KeyValue.ValueRaw` remains a lightweight view of the first encoded AnyValue
-field for hashing-oriented hot paths. `KeyValue.StringValue` fully parses
-AnyValue and follows protobuf oneof behavior, so a later non-string oneof
-member makes `StringValue` report `found=false` even if an earlier encoded
-member was a string.
+`KeyValue.Fields` returns the first encoded key and AnyValue fields in one
+lightweight scan for hashing-oriented hot paths. `Key` and `ValueRaw` expose
+the same views independently. `KeyValue.StringValue` fully parses AnyValue
+and follows protobuf oneof behavior, so a later non-string oneof member makes
+`StringValue` report `found=false` even if an earlier encoded member was a
+string.
 
 `DataPoint` carries its `MetricType` because the attribute field number differs
 per data point wire type (histograms and exponential histograms encode

--- a/README.md
+++ b/README.md
@@ -360,10 +360,11 @@ resolving them the other way costs a full message walk on every conformant
 payload.
 [docs/DESIGN.md](docs/DESIGN.md) explains why.
 
-`KeyValue.Fields` returns the first encoded key and AnyValue fields in one
-lightweight scan for hashing-oriented hot paths. `Key` and `ValueRaw` expose
-the same views independently. `KeyValue.StringValue` fully parses AnyValue
-and follows protobuf oneof behavior, so a later non-string oneof member makes
+`KeyValue.Fields` returns the first encoded key and raw AnyValue message bytes
+as zero-copy views in one lightweight scan for hashing-oriented hot paths. It
+returns nil independently for each absent field. `Key` and `ValueRaw` expose
+the same views separately. `KeyValue.StringValue` fully parses AnyValue and
+follows protobuf oneof behavior, so a later non-string oneof member makes
 `StringValue` report `found=false` even if an earlier encoded member was a
 string.
 

--- a/attributes.go
+++ b/attributes.go
@@ -20,6 +20,13 @@ func (kv KeyValue) ValueRaw() ([]byte, error) {
 	return extractBytesField([]byte(kv), 2)
 }
 
+// Fields returns the attribute key and raw AnyValue message bytes as views
+// into the underlying buffer. It resolves both fields in one scan with the
+// same first-match behavior as calling Key followed by ValueRaw.
+func (kv KeyValue) Fields() (key, valueRaw []byte, err error) {
+	return extractBytesFields([]byte(kv), 1, 2)
+}
+
 // StringValue returns the string value in the KeyValue's AnyValue, if it has
 // one. The bool reports whether a string value was present; an empty string is
 // present and is returned as a non-nil, zero-length slice. The returned slice

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -823,6 +823,38 @@ actually takes.
 Drop the hand-rolled arm and this subsection once overstory moves to the Span
 accessors.
 
+## KeyValue combined field access (E-3340)
+
+Marigold hashes every metric metadata entry and datapoint attribute from both
+the `KeyValue.key` and raw `KeyValue.value` fields. Calling `Key` followed by
+`ValueRaw` walks the same envelope twice; `Fields` resolves the same two
+first-match views in one walk.
+
+**Environment:** Apple M5, darwin/arm64, Go 1.26.6.
+
+**Fixture:** one KeyValue containing a 27-byte key followed by a string-valued
+AnyValue. Both arms return capacity-clamped, zero-copy views and write their
+lengths to the same package-level sink.
+
+**Method:** one prebuilt test binary, six alternating 1-second rounds. Medians
+of six:
+
+```bash
+go test -c -o keyvalue-fields.test .
+for round in 1 2 3 4 5 6; do
+  ./keyvalue-fields.test -test.run '^$' -test.bench '^BenchmarkKeyValueFields/separate$' -test.benchmem -test.benchtime=1s
+  ./keyvalue-fields.test -test.run '^$' -test.bench '^BenchmarkKeyValueFields/combined$' -test.benchmem -test.benchtime=1s
+done
+```
+
+| Access | ns/op | B/op | allocs/op |
+|---|---:|---:|---:|
+| `Key` then `ValueRaw` | 12.25 | 0 | 0 |
+| `Fields` | 9.07 | 0 | 0 |
+
+The combined accessor is **25.9% faster** at the median. Every paired round
+favored it; the measured ranges were 11.75–13.63 ns/op and 8.62–9.87 ns/op.
+
 ## Metric.Name resolution (E-2985)
 
 E-2985 moved `Metric.Name` back to first-match (`extractBytesField`) from the

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -825,7 +825,7 @@ accessors.
 
 ## KeyValue combined field access (E-3340)
 
-Marigold hashes every metric metadata entry and datapoint attribute from both
+marigold hashes every metric metadata entry and datapoint attribute from both
 the `KeyValue.key` and raw `KeyValue.value` fields. Calling `Key` followed by
 `ValueRaw` walks the same envelope twice; `Fields` resolves the same two
 first-match views in one walk.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -131,9 +131,10 @@ iterator therefore tags every `DataPoint` with a `MetricType`; attribute access
 uses that tag rather than guessing from bytes.
 
 Metric names and KeyValue components are returned as slices of the original
-payload. `ValueRaw` exposes the encoded AnyValue for hashing-oriented callers;
-`StringValue` performs the more expensive semantic parse when string meaning
-is required.
+payload. `Fields` returns the key and encoded AnyValue in one first-match walk
+for hashing-oriented callers; `Key` and `ValueRaw` expose either component
+independently. `StringValue` performs the more expensive semantic parse when
+string meaning is required.
 
 `Metric.Metadata` reads field 12. Cardinality consumers combine it with every
 data point's attributes across a whole scrape, so it gets the hot-path

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -134,7 +134,8 @@ Metric names and KeyValue components are returned as slices of the original
 payload. `Fields` returns the key and encoded AnyValue in one first-match walk
 for hashing-oriented callers; `Key` and `ValueRaw` expose either component
 independently. `StringValue` performs the more expensive semantic parse when
-string meaning is required.
+string meaning is required and follows protobuf oneof ordering, so only the
+last encoded AnyValue oneof member determines whether the value is a string.
 
 `Metric.Metadata` reads field 12. Cardinality consumers combine it with every
 data point's attributes across a whole scrape, so it gets the hot-path

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -283,8 +283,10 @@ if err != nil { /* ... */ }
 value, found, err := resource.StringAttribute("service.name")
 ```
 
-`KeyValue.Key` and `ValueRaw` are lightweight views of the first matching
-encoded field. `KeyValue.StringValue` is the semantic string accessor: it
+`KeyValue.Key`, `ValueRaw`, and the combined `Fields` accessor are lightweight
+views of the first matching encoded fields. `Fields` resolves both views in
+one scan and has the same combined validation scope as calling `Key` followed
+by `ValueRaw`. `KeyValue.StringValue` is the semantic string accessor: it
 validates the complete KeyValue and AnyValue structure and applies protobuf
 oneof ordering. These two classes of accessor are deliberately different.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -286,9 +286,11 @@ value, found, err := resource.StringAttribute("service.name")
 `KeyValue.Key`, `ValueRaw`, and the combined `Fields` accessor are lightweight
 views of the first matching encoded fields. `Fields` resolves both views in
 one scan and has the same combined validation scope as calling `Key` followed
-by `ValueRaw`. `KeyValue.StringValue` is the semantic string accessor: it
-validates the complete KeyValue and AnyValue structure and applies protobuf
-oneof ordering. These two classes of accessor are deliberately different.
+by `ValueRaw`; each result is independent, so an absent field returns nil
+without hiding the other result. `KeyValue.StringValue` is the semantic string
+accessor: it validates the complete KeyValue and AnyValue structure and applies
+protobuf oneof ordering. These two classes of accessor are deliberately
+different.
 
 ### Instrumentation scope and schema URL
 

--- a/example_test.go
+++ b/example_test.go
@@ -12,6 +12,20 @@ import (
 	"go.olly.garden/otlp-wire"
 )
 
+// ExampleKeyValue_Fields reads the two raw fields needed by hashing consumers
+// with one scan of the KeyValue envelope.
+func ExampleKeyValue_Fields() {
+	raw := []byte{0x0a, 0x13, 'h', 't', 't', 'p', '.', 'r', 'e', 'q', 'u', 'e', 's', 't', '.', 'm', 'e', 't', 'h', 'o', 'd', 0x12, 0x05, 0x0a, 0x03, 'G', 'E', 'T'}
+
+	key, valueRaw, err := otlpwire.KeyValue(raw).Fields()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Printf("%s raw-value-bytes=%d\n", key, len(valueRaw))
+	// Output: http.request.method raw-value-bytes=5
+}
+
 // Example_observabilityStats demonstrates using Count() for observability metrics.
 func Example_observabilityStats() {
 	// Simulate receiving OTLP metrics data

--- a/keyvalue_fields_test.go
+++ b/keyvalue_fields_test.go
@@ -1,0 +1,144 @@
+package otlpwire
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+func keyValueBytesField(dst []byte, number protowire.Number, value string) []byte {
+	dst = protowire.AppendTag(dst, number, protowire.BytesType)
+	return protowire.AppendString(dst, value)
+}
+
+func keyValueVarintField(dst []byte, number protowire.Number, value uint64) []byte {
+	dst = protowire.AppendTag(dst, number, protowire.VarintType)
+	return protowire.AppendVarint(dst, value)
+}
+
+func separateKeyValueFields(kv KeyValue) ([]byte, []byte, error) {
+	key, err := kv.Key()
+	if err != nil {
+		return nil, nil, err
+	}
+	value, err := kv.ValueRaw()
+	return key, value, err
+}
+
+func TestKeyValueFieldsMatchesSeparateAccessors(t *testing.T) {
+	valid := func(fields ...func([]byte) []byte) []byte {
+		var data []byte
+		for _, field := range fields {
+			data = field(data)
+		}
+		return data
+	}
+	key := func(value string) func([]byte) []byte {
+		return func(dst []byte) []byte { return keyValueBytesField(dst, 1, value) }
+	}
+	value := func(raw string) func([]byte) []byte {
+		return func(dst []byte) []byte { return keyValueBytesField(dst, 2, raw) }
+	}
+	unknown := func(dst []byte) []byte { return keyValueVarintField(dst, 99, 7) }
+	wrongKey := func(dst []byte) []byte { return keyValueVarintField(dst, 1, 7) }
+	wrongValue := func(dst []byte) []byte { return keyValueVarintField(dst, 2, 7) }
+	malformed := func(dst []byte) []byte { return append(dst, 0x80) }
+	truncatedValue := func(dst []byte) []byte {
+		dst = protowire.AppendTag(dst, 2, protowire.BytesType)
+		return append(dst, 4, 'x')
+	}
+
+	tests := map[string][]byte{
+		"normal":                          valid(key("method"), value("GET")),
+		"reversed":                        valid(value("GET"), key("method")),
+		"absent key":                      valid(value("GET")),
+		"absent value":                    valid(key("method")),
+		"both absent":                     valid(unknown),
+		"unknown before fields":           valid(unknown, key("method"), value("GET")),
+		"first duplicate key wins":        valid(key("first"), key("second"), value("GET")),
+		"first duplicate value wins":      valid(key("method"), value("first"), value("second")),
+		"resolved wrong key is skipped":   valid(key("method"), wrongKey, value("GET")),
+		"resolved wrong value is skipped": valid(value("GET"), wrongValue, key("method")),
+		"wrong key":                       valid(wrongKey, value("GET")),
+		"wrong value":                     valid(key("method"), wrongValue),
+		"truncated value":                 valid(key("method"), truncatedValue),
+		"malformed between fields":        valid(key("method"), malformed, value("GET")),
+		"malformed after both":            valid(key("method"), value("GET"), malformed),
+	}
+
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			wantKey, wantValue, wantErr := separateKeyValueFields(KeyValue(data))
+			gotKey, gotValue, gotErr := KeyValue(data).Fields()
+			assert.Equal(t, wantErr != nil, gotErr != nil)
+			if wantErr == nil {
+				assert.Equal(t, wantKey, gotKey)
+				assert.Equal(t, wantValue, gotValue)
+			}
+		})
+	}
+}
+
+func TestKeyValueFieldsReturnsClampedViews(t *testing.T) {
+	data := keyValueBytesField(nil, 1, "method")
+	data = keyValueBytesField(data, 2, "GET")
+	original := append([]byte(nil), data...)
+
+	key, value, err := KeyValue(data).Fields()
+	require.NoError(t, err)
+	require.Equal(t, len(key), cap(key))
+	require.Equal(t, len(value), cap(value))
+	_ = append(key, '!')
+	_ = append(value, '!')
+	assert.Equal(t, original, data)
+}
+
+func TestKeyValueFieldsAllocations(t *testing.T) {
+	data := keyValueBytesField(nil, 1, "method")
+	data = keyValueBytesField(data, 2, "GET")
+	kv := KeyValue(data)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		key, value, err := kv.Fields()
+		if err != nil || len(key) == 0 || len(value) == 0 {
+			panic("unexpected result")
+		}
+	})
+	assert.Zero(t, allocs)
+}
+
+var keyValueFieldsSink int
+
+func BenchmarkKeyValueFields(b *testing.B) {
+	data := keyValueBytesField(nil, 1, "deployment.environment.name")
+	data = keyValueBytesField(data, 2, "production")
+	kv := KeyValue(data)
+
+	b.Run("separate", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			key, err := kv.Key()
+			if err != nil {
+				b.Fatal(err)
+			}
+			value, err := kv.ValueRaw()
+			if err != nil {
+				b.Fatal(err)
+			}
+			keyValueFieldsSink = len(key) + len(value)
+		}
+	})
+
+	b.Run("combined", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			key, value, err := kv.Fields()
+			if err != nil {
+				b.Fatal(err)
+			}
+			keyValueFieldsSink = len(key) + len(value)
+		}
+	})
+}

--- a/wire.go
+++ b/wire.go
@@ -311,6 +311,56 @@ func extractBytesField(data []byte, fieldNum protowire.Number) ([]byte, error) {
 	return nil, nil
 }
 
+// extractBytesFields extracts the first occurrence of two length-delimited
+// fields in one scan. It stops after both are found, matching the combined
+// validation scope of calling extractBytesField for each field separately.
+// Returned slices alias data with their capacities clamped to their lengths.
+func extractBytesFields(data []byte, firstNum, secondNum protowire.Number) ([]byte, []byte, error) {
+	var first, second []byte
+	var firstFound, secondFound bool
+	pos := 0
+
+	for pos < len(data) {
+		num, wireType, tagLen := protowire.ConsumeTag(data[pos:])
+		if tagLen < 0 {
+			return nil, nil, errors.New("malformed protobuf tag")
+		}
+		pos += tagLen
+
+		selected := (num == firstNum && !firstFound) || (num == secondNum && !secondFound)
+		if selected {
+			if wireType != protowire.BytesType {
+				return nil, nil, errors.New("wrong wire type for field")
+			}
+			field, n := protowire.ConsumeBytes(data[pos:])
+			if n < 0 {
+				return nil, nil, errors.New("invalid bytes in field")
+			}
+			pos += n
+			field = field[:len(field):len(field)]
+			if num == firstNum {
+				first = field
+				firstFound = true
+			} else {
+				second = field
+				secondFound = true
+			}
+			if firstFound && secondFound {
+				return first, second, nil
+			}
+			continue
+		}
+
+		n := skipField(data[pos:], num, wireType)
+		if n < 0 {
+			return nil, nil, errors.New("failed to skip field")
+		}
+		pos += n
+	}
+
+	return first, second, nil
+}
+
 // extractLastBytesField extracts a singular length-delimited scalar field,
 // resolving repeated occurrences by last-value-wins the way protobuf and
 // pdata do. Returns nil (not an error) if absent; the returned slice aliases


### PR DESCRIPTION
## Summary

- add `KeyValue.Fields()` to return the first key and raw AnyValue fields in one protobuf-envelope scan
- preserve the zero-copy, first-match, operation-scoped validation contract of `Key()` plus `ValueRaw()`
- document the public API and benchmark methodology

## Motivation

Marigold hashes both fields for every metric metadata entry and datapoint attribute. Fresh profiles attributed about 23.7% cumulative raw-path CPU to `Key()` and 10.0% to `ValueRaw()`, which independently scan the same KeyValue envelope.

Closes [E-3340](https://linear.app/ollygarden/issue/E-3340/otlp-wire-expose-single-pass-keyvalue-fields-for-hashing).

## Compatibility and risk

- **API:** additive; existing accessors are unchanged
- **Wire behavior:** first matching field wins; absent fields return nil; selected wrong-wire-type and malformed prefixes return errors
- **Ownership:** returned slices alias the caller-owned input and have capacity clamped to length
- **Allocations:** 0 B/op, 0 allocs/op
- **Side effects:** none; this module does not deploy a workload

Tests cover normal, absent, reversed, duplicate key/value, unknown, wrong-wire-type, truncated, malformed-between/trailing, aliasing, capacity, allocation, and parity with separate accessors.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test -race -shuffle=on -count=1 ./...`
- `git diff --check`
- focused accessor and executable-example tests
- `go mod tidy -diff` reports only the repository's documented baseline checksum/dependency drift; this change does not modify `go.mod` or `go.sum`

All applicable gates pass.

## Benchmark

Apple M5, darwin/arm64, Go 1.26.6; one prebuilt test binary, six alternating 1-second rounds:

| Access | Median ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| `Key()` then `ValueRaw()` | 12.25 | 0 | 0 |
| `Fields()` | 9.07 | 0 | 0 |

`Fields()` was 25.9% faster at the documented median and won every paired round. A fresh exact-head confirmation also won all six rounds with no allocation change.

## Delivery plan

1. Require green CI and resolve actionable review feedback.
2. Merge and release the library independently after separate authorization.
3. Adopt `Fields()` in Marigold under [E-3047](https://linear.app/ollygarden/issue/E-3047/marigold-adopt-otlp-wire-v023-allocation-free-container-iterators).
4. Validate output parity and representative Marigold service-path performance before rollout.

Stop on wire-contract drift, allocation regression, failed CI, or a consumer-path regression. Consumers can fall back by retaining `Key()` plus `ValueRaw()` or pinning the prior module version.

## Agent involvement

Amp materially assisted with implementation validation, adversarial review, and PR preparation. GitHub user `jpkrohling` owns review and delivery decisions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `KeyValue.Fields`, enabling applications to retrieve a key and its raw value bytes in a single call.
  - Key and value results are resolved independently, while existing validation and first-match behavior remain unchanged.
  - Added an example demonstrating the new accessor.

- **Documentation**
  - Documented the accessor and its behavior.
  - Added benchmark documentation comparing combined and separate access patterns.

- **Tests**
  - Added coverage for valid, missing, duplicate, malformed, and truncated fields, plus allocation and performance checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->